### PR TITLE
fix: remove setuptools-scm root override to fix uv builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ version_file = "vllm_spyre_next/_version.py"
 # Version strings are formatted as `{version}+{local}`, e.g. "0.1.dev1+gb1a7032"
 # Local versioning is incompatible with pypi, so we disable it by default.
 local_scheme = "no-local-version"
-root = ".."
 # Only match spyre-next-vX.Y.Z tags (with optional SemVer pre-release suffix), ignoring v* tags used by vllm-spyre.
 # SemVer pre-release format: hyphen followed by dot-separated identifiers (alphanumeric + hyphens)
 tag_regex = "^spyre-next-v(?P<version>[0-9]+\\.[0-9]+\\.[0-9]+(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?)$"


### PR DESCRIPTION
## Fix setuptools-scm version resolution in isolated build environments

  `setuptools-scm` was configured with `root = ".."`, which made version resolution look outside the project directory. This works fine in a normal checkout, but breaks under `uv`'s isolated build environment — the project gets copied into a temp directory without the original repo structure, so setuptools-scm can't detect the version and the build errors out.

  The fix is just removing the `root` override so setuptools-scm resolves the version relative to the project directory itself.

  ### Error log Pre Fix
```
(.venv) [1000840000@yc-vllm-spyre-next2 spyre-inference]$ uv sync --frozen
warning: `VIRTUAL_ENV=/dev/shm/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
Using CPython 3.12.12 interpreter at: /usr/bin/python3
Creating virtual environment at: .venv
  × Failed to build `vllm-spyre-next @ file:///dev/shm/spyre-inference`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `setuptools.build_meta.build_editable` failed (exit status: 1)

      [stderr]
      Traceback (most recent call last):
        File "<string>", line 14, in <module>
        File "/dev/shm/.cache/uv/builds-v0/.tmpNHFISl/lib64/python3.12/site-packages/setuptools/build_meta.py",
      line 481, in get_requires_for_build_editable
          return self.get_requires_for_build_wheel(config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/dev/shm/.cache/uv/builds-v0/.tmpNHFISl/lib64/python3.12/site-packages/setuptools/build_meta.py",
      line 333, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/dev/shm/.cache/uv/builds-v0/.tmpNHFISl/lib64/python3.12/site-packages/setuptools/build_meta.py",
      line 301, in _get_build_requires
          self.run_setup()
        File "/dev/shm/.cache/uv/builds-v0/.tmpNHFISl/lib64/python3.12/site-packages/setuptools/build_meta.py",
      line 317, in run_setup
          exec(code, locals())
        File "<string>", line 1, in <module>
        File "/dev/shm/.cache/uv/builds-v0/.tmpNHFISl/lib64/python3.12/site-packages/setuptools/__init__.py",
      line 117, in setup
          return distutils.core.setup(**attrs)  # type: ignore[return-value]
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/dev/shm/.cache/uv/builds-v0/.tmpNHFISl/lib64/python3.12/site-packages/setuptools/_distutils/core.py",
      line 148, in setup
          _setup_distribution = dist = klass(attrs)
                                       ^^^^^^^^^^^^
        File "/dev/shm/.cache/uv/builds-v0/.tmpNHFISl/lib64/python3.12/site-packages/setuptools/dist.py", line
      321, in __init__
          _Distribution.__init__(self, dist_attrs)
        File "/dev/shm/.cache/uv/builds-v0/.tmpNHFISl/lib64/python3.12/site-packages/setuptools/_distutils/dist.py",
      line 307, in __init__
          self.finalize_options()
        File "/dev/shm/.cache/uv/builds-v0/.tmpNHFISl/lib64/python3.12/site-packages/setuptools/dist.py", line
      790, in finalize_options
          ep(self)
        File "/usr/lib64/python3.12/contextlib.py", line 81, in inner
          return func(*args, **kwds)
                 ^^^^^^^^^^^^^^^^^^^
        File
      "/dev/shm/.cache/uv/builds-v0/.tmpNHFISl/lib64/python3.12/site-packages/setuptools_scm/_integration/setuptools.py",
      line 192, in infer_version
          _infer_version_impl(
        File
      "/dev/shm/.cache/uv/builds-v0/.tmpNHFISl/lib64/python3.12/site-packages/setuptools_scm/_integration/setuptools.py",
      line 225, in _infer_version_impl
          result.apply(dist)
        File
      "/dev/shm/.cache/uv/builds-v0/.tmpNHFISl/lib64/python3.12/site-packages/setuptools_scm/_integration/version_inference.py",
      line 123, in apply
          data = infer_version_with_config(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
        File
      "/dev/shm/.cache/uv/builds-v0/.tmpNHFISl/lib64/python3.12/site-packages/setuptools_scm/_integration/version_inference.py",
      line 67, in infer_version_with_config
          _version_missing(config)
        File
      "/dev/shm/.cache/uv/builds-v0/.tmpNHFISl/lib64/python3.12/site-packages/vcs_versioning/_get_version_impl.py",
      line 207, in _version_missing
          raise LookupError(error_msg)
      LookupError: setuptools-scm was unable to detect version for /dev/shm.

      Make sure you're either building from a fully intact git repository or PyPI tarballs. Most other sources
      (such as GitHub's tarballs, a git checkout without the .git folder) don't contain the necessary metadata
      and will not work.

      For example, if you're using pip, instead of https://github.com/user/proj/archive/master.zip use
      git+https://github.com/user/proj.git#egg=proj

      Alternatively, set the version with the environment variable
      SETUPTOOLS_SCM_PRETEND_VERSION_FOR_${NORMALIZED_DIST_NAME} as described in
      https://setuptools-scm.readthedocs.io/en/latest/config/

      hint: This usually indicates a problem with the package or the build environment.

```

  ### Logs Post Fix
```
(.venv) [1000840000@yc-vllm-spyre-next2 spyre-inference]$ uv sync --frozen
warning: `VIRTUAL_ENV=/dev/shm/.venv` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
      Built vllm-spyre-next @ file:///dev/shm/spyre-inference
Prepared 1 package in 785ms
Installed 379 packages in 746ms
```