### PR TITLE
docs: reorg installation and add user guide section

### DIFF
--- a/.github/workflows/doc_comment.yml
+++ b/.github/workflows/doc_comment.yml
@@ -44,13 +44,19 @@ jobs:
             const prNumber = parseInt(fs.readFileSync('pr-number.txt', 'utf8').trim());
             const sha = '${{ github.event.workflow_run.head_sha }}'.slice(0, 7);
             const artifactUrl = '${{ steps.artifact-url.outputs.result }}';
-            const body = `## Docs preview\n\nBuilt from ${sha}. [Download artifact](${artifactUrl}), or build the docs locally:\n\`\`\`bash\nuv pip install -r docs/requirements-docs.txt\nmkdocs serve\n\`\`\``;
+            const body = [
+              `📖 This PR includes doc changes. [Download the preview](${artifactUrl}) (built from \`${sha}\`), or build locally:`,
+              `\`\`\`bash`,
+              `uv pip install -r docs/requirements-docs.txt`,
+              `mkdocs serve`,
+              `\`\`\``,
+            ].join('\n');
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber,
             });
-            const existing = comments.find(c => c.body.startsWith('## Docs preview'));
+            const existing = comments.find(c => c.body.startsWith('📖'));
             if (existing) {
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,

--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -5,6 +5,8 @@ nav:
       - Installation: getting_started/installation.md
     - Examples:
       - Offline Inference: examples/offline_inference
+    - User Guide:
+      - Configuration: user_guide/configuration.md
     - Developer Guide:
       - Contributing: contributing/README.md
 
@@ -12,5 +14,7 @@ nav:
     - Installation: getting_started/installation.md
   - Examples:
     - Offline Inference: examples/offline_inference
+  - User Guide:
+    - Configuration: user_guide/configuration.md
   - Developer Guide:
     - Contributing: contributing/README.md

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -14,7 +14,7 @@ Follow the [Installation Guide](../getting_started/installation.md) to get the b
 uv sync --group dev
 ```
 
-This includes additional tools like pytest, pytest-asyncio, and other testing utilities.
+This includes `pytest`, `pyyaml`, and the `spyre-testing-plugin` for running the test suite.
 
 ### Linting
 

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -6,65 +6,37 @@ Thank you for your interest in contributing to the Spyre plugin for vLLM! There 
 - Suggest or implement new features.
 - Improve documentation or contribute a how-to guide.
 
-## Issues
+## Developing
 
-If you encounter a bug or have a feature request, please search [existing issues](https://github.com/torch-spyre/spyre-inference/issues?q=is%3Aissue) first to see if it has already been reported. If not, please create a new issue, by using our [issue templates](https://github.com/torch-spyre/spyre-inference/issues/new/choose):
-
-- **🐛 Bug Report**: For reporting bugs and unexpected behavior
-- **🚀 Feature Request**: For suggesting new features or improvements
-
-You can also reach out for support in the `#sig-spyre` channel in the [vLLM Slack](https://inviter.co/vllm-slack) workspace.
-
-## Docs
-
-### Building the docs with MkDocs
-
-#### Install MkDocs and Plugins
-
-Install MkDocs along with the [plugins](https://github.com/torch-spyre/spyre-inference/blob/main/mkdocs.yaml) used in the Spyre Inference documentation.
+Follow the [Installation Guide](../getting_started/installation.md) to get the base package installed, then install the dev dependency group:
 
 ```bash
-uv pip install -r docs/requirements-docs.txt
+uv sync --group dev
 ```
 
-!!! note
-    Ensure that your Python version is compatible with the plugins (e.g., `mkdocs-awesome-nav` requires Python 3.10+)
+This includes additional tools like pytest, pytest-asyncio, and other testing utilities.
 
-#### Start the Development Server
+### Linting
 
-MkDocs comes with a built-in dev-server that lets you preview your documentation as you work on it.
+When submitting a PR, please make sure your code passes all linting checks. We use prek with a .pre-commit-config.yaml file to run checks on every commit.
 
-Make sure you're in the same directory as the `mkdocs.yaml` configuration file in the `spyre-inference` repository, and then start the server by running the `mkdocs serve` command:
+The `format.sh` script will run prek from an isolated virtual environment using [uvx](https://docs.astral.sh/uv/guides/tools/). The only requirement is that you have `uv` installed.
 
-```bash
-mkdocs serve
+```sh
+bash format.sh
 ```
 
-Example output:
+Alternatively, you can [install prek](https://github.com/j178/prek?tab=readme-ov-file#installation) and set up a git hook to run it on every commit with:
 
-```console
-INFO    -  Documentation built in 106.83 seconds
-INFO    -  [22:02:02] Watching paths for changes: 'docs', 'mkdocs.yaml'
-INFO    -  [22:02:02] Serving on http://127.0.0.1:8000/
+```sh
+prek install
 ```
 
-#### View in Your Browser
-
-Open up [http://127.0.0.1:8000/](http://127.0.0.1:8000/) in your browser to see a live preview.
-
-#### Learn More
-
-For additional features and advanced configurations, refer to the official [MkDocs Documentation](https://www.mkdocs.org/).
-
-## Getting Started
-
-Check out the [Installation Guide](../getting_started/installation.md) for instructions on how to set up your development environment.
-
-## Testing
+### Testing
 
 The project includes both local tests (located in `spyre_inference/tests/`) for spyre-inference specific functionality, and upstream vLLM tests automatically cloned from the vLLM repository at the commit specified in `pyproject.toml`, for compatibility verification.
 
-### Test Markers
+#### Test Markers
 
 The test suite uses pytest markers to categorize tests:
 
@@ -85,7 +57,7 @@ pytest -m upstream
 pytest -m "attention"
 ```
 
-### Upstream Test Integration
+#### Upstream Test Integration
 
 Upstream tests are cloned from the vLLM repository at the commit pinned in `pyproject.toml`, fetching only the `tests/` directory. Cloned tests are cached in `~/.cache/vllm-upstream-tests` (or `$XDG_CACHE_HOME/vllm-upstream-tests`) with separate worktrees per commit, allowing multiple vLLM versions to be tested simultaneously. All upstream tests run with `VLLM_PLUGINS=spyre_inference` set automatically. See `tests/conftest.py` for implementation details.
 
@@ -96,7 +68,7 @@ Upstream tests are cloned from the vLLM repository at the commit pinned in `pypr
     rm -rf ~/.cache/vllm-upstream-tests
     ```
 
-### Configuration
+#### Configuration
 
 **SKIP_UPSTREAM_TESTS**: Skip upstream tests entirely. Accepts `1`, `true`, or `yes`.
 
@@ -109,23 +81,35 @@ Upstream tests are cloned from the vLLM repository at the commit pinned in `pypr
 !!! tip
     Environment variables can be passed directly to the `pytest` command, e.g. `VLLM_COMMIT=abc123def456 pytest`.
 
+### Docs
+
+Install MkDocs along with the [plugins](https://github.com/torch-spyre/spyre-inference/blob/main/mkdocs.yaml) used in the Spyre Inference documentation.
+
+```bash
+uv pip install -r docs/requirements-docs.txt
+```
+
+!!! note
+    Ensure that your Python version is compatible with the plugins (e.g., `mkdocs-awesome-nav` requires Python 3.10+)
+
+MkDocs comes with a built-in dev-server that lets you preview your documentation as you work on it. Make sure you're in the same directory as the `mkdocs.yaml` configuration file and run:
+
+```bash
+mkdocs serve
+```
+
+Open up [http://127.0.0.1:8000/](http://127.0.0.1:8000/) in your browser to see a live preview. For additional features and advanced configurations, refer to the official [MkDocs Documentation](https://www.mkdocs.org/).
+
+## Issues
+
+If you encounter a bug or have a feature request, please search [existing issues](https://github.com/torch-spyre/spyre-inference/issues?q=is%3Aissue) first to see if it has already been reported. If not, please create a new issue, by using our [issue templates](https://github.com/torch-spyre/spyre-inference/issues/new/choose):
+
+- **🐛 Bug Report**: For reporting bugs and unexpected behavior
+- **🚀 Feature Request**: For suggesting new features or improvements
+
+You can also reach out for support in the `#sig-spyre` channel in the [vLLM Slack](https://inviter.co/vllm-slack) workspace.
+
 ## Pull Requests
-
-### Linting
-
-When submitting a PR, please make sure your code passes all linting checks. We use prek with a .pre-commit-config.yaml file to run checks on every commit.
-
-The `format.sh` script will run prek from an isolated virtual environment using [uvx](https://docs.astral.sh/uv/guides/tools/). The only requirement is that you have `uv` installed.
-
-```sh
-bash format.sh
-```
-
-Alternatively, you can [install prek](https://github.com/j178/prek?tab=readme-ov-file#installation) and set up a git hook to run it on every commit with:
-
-```sh
-prek install
-```
 
 ### DCO and Signed-off-by
 

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -5,16 +5,12 @@ This guide covers the installation of `spyre-inference` using `uv`, a fast Pytho
 ## Prerequisites
 
 - Python >= 3.11
-- `uv` package manager installed ([installation guide](https://github.com/astral-sh/uv))
+- [`uv`](https://docs.astral.sh/uv/) package manager
 - Access to IBM Spyre hardware with the Spyre Runtime Stack (required for torch-spyre compilation)
 
-## Installation with uv sync
+## Install
 
-The `spyre-inference` plugin uses `uv` for dependency management and installation. The project configuration in `spyre_inference/pyproject.toml` includes several important settings that ensure proper installation:
-
-### Basic Installation
-
-From the `spyre_inference` directory, run:
+From the repository root, run:
 
 ```bash
 uv sync --frozen
@@ -27,46 +23,6 @@ This command will:
 3. Build torch-spyre from source
 4. Install PyTorch 2.11.0 from the CPU-specific index
 
-### Configuration Highlights
-
-The `pyproject.toml` file includes several key configurations:
-
-#### 1. Build Configuration
-
-```toml
-[tool.uv]
-build-constraint-dependencies = ["torch==2.11.0"]
-extra-build-variables = { vllm = { VLLM_TARGET_DEVICE = "cpu" } }
-```
-
-These settings ensure:
-
-- All packages are built with the same PyTorch version (2.11.0)
-- vLLM is built specifically for the CPU backend
-
-#### 2. Source Repositories
-
-The plugin pulls dependencies from specific Git repositories:
-
-```toml
-[tool.uv.sources]
-vllm = { git = "https://github.com/vllm-project/vllm", rev = "..." }
-torch-spyre = { git = "https://github.com/torch-spyre/torch-spyre", rev = "..." }
-```
-
-This ensures that both torch-spyre and vllm are compiled from source, instead of pulling pre-compiled wheels from pypi.
-
-#### 3. PyTorch CPU Index
-
-```toml
-[[tool.uv.index]]
-name = "pytorch-cpu"
-url = "https://download.pytorch.org/whl/cpu"
-explicit = true
-```
-
-We ensure that the cpu flavor of pytorch is installed, as we're not building cuda support.
-
 ## Verification
 
 After installation, verify the plugin is correctly installed:
@@ -74,16 +30,6 @@ After installation, verify the plugin is correctly installed:
 ```bash
 python -c "import spyre_inference; print(spyre_inference.__version__)"
 ```
-
-## Development Installation
-
-For development work, install with the dev dependency group:
-
-```bash
-uv sync --group dev
-```
-
-This includes additional tools like pytest, pytest-asyncio, and other testing utilities.
 
 ## Troubleshooting
 
@@ -94,25 +40,3 @@ If you encounter build failures:
 1. **torch-spyre compilation**: Ensure the Spyre Runtime Stack is available on your system. See internal development documentation for environment setup.
 2. **vLLM build**: Check that you have sufficient memory and CPU resources for compilation
 3. **Dependency conflicts**: Review the `override-dependencies` section in `pyproject.toml`
-
-## Next Steps
-
-To load the plugin, set the `VLLM_PLUGINS` environment variable before running vLLM:
-
-```bash
-export VLLM_PLUGINS=spyre_inference
-```
-
-You can then use vLLM as usual:
-
-```python
-from vllm import LLM
-
-llm = LLM(
-    model="ibm-ai-platform/micro-g3.3-8b-instruct-1b",
-    max_model_len=128,
-    max_num_seqs=2,
-)
-```
-
-See the [Examples](../examples/offline_inference/torch_spyre_inference.md) page for more usage patterns.

--- a/docs/user_guide/configuration.md
+++ b/docs/user_guide/configuration.md
@@ -1,0 +1,65 @@
+# Configuration
+
+## Plugin Setup
+
+To load the plugin, set the `VLLM_PLUGINS` environment variable before running vLLM:
+
+```bash
+export VLLM_PLUGINS=spyre_inference
+```
+
+## Usage
+
+You can then use vLLM as usual:
+
+```python
+from vllm import LLM
+
+llm = LLM(
+    model="ibm-ai-platform/micro-g3.3-8b-instruct-1b",
+    max_model_len=128,
+    max_num_seqs=2,
+)
+```
+
+See the [Examples](../examples/offline_inference/torch_spyre_inference.md) page for more usage patterns.
+
+## pyproject.toml Reference
+
+The `pyproject.toml` includes several key build configurations:
+
+### Build Configuration
+
+```toml
+[tool.uv]
+build-constraint-dependencies = ["torch==2.10.0"]
+extra-build-variables = { vllm = { VLLM_TARGET_DEVICE = "cpu" } }
+```
+
+These settings ensure:
+
+- All packages are built with the same PyTorch version (2.10.0)
+- vLLM is built specifically for the CPU backend
+
+### Source Repositories
+
+The plugin pulls dependencies from specific Git repositories:
+
+```toml
+[tool.uv.sources]
+vllm = { git = "https://github.com/vllm-project/vllm", rev = "..." }
+torch-spyre = { git = "https://github.com/torch-spyre/torch-spyre", rev = "..." }
+```
+
+This ensures that both torch-spyre and vllm are compiled from source, instead of pulling pre-compiled wheels from PyPI.
+
+### PyTorch CPU Index
+
+```toml
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true
+```
+
+This ensures the CPU flavor of PyTorch is installed, as CUDA support is not required.

--- a/docs/user_guide/configuration.md
+++ b/docs/user_guide/configuration.md
@@ -32,13 +32,13 @@ The `pyproject.toml` includes several key build configurations:
 
 ```toml
 [tool.uv]
-build-constraint-dependencies = ["torch==2.10.0"]
+build-constraint-dependencies = ["torch==2.11.0"]
 extra-build-variables = { vllm = { VLLM_TARGET_DEVICE = "cpu" } }
 ```
 
 These settings ensure:
 
-- All packages are built with the same PyTorch version (2.10.0)
+- All packages are built with the same PyTorch version (2.11.0)
 - vLLM is built specifically for the CPU backend
 
 ### Source Repositories


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

- Consolidate installation doc
- Create `docs/user_guide/configuration.md` which now hosts pyproject and plugin setup info
- Restructure `contributing/README` to make "development" info easier to find with testing, linting, etc. subsections
- Updates the doc bot comment to:
> 📖 This PR includes doc changes. [Download the preview](https://github.com/torch-spyre/spyre-inference/actions/runs/25874130838/artifacts/7000174179) (built from 3a96c77), or build locally:
> 
> ```
> uv pip install -r docs/requirements-docs.txt
> mkdocs serve
> ```


## Test Plan

- Doc bot comment will update when merged, but this PR shows that it does work
- Preview docs for changes

## Checklist

- [x] I have read the [contributing guidelines](https://torch-spyre.github.io/spyre-inference/contributing/)
- [x] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [x] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
