### PR TITLE
:recycle: simplify codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,10 +8,10 @@
 spyre_inference/platform.py @joerunde @yannicks1
 
 # Custom operations (OOT layers for Spyre)
-spyre_inference/custom_ops/ @bohnstingl @yannicks1 @romitjain @dilipgb
+spyre_inference/custom_ops/ @bohnstingl @yannicks1 @dilipgb
 
 # v1 worker and model runner
 spyre_inference/v1/worker/ @bohnstingl @joerunde
 
 # Attention backend (PyTorch-native Spyre attention)
-spyre_inference/v1/attention/ @jvlunteren
+spyre_inference/v1/attention/ @jvlunteren @bohnstingl @bringlein

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,15 +15,3 @@ spyre_inference/v1/worker/ @bohnstingl @joerunde
 
 # Attention backend (PyTorch-native Spyre attention)
 spyre_inference/v1/attention/ @jvlunteren
-
-# Test infrastructure and pytest plugins
-tests/ @joerunde @romitjain
-
-# CI/CD workflows
-.github/workflows/ @romitjain @joerunde
-
-# Documentation
-docs/ @joerunde @rafvasq
-
-# Build configuration
-pyproject.toml @joerunde @yannicks1


### PR DESCRIPTION
As we've been trying out codeowners, I think it could use a little bit of trimming. As we've found out, the last match takes precedence for all files, which has led to more required approvals than intended.

I don't think it makes sense to have a small group of owners for `tests`, since almost all code changes should come with associated tests. As-is, this means that Romit or I had to sign off on every PR. Removing this delegates to the `*` owners, which is a sufficiently large group to get things merged.

Similar logic for the other bits- for docs, GHA workflows, or pyproject.toml edits it should be fine to delegate to the `*` owners. If we want a dedicated group of people required to sign off for these, I think they would need to be bigger groups with timezone and holiday coverage.

The remaining section that will likely need more volunteers is the attention backend:
```
# Attention backend (PyTorch-native Spyre attention)
spyre_inference/v1/attention/ @jvlunteren
```

I don't think it'll work to require Jan and only Jan to sign off on all changes for the attention backends. If we want to keep a dedicated set of owners there though, could I get maybe @tdoublep and @bohnstingl to volunteer to be in there too? Or others?