### PR TITLE
:wrench: use no_grad instead of inference_mode

### DIFF
--- a/spyre_inference/platform.py
+++ b/spyre_inference/platform.py
@@ -70,6 +70,14 @@ class TorchSpyrePlatform(CpuPlatform):
         return "torch-spyre"
 
     @classmethod
+    def inference_mode(cls):
+        """A device-specific wrapper of `torch.inference_mode`.
+
+        See https://github.com/torch-spyre/torch-spyre/issues/2029
+        """
+        return torch.no_grad()
+
+    @classmethod
     def log_server_boot(cls, vllm_config: VllmConfig) -> None:
         # Only log in main process (not in TP workers)
         if multiprocessing.current_process().name != "MainProcess":


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

What it says on the tin!

I noticed that we get some really odd results when using inference_mode, documented here: https://github.com/torch-spyre/torch-spyre/issues/2029

`no_grad` should be sufficient for us, so until (or if) inference_mode works properly, we should probably prefer the correctness of using no_grad instead.

## Related Issues

## Test Plan

- [ ] unit tests

## Checklist

- [ ] I have read the [contributing guidelines](https://torch-spyre.github.io/spyre-inference/contributing/)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
