### PR TITLE
docs(plugin-test): update plugin test setup with inexact sync flag

### DIFF
--- a/tests/plugin/README.md
+++ b/tests/plugin/README.md
@@ -18,6 +18,6 @@ The plugin is automatically discovered by pytest via the `pytest11` entry point.
 
 ```bash
 cd tests/plugin
-uv sync
+uv sync --inexact
 uv run pytest
 ```


### PR DESCRIPTION
Maybe I'm setting something incorrectly but doing `uv sync` without the `inexact` flag removed all dependencies (like `vllm`) for me?