### PR TITLE
Add amd64 Dockerfile for vllm-spyre build

### DIFF
--- a/dockerfile/Dockerfile.amd64
+++ b/dockerfile/Dockerfile.amd64
@@ -1,0 +1,28 @@
+# dockerfile/Dockerfile.amd64
+
+FROM icr.io/ai_sw_accel/mayurtorch-spyre:latest
+
+USER root
+
+# Install uv (required)
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:$PATH"
+
+# Version override (ok)
+ENV SETUPTOOLS_SCM_PRETEND_VERSION_FOR_VLLM_SPYRE_NEXT=0.1.0
+
+WORKDIR /workspace
+
+# Clone + install
+RUN git clone --depth 1 https://github.com/torch-spyre/spyre-inference.git && \
+    cd spyre-inference && \
+    uv pip install vllm torchvision && \
+    uv pip install -e . --no-deps
+
+# Fix permissions before switching user
+RUN chown -R senuser:senuser /workspace
+
+USER senuser
+WORKDIR /workspace/spyre-inference
+
+CMD ["bash"]


### PR DESCRIPTION
## Summary
Add Dockerfile for building vllm-spyre on x86.

## Changes
- Added dockerfile/Dockerfile.amd64

## Validation
1: Build tested on x86 machine
2: mage builds successfully
3: Container runs and environment is ready
Note: Created image for s390x machine and also a multi-arch which supports both x86,s390x and power .Currently we are using localhost/torch-spyre as base image for s390x arch as in icr no image available for torch-spyre for s390x machine.once available will build vllm-spyre on the top of that but locally I am able to create image for vllm-spyre on s390x machine.