### PR TITLE
:zap: Fixup uv caching for faster pre-commit checks

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -24,14 +24,13 @@ jobs:
       with:
         python-version: "3.12"
         enable-cache: true
-        ignore-nothing-to-cache: true
-        cache-dependency-glob: |
-          pyproject.toml
     # Required to build vllm's CPU backend
     - name: "Install system dependencies for vllm CPU build"
       run: sudo apt-get update && sudo apt-get install -y libnuma-dev
+    # torch-spyre cannot install without the spyre runtime libs installed
+    # we're not running any tests so we can skip the dev group with `--no-dev`
     - name: "Install dependencies"
-      run: uv sync --frozen --no-install-package torch-spyre
+      run: uv sync --frozen --no-install-package torch-spyre --no-dev
     - run: echo "::add-matcher::.github/workflows/matchers/ruff.json"
     - uses: j178/prek-action@v1
       with:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Our pre-commit checks are currently _not_ using uv caching, the cache entries are 1KB and every PR is rebuilding vllm from source. This needs to be fixed, but I'm not 100% sure what part of the setup is currently broken. I don't expect that the runs on the PRs themselves will be able to write to the cache because they'll have read-only creds, but this action does run on `main` after the PR is merged and I don't see caches being written back from those builds 🤔 

I don't think we should include `ignore-nothing-to-cache: true`, since we will always build a uv venv and install dependencies, so either we'll pull from cache or install things that should be cached. Experimenting here to see what's going on with that.

Also the `cache-dependency-glob` by default will look for a uv.lock, and we should probably be keying on the lockfile since that can change independently of the pyproject.toml. (Packages can upgrade without changing the supported version ranges).

Update: Looks like a successful cache from this PR! (590MB instead of 1KB)
<img width="1294" height="157" alt="image" src="https://github.com/user-attachments/assets/755dc050-c593-45d8-b8f5-9b1c381b47d7" />


## Related Issues


## Test Plan

- [ ] Find out what's broken 

## Checklist

- [ ] I have read the [contributing guidelines](https://torch-spyre.github.io/spyre-inference/contributing/)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
