### PR TITLE
:bug: simply remove vllm from the pre-commit builds for now 😭

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -32,7 +32,7 @@ jobs:
     # torch-spyre cannot install without the spyre runtime libs installed
     # we're not running any tests so we can skip the dev group with `--no-dev`
     - name: "Install dependencies"
-      run: uv sync --frozen --no-install-package torch-spyre --no-dev
+      run: uv sync --frozen --no-install-package torch-spyre --no-dev -v
     - run: echo "::add-matcher::.github/workflows/matchers/ruff.json"
     - uses: j178/prek-action@v1
       with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -23,7 +23,7 @@ jobs:
       uses: astral-sh/setup-uv@v5
       with:
         python-version: "3.12"
-        enable-cache: false
+        enable-cache: true
     # Required to build vllm's CPU backend
     - name: "Install system dependencies for vllm CPU build"
       run: sudo apt-get update && sudo apt-get install -y libnuma-dev

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -23,7 +23,7 @@ jobs:
       uses: astral-sh/setup-uv@v5
       with:
         python-version: "3.12"
-        enable-cache: true
+        enable-cache: false
     # Required to build vllm's CPU backend
     - name: "Install system dependencies for vllm CPU build"
       run: sudo apt-get update && sudo apt-get install -y libnuma-dev

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -27,6 +27,8 @@ jobs:
     # Required to build vllm's CPU backend
     - name: "Install system dependencies for vllm CPU build"
       run: sudo apt-get update && sudo apt-get install -y libnuma-dev
+    - name: Install CMake & Ninja
+      uses: lukka/get-cmake@latest
     # torch-spyre cannot install without the spyre runtime libs installed
     # we're not running any tests so we can skip the dev group with `--no-dev`
     - name: "Install dependencies"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -27,12 +27,10 @@ jobs:
     # Required to build vllm's CPU backend
     - name: "Install system dependencies for vllm CPU build"
       run: sudo apt-get update && sudo apt-get install -y libnuma-dev
-    - name: Install CMake & Ninja
-      uses: lukka/get-cmake@latest
     # torch-spyre cannot install without the spyre runtime libs installed
     # we're not running any tests so we can skip the dev group with `--no-dev`
     - name: "Install dependencies"
-      run: uv sync --frozen --no-install-package torch-spyre --no-dev -v
+      run: uv sync --frozen --no-install-package torch-spyre --no-install-package vllm --no-dev -v
     - run: echo "::add-matcher::.github/workflows/matchers/ruff.json"
     - uses: j178/prek-action@v1
       with:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

#186 started pushing uv caches for quickly rebuilding our `pre-commit` environment with vllm installed for proper type checking.

However, now other PRs are pulling cache and immediately failing to build vllm because `ninja` is not found. This is a bit puzzling to me because:
1. If vllm is cached, why is it being rebuilt?
2. None of the other build setup changed and vllm wasn't updated so why would ninja now be missing?

The good news is that they're failing in 10 seconds instead of 20 minutes at least.

Debugging this here 😭 


Update: Still not really sure what's going on. But since we've disabled the type checking, we can punt to a future issue to enable it and properly cache vllm builds then. @coderfornow had it right all along with ignoring vllm 😉 

From some input from @tjohnson31415, we'd likely want to use ccache for vllm build caching anyway because the uv cache may be unsafe- it won't take the runtime library versions into account when loading from cache.

## Related Issues

<!-- Link related issues, e.g., `Fixes #` or `Relates to #456` -->

## Test Plan

<!-- Describe how you tested your changes. Include commands or steps to reproduce. -->

## Checklist

- [ ] I have read the [contributing guidelines](https://torch-spyre.github.io/spyre-inference/contributing/)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
