### PR TITLE
[BUG] Minor fix for parallel_lm_output

### DIFF
--- a/spyre_inference/custom_ops/parallel_lm_head.py
+++ b/spyre_inference/custom_ops/parallel_lm_head.py
@@ -148,7 +148,8 @@ class SpyreParallelLMHead(ParallelLMHead):
             bias,
         )
 
-        return convert(out[:, : -self.padding] if self.padding > 0 else out, device=x_device)
+        out_cpu = convert(out, device=x_device)
+        return out_cpu[:, : -self.padding] if self.padding > 0 else out_cpu
 
     @staticmethod
     def forward_spyre(

--- a/spyre_inference/custom_ops/parallel_lm_head.py
+++ b/spyre_inference/custom_ops/parallel_lm_head.py
@@ -148,8 +148,9 @@ class SpyreParallelLMHead(ParallelLMHead):
             bias,
         )
 
-        out_cpu = convert(out, device=x_device)
-        return out_cpu[:, : -self.padding] if self.padding > 0 else out_cpu
+        out_cpu = convert(out, device="cpu")
+        out_real = out_cpu[:, : -self.padding] if self.padding > 0 else out_cpu
+        return convert(out_real, device=x_device)
 
     @staticmethod
     def forward_spyre(

--- a/spyre_inference/custom_ops/parallel_lm_head.py
+++ b/spyre_inference/custom_ops/parallel_lm_head.py
@@ -149,8 +149,8 @@ class SpyreParallelLMHead(ParallelLMHead):
         )
 
         out_cpu = convert(out, device="cpu")
-        out_real = out_cpu[:, : -self.padding] if self.padding > 0 else out_cpu
-        return convert(out_real, device=x_device)
+        out_cpu_no_pad = out_cpu[:, : -self.padding] if self.padding > 0 else out_cpu
+        return convert(out_cpu_no_pad, device=x_device)
 
     @staticmethod
     def forward_spyre(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

This PR fixes a minor issue with the `ParallelLMHead`. As mentioned in the [original PR](https://github.com/torch-spyre/spyre-inference/pull/159), the internal operation is padded because of a limitation of `torch-spyre`. At the end, this padding is removed again. However, currently this slicing is done on cpu, which works, because the padding is at the end and thus does not lead to any stride / contingency issue. However, this PR resolves this inconsistency and performs the slicing on `cpu`.

## Related Issues

NA

## Test Plan

No additional test needed

## Checklist

- [X] I have read the [contributing guidelines](https://torch-spyre.github.io/spyre-inference/contributing/)
- [X] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [X] My commits include a `Signed-off-by:` line (DCO compliance)
