### PR TITLE
docs: improve mike deployment and update README

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -4,13 +4,25 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "docs/**"
+      - "examples/**"
+      - "mkdocs.yaml"
+      - "docs/requirements-docs.txt"
+      - ".github/workflows/deploy-docs.yml"
   release:
     types:
       - published
   workflow_dispatch:
 
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
 permissions:
   contents: write
+  pages: write
+  id-token: write
 
 jobs:
   deploy:
@@ -22,14 +34,25 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: docs-${{ hashFiles('docs/requirements-docs.txt') }}
+          restore-keys: docs-
       - run: pip install -r docs/requirements-docs.txt
       - name: Configure git
         run: |
+          git fetch origin gh-pages --depth=1
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
       - name: Deploy latest (main)
         if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-        run: mike deploy --push --update-aliases latest
+        run: |
+          mike deploy --push latest
+          mike set-default --push latest
       - name: Deploy release
         if: github.event_name == 'release'
-        run: mike deploy --push --update-aliases ${{ github.ref_name }} stable
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          mike deploy --push --update-aliases "$VERSION" stable

--- a/.github/workflows/doc_comment.yml
+++ b/.github/workflows/doc_comment.yml
@@ -1,0 +1,70 @@
+name: Doc PR Preview Comment Bot
+
+on:
+  workflow_run:
+    workflows:
+      - Preview docs
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+
+jobs:
+  comment:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download pr-number artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-number
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download preview-docs artifact URL
+        id: artifact-url
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          result-encoding: string
+          script: |
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id }},
+            });
+            const artifact = artifacts.data.artifacts.find(a => a.name === 'preview-docs');
+            return `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${{ github.event.workflow_run.id }}/artifacts/${artifact.id}`;
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Post or update comment
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const fs = require('fs');
+            const prNumber = parseInt(fs.readFileSync('pr-number.txt', 'utf8').trim());
+            const sha = '${{ github.event.workflow_run.head_sha }}'.slice(0, 7);
+            const artifactUrl = '${{ steps.artifact-url.outputs.result }}';
+            const body = `## Docs preview\n\nBuilt from ${sha}. [Download artifact](${artifactUrl}), or build the docs locally:\n\`\`\`bash\nuv pip install -r docs/requirements-docs.txt\nmkdocs serve\n\`\`\``;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.find(c => c.body.startsWith('## Docs preview'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -16,10 +16,24 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: docs-${{ hashFiles('docs/requirements-docs.txt') }}
+          restore-keys: docs-
       - run: pip install -r docs/requirements-docs.txt
       - run: mkdocs build --strict
       - uses: actions/upload-artifact@v4
         with:
           name: preview-docs
           path: site/
+          retention-days: 7
+      - name: Save PR metadata
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: echo "$PR_NUMBER" > pr-number.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pr-number
+          path: pr-number.txt
           retention-days: 7

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -28,6 +28,8 @@ jobs:
           name: preview-docs
           path: site/
           retention-days: 7
+      # The PR number must be passed via artifact because doc_comment.yml runs on
+      # workflow_run (triggered after this workflow), which has no pull_request context.
       - name: Save PR metadata
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/README.md
+++ b/README.md
@@ -1,76 +1,40 @@
-# spyre-inference
+<h1 align="center">
+Spyre Inference
+</h1>
 
-A vLLM platform plugin for IBM Spyre AI accelerators.
+<p align="center">
+| <a href="https://torch-spyre.github.io/spyre-inference/"><b>Documentation</b></a> | <a href="https://discuss.vllm.ai/c/hardware-support/"><b>Users Forum</b></a> | <a href="https://slack.vllm.ai"><b>#sig-spyre</b></a> |
+</p>
 
-## Overview
+---
 
-`spyre-inference` is the next evolution of [`sendnn-inference`](https://github.com/torch-spyre/sendnn-inference), providing seamless integration of IBM's Spyre hardware accelerators with vLLM for high-performance large language model inference.
+**IBM Spyre** is the first production-grade Artificial Intelligence Unit (AIU) accelerator born out of the IBM Research AIU family, and is part of a long-term strategy of developing novel architectures and full-stack technology solutions for the emerging space of generative AI. Spyre builds on the foundation of IBM's internal AIU research and delivers a scalable, efficient architecture for accelerating AI in enterprise environments.
 
-This plugin leverages `torch-spyre` to utilize PyTorch's native Inductor compiler backend, enabling optimized model execution on Spyre devices through vLLM's plugin architecture.
+`spyre-inference` is a vLLM platform plugin that enables seamless integration of IBM Spyre accelerators with vLLM via the [`torch-spyre`](https://github.com/torch-spyre/torch-spyre) PyTorch backend. It is the next evolution of [`sendnn-inference`](https://github.com/torch-spyre/sendnn-inference), leveraging PyTorch's native Inductor compiler backend through vLLM's plugin architecture.
 
-## Requirements
+For more information, check out the following:
 
-- Python >= 3.11
-- Access to IBM Spyre hardware with the Spyre Runtime stack
-- PyTorch 2.10.0 (CPU backend)
+- 📚 [Meet the IBM Artificial Intelligence Unit](https://research.ibm.com/blog/ibm-artificial-intelligence-unit-aiu)
+- 📽️ [AI Accelerators: Transforming Scalability & Model Efficiency](https://www.youtube.com/watch?v=KX0qBM-ByAg)
+- 🚀 [Spyre Accelerator for IBM Z](https://research.ibm.com/blog/spyre-for-z)
+- 🚀 [Spyre Accelerator for IBM POWER](https://newsroom.ibm.com/2025-07-08-ibm-power11-raises-the-bar-for-enterprise-it)
 
-## Installation
+## Getting Started
 
-```bash
-# Clone the repository
-git clone https://github.com/torch-spyre/spyre-inference
-cd spyre-inference
+Visit our [documentation](https://torch-spyre.github.io/spyre-inference/):
 
-# Install with uv (recommended)
-uv sync --frozen
-```
-
-**Note:** `torch-spyre` compilation requires access to IBM Spyre hardware with the Spyre Runtime stack. See internal development documentation for environment setup.
-
-## Usage
-
-The plugin automatically registers with vLLM when installed.
-Use it by setting `VLLM_PLUGINS=spyre_inference`
-
-```python
-from vllm import LLM
-
-llm = LLM(
-    model="ibm-ai-platform/micro-g3.3-8b-instruct-1b",
-    max_model_len=128,
-    max_num_seqs=2,
-)
-```
-
-## Testing
-
-The test suite includes:
-
-- **Local tests** (`-m spyre`) - Spyre-specific functionality validation
-- **Upstream tests** (`-m upstream`) - vLLM compatibility verification
-
-Upstream tests are automatically synced from the vLLM repository at the commit specified in `pyproject.toml`.
+- [Installation](https://torch-spyre.github.io/spyre-inference/latest/getting_started/installation.html)
+- [Examples](https://torch-spyre.github.io/spyre-inference/latest/examples/offline_inference/)
+- [Contributing Guide](https://torch-spyre.github.io/spyre-inference/latest/contributing/)
 
 ## Contributing
 
-See [Contributing Guide](docs/contributing/README.md) for:
+We welcome and value any contributions and collaborations. Please check out [Contributing to Spyre Inference](https://torch-spyre.github.io/spyre-inference/latest/contributing/) for how to get involved.
 
-- Issue reporting and feature requests
-- Development setup
-- Testing guidelines
-- Pull request process
+## Contact
 
-## Documentation
-
-- [Installation Guide](docs/getting_started/installation.md)
-- [Contributing Guide](docs/contributing/README.md)
+You can reach out for discussion or support in the `#sig-spyre` channel in the [vLLM Slack](https://inviter.co/vllm-slack) workspace or by [opening an issue](https://github.com/torch-spyre/spyre-inference/issues).
 
 ## License
 
 [Apache-2.0](LICENSE)
-
-## Related Projects
-
-- [torch-spyre](https://github.com/torch-spyre/torch-spyre) - PyTorch backend for Spyre accelerators
-- [vLLM](https://github.com/vllm-project/vllm) - High-throughput LLM inference engine
-- [sendnn-inference](https://github.com/torch-spyre/sendnn-inference) - Previous generation Spyre vLLM plugin

--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -1,5 +1,13 @@
 nav:
-  - Home: README.md
+  - Home:
+    - Spyre Inference: README.md
+    - Getting Started:
+      - Installation: getting_started/installation.md
+    - Examples:
+      - Offline Inference: examples/offline_inference
+    - Developer Guide:
+      - Contributing: contributing/README.md
+
   - Getting Started:
     - Installation: getting_started/installation.md
   - Examples:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,42 +1,19 @@
-# spyre-inference
+# Welcome to Spyre Inference
 
-## Overview
+<p style="text-align:center">
+<script async defer src="https://buttons.github.io/buttons.js"></script>
+<a class="github-button" href="https://github.com/torch-spyre/spyre-inference" data-show-count="true" data-size="large" aria-label="Star">Star</a>
+<a class="github-button" href="https://github.com/torch-spyre/spyre-inference/subscription" data-icon="octicon-eye" data-size="large" aria-label="Watch">Watch</a>
+<a class="github-button" href="https://github.com/torch-spyre/spyre-inference/fork" data-icon="octicon-repo-forked" data-size="large" aria-label="Fork">Fork</a>
+</p>
 
-The `spyre-inference` plugin represents the next iteration of sendnn-inference, built on the `torch-spyre` stack. This plugin integrates with `torch-spyre` to leverage the PyTorch Inductor backend for model compilation, providing enhanced performance and optimization capabilities for large language model inference.
+**IBM Spyre** is the first production-grade Artificial Intelligence Unit (AIU) accelerator born out of the IBM Research AIU family. It is part of a long-term strategy of developing novel architectures and full-stack technology solutions for the emerging space of generative AI. Spyre builds on the foundation of IBM's internal AIU research and delivers a scalable, efficient architecture for accelerating AI in enterprise environments.
 
-## Key Features
+`spyre-inference` is a vLLM platform plugin that enables seamless integration of IBM Spyre accelerators with vLLM via the [`torch-spyre`](https://github.com/torch-spyre/torch-spyre) PyTorch backend. It is the next evolution of [`sendnn-inference`](https://github.com/torch-spyre/sendnn-inference), leveraging PyTorch's native Inductor compiler backend through vLLM's plugin architecture.
 
-- **Torch Inductor Backend**: Utilizes PyTorch's native Inductor compiler for optimized model execution
-- **torch-spyre Integration**: Built on the torch-spyre framework for advanced compilation and optimization
-- **vLLM Platform Plugin**: Seamlessly integrates with vLLM's plugin architecture via the `vllm.platform_plugins` entry point
-- **CPU-Optimized**: Configured for efficient CPU-based inference with vLLM 0.15.1+cpu
+For more information, check out the following:
 
-## Architecture
-
-The plugin registers itself as a vLLM platform plugin through the entry point:
-
-```python
-[project.entry-points."vllm.platform_plugins"]
-spyre_inference = "spyre_inference:register"
-```
-
-This allows vLLM to automatically discover and load the plugin, enabling torch-spyre-based compilation and execution.
-
-## Getting Started
-
-To get started with spyre-inference, see the [Installation Guide](getting_started/installation.md).
-
-## Documentation
-
-- [Installation](getting_started/installation.md) - Setup and installation instructions
-
-## Requirements
-
-- Python >= 3.11
-- torch-spyre (built from source)
-- vLLM 0.15.1+cpu
-- PyTorch 2.10.0 (CPU version)
-
-## License
-
-Apache-2.0
+- 📚 [Meet the IBM Artificial Intelligence Unit](https://research.ibm.com/blog/ibm-artificial-intelligence-unit-aiu)
+- 📽️ [AI Accelerators: Transforming Scalability & Model Efficiency](https://www.youtube.com/watch?v=KX0qBM-ByAg)
+- 🚀 [Spyre Accelerator for IBM Z](https://research.ibm.com/blog/spyre-for-z)
+- 🚀 [Spyre Accelerator for IBM POWER](https://newsroom.ibm.com/2025-07-08-ibm-power11-raises-the-bar-for-enterprise-it)

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -6,7 +6,7 @@ This guide covers the installation of `spyre-inference` using `uv`, a fast Pytho
 
 - Python >= 3.11
 - `uv` package manager installed ([installation guide](https://github.com/astral-sh/uv))
-- Access to systems where `sendnn` is available (required for torch-spyre compilation)
+- Access to IBM Spyre hardware with the Spyre Runtime Stack (required for torch-spyre compilation)
 
 ## Installation with uv sync
 
@@ -91,10 +91,28 @@ This includes additional tools like pytest, pytest-asyncio, and other testing ut
 
 If you encounter build failures:
 
-1. **torch-spyre compilation**: Ensure `sendnn` is available on your system. See internal development documentation for how to set up a dev environment with `sendnn`.
+1. **torch-spyre compilation**: Ensure the Spyre Runtime Stack is available on your system. See internal development documentation for environment setup.
 2. **vLLM build**: Check that you have sufficient memory and CPU resources for compilation
 3. **Dependency conflicts**: Review the `override-dependencies` section in `pyproject.toml`
 
 ## Next Steps
 
-After installation, you can start using spyre-inference with your vLLM applications. The plugin will automatically be loaded by vLLM when the appropriate platform is detected.
+To load the plugin, set the `VLLM_PLUGINS` environment variable before running vLLM:
+
+```bash
+export VLLM_PLUGINS=spyre_inference
+```
+
+You can then use vLLM as usual:
+
+```python
+from vllm import LLM
+
+llm = LLM(
+    model="ibm-ai-platform/micro-g3.3-8b-instruct-1b",
+    max_model_len=128,
+    max_num_seqs=2,
+)
+```
+
+See the [Examples](../examples/offline_inference/torch_spyre_inference.md) page for more usage patterns.

--- a/docs/mkdocs/overrides/main.html
+++ b/docs/mkdocs/overrides/main.html
@@ -1,6 +1,12 @@
 {% extends "base.html" %}
 
 {% block announce %}
-  {# TODO: add the spyre-inference stable docs URL once available. #}
-  <p>You are viewing the latest developer preview docs. <a href="">Click here</a> to view docs for the latest stable release.</p>
+  <p id="dev-banner" style="display:none">
+    You are viewing development docs. <a href="{{ config.site_url }}stable/">Click here</a> to view docs for the latest stable release.
+  </p>
+  <script>
+    if (window.location.pathname.includes('/latest/')) {
+      document.getElementById('dev-banner').style.display = '';
+    }
+  </script>
 {% endblock %}

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,4 +1,4 @@
-site_name: Spyre Inference Plugin
+site_name: Spyre Inference
 site_url: https://torch-spyre.github.io/spyre-inference/
 repo_url: https://github.com/torch-spyre/spyre-inference
 exclude_docs: |
@@ -29,10 +29,12 @@ theme:
   features:
     - content.code.copy
     - content.tabs.link
+    - navigation.instant
+    - navigation.instant.progress
     - navigation.tracking
     - navigation.tabs
+    - navigation.tabs.sticky
     - navigation.sections
-    - navigation.prune
     - navigation.top
     - search.highlight
     - search.share


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

This PR generally improves/fixes a few things about the `mike` deployment and updates the repo's README and doc site landing page.

- fetch gh-pages before mike runs (otherwise probably results in a bug caught in [sendnn-inference/725](https://github.com/torch-spyre/sendnn-inference/pull/725))
- add pip caching to speed up doc previews, correct permissions and concurrent build guards
- add path filters to avoid deploying docs on every PR
- fix the "_you're currently looking at the dev docs_" banner; should now only show on `latest` (`main`) and link to a `stable` release
- Add automated PR comment to link to the doc artifact/provide quick preview instructions for reviewers (only on PRs that touch doc related files)
- Update the repo's README and doc site landing page to include updated links, resources, etc., similar to [sendnn-inference](https://github.com/torch-spyre/sendnn-inference/blob/main/README.md)
- Misc mkdocs improvements

## Test Plan

- Preview docs
- Automated PR comment with doc review instructions won't trigger until merged

## Checklist

- [x] I have read the [contributing guidelines](https://torch-spyre.github.io/spyre-inference/contributing/)
- [x] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [x] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
