### PR TITLE
[Feature] Implement spyre-specific model runner (Squash from https://github.com/torch-spyre/sendnn-inference/pull/878)

### DIFF
--- a/vllm_spyre_next/custom_ops/__init__.py
+++ b/vllm_spyre_next/custom_ops/__init__.py
@@ -1,6 +1,10 @@
 """This module contains all custom ops for spyre"""
 
+from functools import lru_cache
+
+from . import parallel_lm_head
 from . import rms_norm
+from . import rotary_embedding
 from . import silu_and_mul
 from . import vocab_parallel_embedding
 from . import linear
@@ -9,9 +13,12 @@ from vllm.logger import init_logger
 logger = init_logger(__name__)
 
 
+@lru_cache(maxsize=1)
 def register_all():
     logger.info("Registering custom ops for spyre_next")
+    vocab_parallel_embedding.register()
+    parallel_lm_head.register()
+    rotary_embedding.register()
     rms_norm.register()
     silu_and_mul.register()
-    vocab_parallel_embedding.register()
     linear.register()

--- a/vllm_spyre_next/custom_ops/linear.py
+++ b/vllm_spyre_next/custom_ops/linear.py
@@ -7,6 +7,8 @@ layer classes used inside MLP blocks:
 
     - SpyreMergedColumnParallelLinear  — replaces MergedColumnParallelLinear
       (vllm/model_executor/layers/linear.py)
+    - SpyreQKVParallelLinear          — replaces QKVParallelLinear
+      (vllm/model_executor/layers/linear.py)
     - SpyreRowParallelLinear          — replaces RowParallelLinear
       (vllm/model_executor/layers/linear.py)
 
@@ -32,6 +34,7 @@ from vllm.logger import init_logger
 from vllm.utils.torch_utils import direct_register_custom_op
 from vllm.model_executor.layers.linear import (
     MergedColumnParallelLinear,
+    QKVParallelLinear,
     RowParallelLinear,
 )
 
@@ -103,11 +106,40 @@ class SpyreMergedColumnParallelLinear(SpyreLinearBase, MergedColumnParallelLinea
     # `MergedColumnParallelLinear` is a PluggableLayer and we register a class as OOT,
     # thus, the `forward` method is invoked when the OOT is triggered.
     def forward(self, input_: torch.Tensor):
-        output = input_.new_empty(
-            input_.shape[0],
-            self.output_size_per_partition,
-        )
-        torch.ops.vllm.spyre_merged_col_linear(input_, output, self._layer_name)
+        if input_.device.type == "spyre":
+            output = self._forward_spyre_impl(input_)
+        else:
+            output = input_.new_empty(
+                input_.shape[0],
+                self.output_size_per_partition,
+            )
+            torch.ops.vllm.spyre_merged_col_linear(input_, output, self._layer_name)
+
+        if not self.return_bias:
+            return output
+        output_bias = self.bias if self.skip_bias_add else None
+        return output, output_bias
+
+
+@QKVParallelLinear.register_oot(name="QKVParallelLinear")
+class SpyreQKVParallelLinear(SpyreLinearBase, QKVParallelLinear):
+    """Spyre QKVParallelLinear (TP=1 only)."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._init_spyre_linear("spyre_qkv_parallel_linear")
+
+    def forward(self, input_: torch.Tensor):
+        if input_.device.type == "spyre":
+            output = self._forward_spyre_impl(input_)
+            # D2H before downstream .split() — Spyre can't handle strided views
+            output = convert(output, device="cpu")
+        else:
+            output = input_.new_empty(
+                input_.shape[0],
+                self.output_size_per_partition,
+            )
+            torch.ops.vllm.spyre_qkv_parallel_linear(input_, output, self._layer_name)
 
         if not self.return_bias:
             return output
@@ -126,12 +158,16 @@ class SpyreRowParallelLinear(SpyreLinearBase, RowParallelLinear):
     # `SpyreRowParallelLinear` is a PluggableLayer and we register a class as OOT,
     # thus, the `forward` method is invoked when the OOT is triggered.
     def forward(self, input_: torch.Tensor):
-        output = input_.new_empty(
-            *input_.shape[:-1],
-            self.output_size_per_partition,
-        )
-
-        torch.ops.vllm.spyre_row_parallel_linear(input_, output, self._layer_name)
+        if input_.device.type == "spyre":
+            output = self._forward_spyre_impl(input_)
+        else:
+            output = input_.new_empty(
+                *input_.shape[:-1],
+                self.output_size_per_partition,
+            )
+            torch.ops.vllm.spyre_row_parallel_linear(input_, output, self._layer_name)
+            # Always output on Spyre — needed for residual add with Spyre hidden_states
+            output = convert(output, device=self._target_device, dtype=self._target_dtype)
 
         if not self.return_bias:
             return output
@@ -156,7 +192,11 @@ def _make_spyre_linear_op_func(op_name: str):
 @lru_cache(maxsize=1)
 def register():
     """Register Spyre linear custom ops."""
-    for op_name in ["spyre_merged_col_linear", "spyre_row_parallel_linear"]:
+    for op_name in [
+        "spyre_merged_col_linear",
+        "spyre_qkv_parallel_linear",
+        "spyre_row_parallel_linear",
+    ]:
         direct_register_custom_op(
             op_name=op_name,
             op_func=_make_spyre_linear_op_func(op_name),

--- a/vllm_spyre_next/custom_ops/parallel_lm_head.py
+++ b/vllm_spyre_next/custom_ops/parallel_lm_head.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Spyre OOT replacement for ParallelLMHead.
+
+Remove this file once all model execution happens on Spyre.
+"""
+
+from vllm.logger import init_logger
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+)
+
+logger = init_logger(__name__)
+
+
+@ParallelLMHead.register_oot(name="ParallelLMHead")
+class SpyreParallelLMHead(ParallelLMHead):
+    """OOT ParallelLMHead that keeps weights on CPU."""
+
+    def _apply(self, fn, recurse=True):
+        """No-op: keep lm_head weights on CPU.
+
+        In the current Spyre eager-mode flow, hidden_states stay on CPU
+        throughout the model. The lm_head weights must also be on CPU
+        for F.linear to work without device mismatches.
+        """
+        return self
+
+
+def register():
+    # OOT class registration happens at import time via the decorator.
+    pass

--- a/vllm_spyre_next/custom_ops/parallel_lm_head.py
+++ b/vllm_spyre_next/custom_ops/parallel_lm_head.py
@@ -10,6 +10,8 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
 )
 
+from functools import lru_cache
+
 logger = init_logger(__name__)
 
 
@@ -28,5 +30,9 @@ class SpyreParallelLMHead(ParallelLMHead):
 
 @lru_cache(maxsize=1)
 def register():
-    # OOT class registration happens at import time via the decorator.
+    # No-op: ParallelLMHead doesn't require custom op registration.
+    
+    # Unlike other Spyre layers (RMSNorm, SiluAndMul, etc.), ParallelLMHead
+    # only needs a class replacement that overrides _apply() to keep weights on CPU.
+    # This replacement happens at import time via @ParallelLMHead.register_oot().
     pass

--- a/vllm_spyre_next/custom_ops/parallel_lm_head.py
+++ b/vllm_spyre_next/custom_ops/parallel_lm_head.py
@@ -26,7 +26,7 @@ class SpyreParallelLMHead(ParallelLMHead):
         """
         return self
 
-
+@lru_cache(maxsize=1)
 def register():
     # OOT class registration happens at import time via the decorator.
     pass

--- a/vllm_spyre_next/custom_ops/rms_norm.py
+++ b/vllm_spyre_next/custom_ops/rms_norm.py
@@ -43,9 +43,6 @@ from .utils import convert, register_layer, get_layer, _fake_impl
 
 logger = init_logger(__name__)
 
-# Minimum batch size required by Spyre hardware.
-_SPYRE_MIN_BATCH_SIZE = 64
-
 
 @RMSNorm.register_oot(name="RMSNorm")
 class SpyreRMSNorm(RMSNorm):
@@ -89,12 +86,13 @@ class SpyreRMSNorm(RMSNorm):
         x: torch.Tensor,
         residual: torch.Tensor | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        """OOT forward pass using custom op to bypass torch.compile.
+        """OOT forward pass.
 
-        Delegates to torch.ops.vllm.spyre_rmsnorm which retrieves this layer
-        from the layer registry and calls _forward_spyre_impl outside
-        the compilation graph. This prevents torch.compile from inlining the
-        Spyre-specific operations.
+        When input is on Spyre, calls _forward_spyre_impl directly to avoid
+        the custom op boundary (Spyre does not support in-device copy_).
+        When input is on CPU, delegates to torch.ops.vllm.spyre_rmsnorm
+        which retrieves this layer from the layer registry and calls
+        _forward_spyre_impl outside the compilation graph.
 
         Args:
             x: Input tensor [batch_size, hidden_size]
@@ -103,6 +101,9 @@ class SpyreRMSNorm(RMSNorm):
         Returns:
             Normalized output, or (output, residual) tuple if residual provided
         """
+        if x.device.type == "spyre":
+            return self._forward_spyre_impl(x, residual)
+
         output = torch.empty_like(x)
         residual_out = torch.empty_like(residual) if residual is not None else None
 
@@ -169,7 +170,7 @@ class SpyreRMSNorm(RMSNorm):
             - variance_size_override not implemented (raises NotImplementedError)
 
         Args:
-            x: Input tensor [batch_size, hidden_size] on CPU
+            x: Input tensor [batch_size, hidden_size]
             residual: Optional residual
 
         Returns:
@@ -181,16 +182,6 @@ class SpyreRMSNorm(RMSNorm):
         if self.variance_size_override is not None:
             raise NotImplementedError("TODO: variance_size_override not yet implemented")
 
-        orig_batch_size = x.shape[0]
-
-        # Pad to minimum batch size of 64 (Spyre constraint)
-        # Pad at END so original data stays at indices [0:orig_batch_size]
-        if x.shape[0] < _SPYRE_MIN_BATCH_SIZE:
-            pad_amount = _SPYRE_MIN_BATCH_SIZE - x.shape[0]
-            x = torch.nn.functional.pad(x, (0, 0, 0, pad_amount))
-            if residual is not None:
-                residual = torch.nn.functional.pad(residual, (0, 0, 0, pad_amount))
-
         # Execute compiled kernel on Spyre device
         outs = self.maybe_compiled_forward_spyre(
             convert(x, self._target_device, self._target_dtype),
@@ -199,12 +190,14 @@ class SpyreRMSNorm(RMSNorm):
             convert(self.weight.data, self._target_device, self._target_dtype)
             if self.has_weight
             else None,
-            convert(residual, self._target_device, self._target_dtype),
+            convert(residual, self._target_device, self._target_dtype)
+            if residual is not None
+            else None,
         )
 
-        # Transfer back to CPU and restore original shape
+        # Transfer back to original device/dtype
         return pytree.tree_map(
-            lambda el: convert(el, dtype=x_dtype, device=x_device)[:orig_batch_size, :],
+            lambda el: convert(el, dtype=x_dtype, device=x_device),
             outs,
         )
 

--- a/vllm_spyre_next/custom_ops/rotary_embedding.py
+++ b/vllm_spyre_next/custom_ops/rotary_embedding.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Spyre OOT replacement for RotaryEmbedding (CPU fallback).
+
+Remove this file once Spyre natively supports rotary embedding ops.
+"""
+
+import torch
+
+from vllm.logger import init_logger
+from vllm.model_executor.layers.rotary_embedding.base import (
+    RotaryEmbedding,
+    RotaryEmbeddingBase,
+)
+from functools import lru_cache
+
+from .utils import convert
+
+logger = init_logger(__name__)
+
+
+@RotaryEmbeddingBase.register_oot(name="RotaryEmbedding")
+class SpyreRotaryEmbedding(RotaryEmbedding):
+    """OOT RotaryEmbedding that falls back to CPU execution.
+
+    Keeps cos_sin_cache on CPU via an _apply no-op. Inputs are moved to
+    CPU for computation, and outputs are copied back to the original device.
+    """
+
+    def _apply(self, fn, recurse=True):
+        # Keep cos_sin_cache on CPU so forward_native can use it directly.
+        return self
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        query: torch.Tensor,
+        key: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        target_device = query.device
+        target_dtype = query.dtype
+
+        cpu_positions = convert(positions, device="cpu")
+        cpu_query = convert(query, device="cpu")
+        cpu_key = convert(key, device="cpu")
+
+        result_query, result_key = RotaryEmbedding.forward_native(
+            self,
+            cpu_positions,
+            cpu_query,
+            cpu_key,
+        )
+
+        out_query = convert(result_query, device=target_device, dtype=target_dtype)
+        out_key = (
+            convert(result_key, device=target_device, dtype=target_dtype)
+            if result_key is not None
+            else None
+        )
+        return out_query, out_key
+
+
+@lru_cache(maxsize=1)
+def register():
+    # OOT class registration happens at import time via the decorator.
+    pass

--- a/vllm_spyre_next/custom_ops/rotary_embedding.py
+++ b/vllm_spyre_next/custom_ops/rotary_embedding.py
@@ -62,5 +62,9 @@ class SpyreRotaryEmbedding(RotaryEmbedding):
 
 @lru_cache(maxsize=1)
 def register():
-    # OOT class registration happens at import time via the decorator.
+    # No-op: RotaryEmbedding doesn't require custom op registration.
+    
+    # Unlike other Spyre layers (RMSNorm, SiluAndMul, etc.), RotaryEmbedding
+    # only needs a class replacement that overrides _apply() to keep weights on CPU.
+    # This replacement happens at import time via @RotaryEmbedding.register_oot().
     pass

--- a/vllm_spyre_next/custom_ops/silu_and_mul.py
+++ b/vllm_spyre_next/custom_ops/silu_and_mul.py
@@ -75,11 +75,13 @@ class SpyreSiluAndMul(SiluAndMul):
         )
 
     def forward_oot(self, x: torch.Tensor) -> torch.Tensor:
-        """OOT forward pass using custom op to bypass torch.compile.
+        """OOT forward pass.
 
-        Delegates to torch.ops.vllm.spyre_siluandmul which retrieves this layer
-        from the layer registry and calls _forward_spyre_impl outside
-        the compilation graph.
+        When input is on Spyre, calls _forward_spyre_impl directly to avoid
+        the custom op boundary (Spyre does not support in-device copy_).
+        When input is on CPU, delegates to torch.ops.vllm.spyre_siluandmul
+        which retrieves this layer from the layer registry and calls
+        _forward_spyre_impl outside the compilation graph.
 
         Args:
             x: Input tensor [..., 2*d]
@@ -87,6 +89,9 @@ class SpyreSiluAndMul(SiluAndMul):
         Returns:
             Activated output tensor [..., d]
         """
+        if x.device.type == "spyre":
+            return self._forward_spyre_impl(x)
+
         d = x.shape[-1] // 2
         output = torch.empty(x.shape[:-1] + (d,), dtype=x.dtype, device=x.device)
 

--- a/vllm_spyre_next/custom_ops/silu_and_mul.py
+++ b/vllm_spyre_next/custom_ops/silu_and_mul.py
@@ -126,18 +126,18 @@ class SpyreSiluAndMul(SiluAndMul):
 
         The Spyre device does not currently support strided tensor views (slicing),
         so the input is split into its two halves on the CPU before being
-        transferred to the device.  Once tensor slicing is supported this method
-        should revert to the simpler single-tensor path (see commented-out block).
+        transferred to the device.  When the input is already on Spyre it is
+        first moved to CPU for slicing.
 
         Execution steps:
-            1. Slice on CPU: split x into x1 = x[..., :d] and x2 = x[..., d:]
-            2. Device transfer: convert x1 and x2 independently to Spyre (float16)
-               via convert_for_spyre
-            3. Kernel execution: call compiled maybe_compiled_forward_spyre(x1_spyre, x2_spyre)
-            4. Result transfer: Spyre -> original device, restore original dtype
+            1. If on Spyre, move to CPU (strided views are unsupported on Spyre)
+            2. Slice on CPU: split x into x1 = x[..., :d] and x2 = x[..., d:]
+            3. Device transfer: convert x1 and x2 independently to Spyre (float16)
+            4. Kernel execution: call compiled maybe_compiled_forward_spyre(x1_spyre, x2_spyre)
+            5. Result transfer: Spyre -> original device, restore original dtype
 
         Args:
-            x: Input tensor of shape [..., 2*d] on CPU with arbitrary float dtype.
+            x: Input tensor of shape [..., 2*d] on CPU or Spyre.
 
         Returns:
             Activated output tensor of shape [..., d] on the original device with
@@ -146,7 +146,10 @@ class SpyreSiluAndMul(SiluAndMul):
         x_dtype = x.dtype
         x_device = x.device
 
-        # Note: Workaround with tensor slicing on CPU
+        # Spyre does not support strided tensor views — must slice on CPU
+        if x.device.type == "spyre":
+            x = x.to(device="cpu")
+
         d = x.shape[-1] // 2
         x1 = x[..., :d]
         x2 = x[..., d:]

--- a/vllm_spyre_next/custom_ops/utils.py
+++ b/vllm_spyre_next/custom_ops/utils.py
@@ -49,22 +49,6 @@ def _fake_impl(*args, **kwargs) -> None:
     return
 
 
-# Library object for registering PrivateUse1 (Spyre) dispatch keys.
-# vLLM's direct_register_custom_op only registers the platform dispatch_key
-# (CPU). When tensors flow on Spyre, PyTorch dispatches to PrivateUse1 —
-# so we must register the same kernels there too.
-_spyre_dispatch_lib = torch.library.Library("vllm", "IMPL")
-
-
-def register_spyre_dispatch(op_name: str, op_func) -> None:
-    """Register an op implementation for the PrivateUse1 (Spyre) dispatch key.
-
-    Call this after direct_register_custom_op to ensure the op can be
-    dispatched when any argument is a Spyre tensor.
-    """
-    _spyre_dispatch_lib.impl(op_name, op_func, dispatch_key="PrivateUse1")
-
-
 def convert(tensor, device=None, dtype=None):
     """Convert tensor device and/or dtype. No-op when both are None.
 

--- a/vllm_spyre_next/custom_ops/utils.py
+++ b/vllm_spyre_next/custom_ops/utils.py
@@ -7,6 +7,8 @@ dtype conversion.
 
 from typing import Any
 
+import torch
+
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
@@ -47,6 +49,22 @@ def _fake_impl(*args, **kwargs) -> None:
     return
 
 
+# Library object for registering PrivateUse1 (Spyre) dispatch keys.
+# vLLM's direct_register_custom_op only registers the platform dispatch_key
+# (CPU). When tensors flow on Spyre, PyTorch dispatches to PrivateUse1 —
+# so we must register the same kernels there too.
+_spyre_dispatch_lib = torch.library.Library("vllm", "IMPL")
+
+
+def register_spyre_dispatch(op_name: str, op_func) -> None:
+    """Register an op implementation for the PrivateUse1 (Spyre) dispatch key.
+
+    Call this after direct_register_custom_op to ensure the op can be
+    dispatched when any argument is a Spyre tensor.
+    """
+    _spyre_dispatch_lib.impl(op_name, op_func, dispatch_key="PrivateUse1")
+
+
 def convert(tensor, device=None, dtype=None):
     """Convert tensor device and/or dtype. No-op when both are None.
 
@@ -58,8 +76,8 @@ def convert(tensor, device=None, dtype=None):
     Returns:
         Converted tensor, or None if input is None.
     """
-    if tensor is None:
-        return None
+    if tensor is None or not isinstance(tensor, torch.Tensor):
+        return tensor
     if tensor.device.type == "spyre":
         # In case the tensor is on spyre, we first need to move it to cpu and then change the dtype.
         if device is not None:

--- a/vllm_spyre_next/custom_ops/vocab_parallel_embedding.py
+++ b/vllm_spyre_next/custom_ops/vocab_parallel_embedding.py
@@ -103,9 +103,11 @@ class SpyreVocabParallelEmbedding(VocabParallelEmbedding):
         )
 
     def forward_oot(self, x: torch.Tensor) -> torch.Tensor:
-        """OOT forward pass using custom op to bypass torch.compile.
+        """OOT forward pass.
 
-        Delegates to torch.ops.vllm.spyre_vocab_parallel_embedding which
+        When input is on Spyre, calls _forward_spyre_impl directly to avoid
+        the custom op boundary (Spyre does not support in-device copy_).
+        When input is on CPU, delegates to torch.ops.vllm.spyre_vocab_parallel_embedding which
         retrieves this layer from the layer registry and calls
         _forward_spyre_impl outside the compilation graph. This prevents
         torch.compile from inlining the Spyre-specific operations.
@@ -116,6 +118,9 @@ class SpyreVocabParallelEmbedding(VocabParallelEmbedding):
         Returns:
             Embedding output [num_tokens, embedding_dim] in weight dtype
         """
+        if x.device.type == "spyre":
+            return self._forward_spyre_impl(x)
+
         output = torch.empty(
             *x.shape,
             self.embedding_dim,
@@ -126,6 +131,8 @@ class SpyreVocabParallelEmbedding(VocabParallelEmbedding):
         # Custom op call - executes outside torch.compile graph
         torch.ops.vllm.spyre_vocab_parallel_embedding(x, output, self._layer_name)
 
+        # Push output to Spyre so hidden_states flows on Spyre between layers
+        output = convert(output, dtype=self._weight_target_dtype, device=self._target_device)
         return output
 
     @staticmethod

--- a/vllm_spyre_next/platform.py
+++ b/vllm_spyre_next/platform.py
@@ -1,3 +1,4 @@
+import torch
 import sys
 from typing import TYPE_CHECKING
 from string import Template
@@ -36,6 +37,13 @@ class TorchSpyrePlatform(CpuPlatform):
     # "spyre" device_name no longer worked due to https://github.com/vllm-project/vllm/pull/16464
     device_name: str = "cpu"
     device_type: str = "cpu"
+
+    # Primary dispatch key for direct_register_custom_op. Kept as CPU
+    # because some custom ops receive CPU-only tensors (e.g. rotary_embedding).
+    # All ops are ALSO registered for PrivateUse1 (Spyre) via
+    # register_spyre_dispatch() in each module's register() function,
+    # so dispatch works regardless of tensor device.
+    dispatch_key: str = "CPU"
 
     # Register the PyTorch Native Attention implementation as the CUSTOM backend
     register_backend(
@@ -82,6 +90,20 @@ class TorchSpyrePlatform(CpuPlatform):
         logger.info(message, version, model_name)
 
     @classmethod
+    def apply_config_platform_defaults(cls, vllm_config: VllmConfig) -> None:
+        """Set Spyre-specific config defaults before vLLM's defaulting logic."""
+        from vllm.config import CompilationMode
+
+        vllm_config.compilation_config.mode = CompilationMode.NONE
+
+        # Force eager execution. torch.compile with the Spyre inductor
+        # backend requires ALL graph tensors on Spyre, but our CPU fallback
+        # ops (embedding, linear, rotary, attention) create intermediate
+        # CPU tensors that the Spyre backend cannot codegen. Once all layers
+        # run natively on Spyre, this can be removed to enable compilation.
+        vllm_config.model_config.enforce_eager = True
+
+    @classmethod
     def get_attn_backend_cls(cls, selected_backend, *args, **kwargs) -> str:
         if selected_backend == AttentionBackendEnum.CUSTOM:
             return AttentionBackendEnum.CUSTOM.get_path()
@@ -92,6 +114,14 @@ class TorchSpyrePlatform(CpuPlatform):
     def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
         cls.log_server_boot(vllm_config)
 
+        # Check if the model dtype is different from float16,
+        # which is only currently supported in torch-spyre
+        if vllm_config.model_config.dtype != torch.float16:
+            raise ValueError(
+                f"The model dtype needs to be torch.float16 for spyre, "
+                f"but was specified to be {vllm_config.model_config.dtype}"
+            )
+
         # ---- worker ----
         parallel_config = vllm_config.parallel_config
         if parallel_config.worker_cls == "auto":
@@ -100,12 +130,6 @@ class TorchSpyrePlatform(CpuPlatform):
             worker_class = "vllm_spyre_next.v1.worker.spyre_worker.TorchSpyreWorker"
             logger.info("Loading worker from: %s", worker_class)
             parallel_config.worker_cls = worker_class
-
-        # ---- model runner ----
-        # A custom model runner has to be added to a potential TorchSpyreWorker class:
-        # TorchSpyreWorker.model_runner = TorchSpyreModelRunner (see SpyreWorker for reference)
-        # The default vllm.v1.worker.cpu_worker.CPUWorker uses
-        # vllm.v1.worker.cpu_model_runner.CPUModelRunner
 
         # ---- scheduler ----
         scheduler_config = vllm_config.scheduler_config

--- a/vllm_spyre_next/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre_next/v1/worker/spyre_model_runner.py
@@ -1,7 +1,372 @@
-from vllm.v1.worker.cpu_model_runner import CPUModelRunner
+"""Spyre-specific model runner for vLLM v1.
+
+Inherits from GPUModelRunner to preserve the CpuGpuBuffer
+dual-buffer pattern where .cpu = CPU staging and .gpu = Spyre device tensors.
+
+Data flow in the current WIP version:
+- self.device = CPU. Buffers and scatter ops stay on CPU.
+- _SpyreModelWrapper converts input_ids/positions to Spyre int64 at the
+  model call boundary.
+- _SpyreModelWrapper converts final hidden_states to CPU for downstream
+  operations (logits indexing, lm_head, sampling).
+- Embedding: Spyre int64 input → Spyre compute → float16 output on Spyre.
+- Hidden states flow on Spyre between decoder layers.
+- There are few exceptions where a CPU fallback is currently needed:
+  - Attention block: Spyre input → CPU (and partial Spyre) compute → Spyre output.
+  - Layers that are not yet wrapped for torch-spyre,
+    for example RotaryEmbedding or ParallelLMHead
+
+As the TorchSpyreModelRunner is evolving, more layers will natively support inputs
+arriving as a Spyre tensor and perform their operations on Spyre.
+Thus, in the final state of the runner minimal D2H and H2D transfers will be necessary,
+the SpyreCpuFallbackMixin will be obsolete and most operations will be performed on Spyre.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import torch
+import torch.nn as nn
+from torch.utils._pytree import tree_map
+
+import numpy as np
+
+from vllm.config import VllmConfig, CompilationMode
+from vllm.logger import init_logger
+from vllm.model_executor.model_loader import get_model
+from vllm.model_executor.layers.attention.attention import Attention
+from vllm.v1.worker.cpu_model_runner import _torch_cuda_wrapper
+from vllm.v1.worker.gpu_model_runner import GPUModelRunner
+
+from vllm_spyre_next.custom_ops.utils import convert
+
+logger = init_logger(__name__)
 
 
-class TorchSpyreModelRunner(CPUModelRunner):
-    """Torch Spyre specific model runner class inheriting from the CPUModelRunner."""
+class SpyreCpuGpuBuffer:
+    """Spyre-specific CpuGpuBuffer with Spyre-safe copies and split dtypes.
+    This buffer is closely related to the CpuGpuBuffer in vllm/v1/utils.py.
 
-    raise NotImplementedError
+    For float dtypes: .cpu on CPU, .gpu on Spyre (float16).
+    For int/bool dtypes: .gpu aliased to .cpu (CPUModelRunner pattern).
+    All copies are currently synchronous as torch-spyre does not yet support `non_blocking`.
+    """
+
+    def __init__(
+        self,
+        *size: int | torch.SymInt,
+        cpu_dtype: torch.dtype,
+        gpu_dtype: torch.dtype,
+        device: torch.device,
+        pin_memory: bool,
+        with_numpy: bool = True,
+    ) -> None:
+        self.cpu = torch.zeros(*size, dtype=cpu_dtype, device="cpu", pin_memory=pin_memory)
+        if device.type == "spyre":
+            self.gpu = torch.zeros(*size, dtype=gpu_dtype, device=device)
+        else:
+            # int/bool: alias gpu = cpu (CPUModelRunner pattern)
+            self.gpu = self.cpu
+        self.np: np.ndarray
+        if with_numpy:
+            if cpu_dtype == torch.bfloat16:
+                raise ValueError(
+                    "Bfloat16 torch tensors cannot be directly cast to a "
+                    "numpy array, so call SpyreCpuGpuBuffer with "
+                    "with_numpy=False"
+                )
+            self.np = self.cpu.numpy()
+
+    def copy_to_gpu(self, n: int | None = None) -> torch.Tensor:
+        if self.gpu is self.cpu:
+            # Aliased (int/bool) — no copy needed
+            return self.gpu if n is None else self.gpu[:n]
+        src = self.cpu if n is None else self.cpu[:n]
+        dst = self.gpu if n is None else self.gpu[:n]
+        dst.copy_(src)
+        return dst
+
+    # Currently only the copy_to_gpu function is invoked.
+    # If the copy_to_cpu also becomes required, override it here with
+    # spyre-specific aspects.
+    # def copy_to_cpu(self, n: int | None = None) -> torch.Tensor:
+
+
+class _SpyreModelWrapper:
+    """Transparent wrapper that converts model inputs/outputs at the boundary.
+
+    Input conversion (CPU → Spyre):
+        For example, input_ids and positions arrive as CPU tensors (int32/int64) because
+        self.device=CPU in the runner and buffer scatter ops run on CPU.
+        Convert them to int64 and provide them to the model.
+
+    Output conversion (Spyre → CPU):
+        The model's final hidden_states come out on Spyre. Downstream
+        operations (indexing via logits_indices, compute_logits/lm_head,
+        sampling) all run on CPU.
+
+    Wrapping at the model level ensures ALL call sites get the right
+    device — both execute_model (via _model_forward) and _dummy_run
+    (which calls self.model(...) directly).
+    """
+
+    def __init__(self, model: nn.Module, spyre_device: torch.device):
+        # Use object.__setattr__ to avoid triggering __setattr__ override
+        object.__setattr__(self, "_model", model)
+        object.__setattr__(self, "_spyre_device", spyre_device)
+
+    def __call__(self, *args, **kwargs):
+        # Convert integer tensor inputs to Spyre int64
+        def _convert_int(t):
+            if (
+                t is not None
+                and isinstance(t, torch.Tensor)
+                and t.dtype in (torch.int32, torch.int64)
+            ):
+                return convert(t, dtype=torch.int64, device=self._spyre_device)
+            return t
+
+        args_converted = []
+        for arg in args:
+            args_converted.append(_convert_int(arg))
+
+        kwargs_converted = {}
+        for key in kwargs:
+            val = kwargs.get(key)
+            kwargs_converted[key] = _convert_int(val)
+
+        result = self._model(*args_converted, **kwargs_converted)
+
+        def _to_cpu(x):
+            return convert(x, device="cpu")
+
+        return tree_map(_to_cpu, result)
+
+    def __getattr__(self, name):
+        return getattr(self._model, name)
+
+    def __setattr__(self, name, value):
+        setattr(self._model, name, value)
+
+
+class TorchSpyreModelRunner(GPUModelRunner):
+    """Model runner for Spyre.
+
+    Treats Spyre as the 'GPU' device in vLLM's CpuGpuBuffer pattern:
+    - .cpu tensors on CPU (numpy staging for scheduler)
+    - .gpu tensors on Spyre for floats, aliased to CPU for int/bool
+
+    Inherits from GPUModelRunner to preserve
+    the dual-buffer device placement pattern.
+    """
+
+    def __init__(self, vllm_config: VllmConfig, device: torch.device):
+        # Store the real Spyre device before super().__init__ so that
+        # _make_buffer can place .gpu tensors on Spyre directly.
+        self._spyre_device = device
+
+        # Phase 1: Init with device="cpu" to avoid dtype/device errors.
+        # Many components create tensors on self.device during init, and
+        # Spyre doesn't support all dtypes (int32, bool) natively.
+        # _make_buffer (overridden below) already places .gpu on Spyre
+        # via self._spyre_device regardless of self.device.
+        with _torch_cuda_wrapper():
+            super().__init__(vllm_config, torch.device("cpu"))
+
+        # Keep self.device as CPU so buffer management (scatter, copy) stays
+        # on CPU. _SpyreModelWrapper converts input_ids/positions to Spyre
+        # int64 at the model call boundary, so the embedding takes the Spyre
+        # fast-path and hidden_states flow on Spyre between decoder layers.
+        # _make_buffer (overridden below) places float .gpu tensors on Spyre
+        # regardless of self.device.
+
+        # Disable GPU-specific features (same as CPUModelRunner)
+        self.use_cuda_graph = False
+        self.cascade_attn_enabled = False
+
+        # Replace Triton kernel with C++ CPU implementation.
+        # GPUModelRunner uses @triton.jit which is mocked on non-GPU platforms.
+        # Same replacement as CPUModelRunner._postprocess_triton().
+        import vllm.utils.cpu_triton_utils as cpu_tl
+        import vllm.v1.worker.block_table
+
+        vllm.v1.worker.block_table._compute_slot_mapping_kernel = cpu_tl.compute_slot_mapping_kernel
+
+    def load_model(self, load_dummy_weights: bool = False) -> None:
+        """Load model and compile for Spyre."""
+        logger.info("Loading model %s...", self.model_config.model)
+
+        # Load model on CPU
+        self.model = get_model(vllm_config=self.vllm_config)
+        self.model_memory_usage = 0  # No GPU memory profiling for Spyre
+
+        if self.lora_config:
+            self.model = self.load_lora_model(self.model, self.vllm_config, self.device)
+
+        # Keep Attention module buffers (_k_scale, _v_scale, etc.) on CPU.
+        # Attention is nn.Module (not PluggableLayer) so OOT registration is
+        # not possible. Patch _apply to no-op before model.to("spyre") so
+        # the CPU attention backend can access scale buffers without device
+        # mismatch.
+        for module in self.model.modules():
+            if isinstance(module, Attention):
+                module._apply = lambda fn, recurse=True, _m=module: _m
+
+        # Move layer weights to Spyre device.
+        # SpyreCpuFallbackMixin._apply() no-op keeps CPU fallback layer
+        # weights on CPU (linear, embedding, rotary, lm_head).
+        # Spyre-native layers (RMSNorm, SiluAndMul) get their weights moved.
+        self.model.to(device=self._spyre_device)
+        logger.info("Spyre-native layer weights moved to %s", self._spyre_device)
+
+        # Compile for Spyre (no-op if enforce_eager=True)
+        self._compile_for_spyre()
+
+        # Wrap model so ALL forward() calls to the entire model,
+        # for example in execute_model, _dummy_run, etc.,
+        # automatically convert Spyre outputs to CPU. This ensures downstream
+        # indexing (logits_indices), lm_head (CPU weights), and sampling all
+        # receive CPU tensors without needing per-call-site overrides.
+        self.model = _SpyreModelWrapper(self.model, self._spyre_device)
+
+        logger.info("Model loaded and compiled for Spyre.")
+
+    def _compile_for_spyre(self) -> None:
+        """Apply torch.compile for Spyre with static shapes.
+
+        Spyre compilation is handled here (not by vLLM's @support_torch_compile)
+        because Spyre requires static shapes — dynamic shapes (SymInt) are not
+        supported by the Spyre Inductor backend.
+
+        Supported modes:
+        - enforce_eager=True: no compilation (eager execution)
+        - CompilationMode.NONE: Spyre-managed compilation with torch.compile
+        Other vLLM compilation modes (VLLM_COMPILE, STOCK_TORCH_COMPILE) are
+        not supported — the platform forces CompilationMode.NONE in
+        apply_config_platform_defaults().
+        """
+        mode = self.compilation_config.mode
+        if mode != CompilationMode.NONE:
+            raise ValueError(
+                f"Unsupported compilation mode {mode} for Spyre. "
+                f"Only CompilationMode.NONE is supported. Spyre handles "
+                f"compilation internally via _compile_for_spyre(). "
+                f"Use enforce_eager=True to disable compilation entirely."
+            )
+
+        if self.vllm_config.model_config.enforce_eager:
+            logger.info("Compilation disabled (enforce_eager=True)")
+            return
+
+        # Custom ops (spyre_rmsnorm, spyre_cpu_fallback, etc.) are opaque
+        # to dynamo but don't cause graph breaks — fullgraph=True is safe.
+        # dynamic=False ensures static shapes (Spyre can't handle SymInt).
+        self.model = torch.compile(
+            self.model,
+            backend="inductor",
+            fullgraph=True,
+            dynamic=False,
+        )
+        logger.info("Model compiled for Spyre (backend=inductor)")
+
+    def warming_up_model(self) -> None:
+        """Run a dummy forward pass to warm up the model.
+
+        _dummy_run creates CPU int inputs, but _SpyreModelWrapper converts
+        input_ids/positions to Spyre int64 at the model boundary. The
+        embedding thus runs on Spyre and hidden_states flow on Spyre.
+        _SpyreModelWrapper also converts final outputs back to CPU.
+
+        When enforce_eager=False, this also triggers torch.compile.
+        """
+        logger.info("Warming up model...")
+        num_tokens = min(
+            max(16, self.max_num_reqs),
+            self.scheduler_config.max_num_batched_tokens,
+        )
+        with _set_spyre_compilation_settings(self.vllm_config):
+            self._dummy_run(num_tokens)
+        logger.info("Warmup done.")
+
+    # --- KV cache allocation ---
+    # Potential sub to override KV cache tensor allocation
+    # def _allocate_kv_cache_tensors(
+    #     self,
+    #     kv_cache_config,
+    # ) -> dict[str, torch.Tensor]:
+
+    # --- Stubs copied from CPUModelRunner ---
+    # These are trivial overrides that GPUModelRunner expects.
+
+    def _init_device_properties(self) -> None:
+        # No CUDA/GPU device properties to query for Spyre
+        pass
+
+    def _sync_device(self) -> None:
+        # TODO: Replace with torch.spyre.synchronize() when available.
+        # For now, all copies are synchronous (no non_blocking), so
+        # explicit sync is not needed.
+        pass
+
+    def get_dp_padding(self, num_tokens: int) -> tuple[int, torch.Tensor | None]:
+        return 0, None
+
+    def get_model(self) -> nn.Module:
+        # Return the unwrapped model for isinstance checks
+        # (e.g. is_text_generation_model in get_supported_tasks).
+        model = self.model
+        if isinstance(model, _SpyreModelWrapper):
+            model = model._model
+        # Unwrap torch.compile's OptimizedModule (has _orig_mod attribute)
+        if hasattr(model, "_orig_mod"):
+            model = model._orig_mod
+        return model
+
+    # --- Buffer management ---
+
+    def _make_buffer(
+        self, *size: int | torch.SymInt, dtype: torch.dtype, numpy: bool = True
+    ) -> SpyreCpuGpuBuffer:
+        """Create a SpyreCpuGpuBuffer with float tensors on Spyre.
+
+        - Float dtypes: .cpu on CPU, .gpu on Spyre as float16
+        - Int/bool dtypes: .gpu aliased to .cpu (stays on CPU)
+        """
+        if dtype.is_floating_point:
+            return SpyreCpuGpuBuffer(
+                *size,
+                cpu_dtype=dtype,
+                gpu_dtype=torch.float16,
+                device=self._spyre_device,
+                pin_memory=False,
+                with_numpy=numpy,
+            )
+        # Int/bool → CPU-only (aliased)
+        return SpyreCpuGpuBuffer(
+            *size,
+            cpu_dtype=dtype,
+            gpu_dtype=dtype,
+            device=torch.device("cpu"),
+            pin_memory=False,
+            with_numpy=numpy,
+        )
+
+
+@contextmanager
+def _set_spyre_compilation_settings(config: VllmConfig):
+    """Context manager for Spyre-specific compilation settings during warmup.
+
+    Similar to _set_global_compilation_settings in cpu_model_runner.py but
+    adapted for Spyre's compilation requirements.
+    """
+    import torch._inductor.config as torch_inductor_config
+
+    inductor_config = config.compilation_config.inductor_compile_config
+    freezing_value = torch_inductor_config.freezing
+    try:
+        if inductor_config.get("max_autotune", False):
+            torch_inductor_config.freezing = True
+        yield
+    finally:
+        torch_inductor_config.freezing = freezing_value

--- a/vllm_spyre_next/v1/worker/spyre_model_runner.py
+++ b/vllm_spyre_next/v1/worker/spyre_model_runner.py
@@ -34,7 +34,7 @@ import numpy as np
 
 from vllm.config import VllmConfig, CompilationMode
 from vllm.logger import init_logger
-from vllm.model_executor.model_loader import get_model
+from vllm.model_executor.model_loader import get_model_loader
 from vllm.model_executor.layers.attention.attention import Attention
 from vllm.v1.worker.cpu_model_runner import _torch_cuda_wrapper
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
@@ -197,12 +197,23 @@ class TorchSpyreModelRunner(GPUModelRunner):
         """Load model and compile for Spyre."""
         logger.info("Loading model %s...", self.model_config.model)
 
+        if load_dummy_weights:
+            self.load_config.load_format = "dummy"
+        model_loader = get_model_loader(self.load_config)
+        
         # Load model on CPU
-        self.model = get_model(vllm_config=self.vllm_config)
+        self.model = model_loader.load_model(
+            vllm_config=self.vllm_config, model_config=self.model_config
+        )
         self.model_memory_usage = 0  # No GPU memory profiling for Spyre
 
+        # Cases appearing in GPUModelRunner.
+        # When needed, they can be implemented for Spyre.
         if self.lora_config:
-            self.model = self.load_lora_model(self.model, self.vllm_config, self.device)
+            raise NotImplementedError('LoRA adapters are not yet implemented and tested for Spyre.')
+        
+        if hasattr(self, "drafter"):
+            raise NotImplementedError('Models with a drafter model are not yet implemented and tested for Spyre.')
 
         # Keep Attention module buffers (_k_scale, _v_scale, etc.) on CPU.
         # Attention is nn.Module (not PluggableLayer) so OOT registration is

--- a/vllm_spyre_next/v1/worker/spyre_worker.py
+++ b/vllm_spyre_next/v1/worker/spyre_worker.py
@@ -1,16 +1,23 @@
 """A Torch Spyre worker class."""
 
+import torch
+
 from vllm.config import VllmConfig
-from vllm.v1.worker.cpu_worker import CPUWorker
 from vllm.logger import init_logger
+from vllm.v1.worker.cpu_worker import CPUWorker
 
 from vllm_spyre_next.custom_ops import register_all
+from vllm_spyre_next.v1.worker.spyre_model_runner import TorchSpyreModelRunner
 
 logger = init_logger(__name__)
 
 
 class TorchSpyreWorker(CPUWorker):
-    """A worker class that executes the model on a group of Spyre cores."""
+    """A worker class that executes the model on IBM's Spyre device.
+
+    Inherits from CPUWorker but extends init_device to:
+    - Create a TorchSpyreModelRunner with torch.device("spyre")
+    """
 
     def __init__(
         self,
@@ -20,14 +27,30 @@ class TorchSpyreWorker(CPUWorker):
         distributed_init_method: str,
         is_driver_worker: bool = False,
     ) -> None:
-        super().__init__(vllm_config, local_rank, rank, distributed_init_method, is_driver_worker)
+        super().__init__(
+            vllm_config,
+            local_rank,
+            rank,
+            distributed_init_method,
+            is_driver_worker,
+        )
 
         # Register all the custom ops here when a worker is created.
-        # This has to happen before the model is loaded, so that all the layers will be swapped out
-        # with the custom implementations for spyre.
+        # This has to happen before the model is loaded, so that all the
+        # layers will be swapped out with the custom implementations for spyre.
         register_all()
 
-    def compile_or_warm_up_model(self):
+    def init_device(self) -> None:
+        # Call the upstream init_device function for the environment setup
+        super().init_device()
+
+        # Construct Spyre model runner with torch.device("spyre")
+        self.model_runner = TorchSpyreModelRunner(
+            self.vllm_config,
+            torch.device("spyre"),
+        )
+
+    def compile_or_warm_up_model(self) -> float:
         # FIXME: Work around for https://github.com/torch-spyre/torch-spyre/issues/1420
         # Ensure registration of Spyre decompositions before FX Graph tracing
         import torch._inductor.decomposition
@@ -39,4 +62,9 @@ class TorchSpyreWorker(CPUWorker):
                     "FIXME: Adding %s decomposition to work-around torch-spyre crash", op.name()
                 )
                 torch._inductor.decomposition.decompositions[op] = impl
-        return super().compile_or_warm_up_model()
+        import time
+
+        warmup_start_time = time.perf_counter()
+        self.model_runner.warming_up_model()
+        self.compilation_config.compilation_time = time.perf_counter() - warmup_start_time
+        return self.compilation_config.compilation_time


### PR DESCRIPTION
This PR replaces https://github.com/torch-spyre/sendnn-inference/pull/878 and targets the new `spyre-inference` repo.