### PR TITLE
Add SpyreSiluAndMul registration to enable custom op

### DIFF
--- a/spyre_inference/custom_ops/__init__.py
+++ b/spyre_inference/custom_ops/__init__.py
@@ -7,6 +7,7 @@ from . import rms_norm
 from . import rotary_embedding
 from . import vocab_parallel_embedding
 from . import linear
+from . import silu_and_mul
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)

--- a/spyre_inference/custom_ops/silu_and_mul.py
+++ b/spyre_inference/custom_ops/silu_and_mul.py
@@ -80,3 +80,4 @@ class SpyreSiluAndMul(SiluAndMul):
         x2 = convert(x2, device=original_device)
 
         return F.silu(x1) * x2
+


### PR DESCRIPTION
The SpyreSiluAndMul custom op was not being invoked because the module was never imported. This commit adds:

- Import of silu_and_mul module in custom_ops/__init__.py
