### PR TITLE
Add Spyre Operation Support Test for Online Softmax

### DIFF
--- a/examples/experimental/spyre_online_softmax_check.py
+++ b/examples/experimental/spyre_online_softmax_check.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The Torch-Spyre Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 Experimental example for Spyre Inference project.
 This code is for demonstration and testing purposes.

--- a/examples/experimental/spyre_online_softmax_check.py
+++ b/examples/experimental/spyre_online_softmax_check.py
@@ -56,8 +56,10 @@ KNOWN SPYRE BUGS THIS SCRIPT WORKS AROUND
        data when consumed by bmm. .clone() and .contiguous() on the device
        do NOT repair it — they faithfully copy the corrupted source. The
        only known fix is to slice on host, then transfer (see _seq_slice).
-       Symmetric to the destination-side bug already worked around in
-       torch_spyre/ops/eager.py:_is_narrowed_view (spyre__copy_from).
+    3. Seq-dim narrowed-view writes — writing to a sliced Spyre tensor along
+       the seq dimension (e.g. output[:, 32:64, :] = data) corrupts the data.
+       Workaround: transfer output to CPU, perform the write, transfer back.
+       This is the destination-side counterpart to bug #2.
 """
 
 import os
@@ -297,7 +299,16 @@ def fused_tiled_attention(
                 tile_output = tile_output + torch.bmm(tile_probs, v_tile)
                 tile_sum = tile_sum + tile_probs.sum(dim=-1, keepdim=True)
 
-        output[:, q_start:q_end, :] = tile_output / tile_sum
+        final_tile = tile_output / tile_sum
+        
+        # Workaround for destination-side narrowed-view write bug on Spyre
+        if query.device.type == "spyre":
+            # Write via CPU to avoid corrupted narrowed-view writes
+            output_cpu = output.cpu()
+            output_cpu[:, q_start:q_end, :] = final_tile.cpu()
+            output = output_cpu.to(query.device)
+        else:
+            output[:, q_start:q_end, :] = final_tile
 
     return output
 
@@ -474,3 +485,5 @@ else:
 print("\n  Known bugs requiring workarounds:")
 print("    - seq-dim narrowed-view reads on Spyre (bmm yields garbage)")
 print("      workaround: slice on host then transfer (_seq_slice)")
+print("    - seq-dim narrowed-view writes on Spyre (data corruption)")
+print("      workaround: write via CPU round-trip (fused_tiled_attention line 340-344)")

--- a/examples/experimental/spyre_online_softmax_check.py
+++ b/examples/experimental/spyre_online_softmax_check.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 """
 Experimental example for Spyre Inference project.
 This code is for demonstration and testing purposes.

--- a/examples/experimental/spyre_online_softmax_check.py
+++ b/examples/experimental/spyre_online_softmax_check.py
@@ -1,10 +1,10 @@
-# Copyright 2026 The Torch-Spyre Authors.
+# Copyright 2026 The Spyre-Inference Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/examples/experimental/spyre_online_softmax_check.py
+++ b/examples/experimental/spyre_online_softmax_check.py
@@ -89,11 +89,11 @@ print("\nDetecting Spyre operation support...")
 
 def _probe_operation(op_name: str, test_fn) -> bool:
     """Probe if an operation works on Spyre.
-    
+
     Args:
         op_name: Human-readable operation name for display
         test_fn: Callable that performs the operation test
-        
+
     Returns:
         True if operation is supported, False otherwise
     """
@@ -300,7 +300,7 @@ def fused_tiled_attention(
                 tile_sum = tile_sum + tile_probs.sum(dim=-1, keepdim=True)
 
         final_tile = tile_output / tile_sum
-        
+
         # Workaround for destination-side narrowed-view write bug on Spyre
         if query.device.type == "spyre":
             # Write via CPU to avoid corrupted narrowed-view writes

--- a/examples/experimental/spyre_online_softmax_check.py
+++ b/examples/experimental/spyre_online_softmax_check.py
@@ -132,7 +132,7 @@ SEQ_LEN_KV = 256
 Q_TILE_SIZE = 32
 KV_TILE_SIZE = 64
 
-SCALE = 1.0 / (HEAD_SIZE ** 0.5)
+SCALE = 1.0 / (HEAD_SIZE**0.5)
 
 # fp16 tolerance for end-to-end attention vs fp32 reference
 FP16_TOL = 1e-2
@@ -140,6 +140,7 @@ FP16_TOL = 1e-2
 # ---------------------------------------------------------------------------
 # Spyre workarounds
 # ---------------------------------------------------------------------------
+
 
 def _seq_slice(t: torch.Tensor, lo: int, hi: int) -> torch.Tensor:
     """Slice a tensor along dim 1 (sequence dim).
@@ -166,6 +167,7 @@ def _elemwise_max(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
 # ---------------------------------------------------------------------------
 # Fused Tiled Attention
 # ---------------------------------------------------------------------------
+
 
 def fused_tiled_attention(
     query: torch.Tensor,
@@ -210,7 +212,9 @@ def fused_tiled_attention(
 
         tile_max = None  # initialized on the first KV iteration
         tile_sum = torch.zeros(
-            (num_heads, q_tile_len, 1), dtype=query.dtype, device=query.device,
+            (num_heads, q_tile_len, 1),
+            dtype=query.dtype,
+            device=query.device,
         )
         tile_output = torch.zeros(
             (num_heads, q_tile_len, head_size),
@@ -275,7 +279,12 @@ reference_output = standard_attention(query_cpu, key_cpu, value_cpu, SCALE)
 
 print(f"Computing fused tiled attention (Q_tile={Q_TILE_SIZE}, KV_tile={KV_TILE_SIZE}, CPU)...")
 fused_output_cpu = fused_tiled_attention(
-    query_cpu, key_cpu, value_cpu, SCALE, Q_TILE_SIZE, KV_TILE_SIZE,
+    query_cpu,
+    key_cpu,
+    value_cpu,
+    SCALE,
+    Q_TILE_SIZE,
+    KV_TILE_SIZE,
 )
 
 max_diff_cpu = torch.max(torch.abs(reference_output - fused_output_cpu)).item()
@@ -283,8 +292,11 @@ mean_diff_cpu = torch.mean(torch.abs(reference_output - fused_output_cpu)).item(
 print("\nCPU Validation:")
 print(f"  Max difference:  {max_diff_cpu:.2e}")
 print(f"  Mean difference: {mean_diff_cpu:.2e}")
-print("  Matches reference!" if max_diff_cpu < 1e-5
-      else f"  Differs from reference (max_diff={max_diff_cpu:.2e})")
+print(
+    "  Matches reference!"
+    if max_diff_cpu < 1e-5
+    else f"  Differs from reference (max_diff={max_diff_cpu:.2e})"
+)
 
 # ---------------------------------------------------------------------------
 # Spyre run
@@ -337,7 +349,12 @@ print(
 )
 try:
     fused_output_spyre = fused_tiled_attention(
-        query_spyre, key_spyre, value_spyre, SCALE, Q_TILE_SIZE, KV_TILE_SIZE,
+        query_spyre,
+        key_spyre,
+        value_spyre,
+        SCALE,
+        Q_TILE_SIZE,
+        KV_TILE_SIZE,
     )
     fused_output_spyre_cpu = fused_output_spyre.cpu().to(dtype=torch.float32)
 

--- a/examples/experimental/spyre_online_softmax_check.py
+++ b/examples/experimental/spyre_online_softmax_check.py
@@ -1,0 +1,352 @@
+"""
+Experimental example for Spyre Inference project.
+This code is for demonstration and testing purposes.
+
+Fused Tiled Attention with Online Softmax — Spyre Operation Support Test
+
+This test verifies which operations required by the online softmax algorithm
+are supported on Spyre device. The implementation uses FlashAttention-style
+fused tiled attention that combines:
+    1. QK^T (query-key multiplication)
+    2. Online softmax (numerically stable, tiled)
+    3. PV (probability-value multiplication)
+
+Online Softmax Algorithm (per query tile):
+    Initialize: output = 0, max = -inf, sum = 0
+    For each KV tile:
+        1. scores = Q_tile @ K_tile^T
+        2. tile_max = max(scores)
+        3. new_max = max(max, tile_max)        ← needs element-wise maximum
+        4. Rescale: output *= exp(max - new_max), sum *= exp(max - new_max)
+        5. Update: max = new_max
+        6. tile_probs = exp(scores - max)
+        7. Accumulate: output += tile_probs @ V_tile, sum += sum(tile_probs)
+    Normalize: output = output / sum
+
+OPERATION DETECTION
+    The detection probe runs torch.maximum() on Spyre once and inspects the
+    error. If the probe surfaces an InductorError ("UnimplementedOp"), the
+    hybrid path runs torch.maximum on CPU via host round-trips.
+
+    Manual override via environment variable (optional):
+        SPYRE_ONLINE_SOFTMAX_ALLOW_CPU_FALLBACK=0/1
+
+KNOWN SPYRE BUGS THIS SCRIPT WORKS AROUND
+    1. torch.maximum() — recognized by the Spyre compiler but fails inductor
+       codegen with 'UnimplementedOp'. Hybrid path performs the op on CPU.
+    2. Seq-dim narrowed-view reads — slicing a Spyre tensor along the seq
+       dimension at a non-zero offset (e.g. q[:, 32:64, :]) produces wrong
+       data when consumed by bmm. .clone() and .contiguous() on the device
+       do NOT repair it — they faithfully copy the corrupted source. The
+       only known fix is to slice on host, then transfer (see _seq_slice).
+       Symmetric to the destination-side bug already worked around in
+       torch_spyre/ops/eager.py:_is_narrowed_view (spyre__copy_from).
+"""
+
+import os
+
+if os.environ.get("SPYRE_DEBUG"):
+    os.environ.setdefault("SPYRE_INDUCTOR_LOG", "1")
+    os.environ.setdefault("SPYRE_INDUCTOR_LOG_LEVEL", "DEBUG")
+    os.environ.setdefault("TORCH_SENDNN_LOG", "DEBUG")
+
+import traceback
+
+import torch
+from torch.spyre import SpyreTensorLayout, get_device_dtype  # type: ignore[import-not-found]
+
+
+DEVICE = torch.device("spyre")
+
+# ---------------------------------------------------------------------------
+# Operation detection
+# ---------------------------------------------------------------------------
+
+print("=" * 60)
+print("Online Softmax — Spyre Operation Support Test")
+print("=" * 60)
+print("\nDetecting Spyre operation support...")
+
+
+def _probe_torch_maximum() -> bool:
+    """Return True iff torch.maximum() works on Spyre."""
+    a = torch.tensor([[1.0, 2.0]], dtype=torch.float16, device=DEVICE)
+    b = torch.tensor([[1.5, 1.0]], dtype=torch.float16, device=DEVICE)
+    try:
+        torch.maximum(a, b).cpu()
+        print("  ✅ torch.maximum() — Supported")
+        return True
+    except Exception as e:
+        print(f"  torch.maximum() — Not supported: {type(e).__name__}")
+        return False
+
+
+MAXIMUM_SUPPORTED = _probe_torch_maximum()
+
+ALLOW_CPU_FALLBACK = not MAXIMUM_SUPPORTED
+override = os.environ.get("SPYRE_ONLINE_SOFTMAX_ALLOW_CPU_FALLBACK")
+if override is not None:
+    truthy = {"1", "true", "yes", "on"}
+    falsy = {"0", "false", "no", "off"}
+    val = override.strip().lower()
+    if val in truthy:
+        ALLOW_CPU_FALLBACK = True
+    elif val in falsy:
+        ALLOW_CPU_FALLBACK = False
+    else:
+        raise ValueError(
+            f"SPYRE_ONLINE_SOFTMAX_ALLOW_CPU_FALLBACK={override!r}; "
+            f"expected one of {sorted(truthy | falsy)}"
+        )
+    print(f"   (Overridden by env: ALLOW_CPU_FALLBACK={ALLOW_CPU_FALLBACK})")
+
+print(
+    f"\nMode: "
+    f"{'Hybrid (CPU fallback for torch.maximum)' if ALLOW_CPU_FALLBACK else 'Native Spyre only'}"
+)
+print("=" * 60)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+NUM_HEADS = 8
+HEAD_SIZE = 128
+SEQ_LEN_Q = 64
+SEQ_LEN_KV = 256
+
+Q_TILE_SIZE = 32
+KV_TILE_SIZE = 64
+
+SCALE = 1.0 / (HEAD_SIZE ** 0.5)
+
+# fp16 tolerance for end-to-end attention vs fp32 reference
+FP16_TOL = 1e-2
+
+# ---------------------------------------------------------------------------
+# Spyre workarounds
+# ---------------------------------------------------------------------------
+
+def _seq_slice(t: torch.Tensor, lo: int, hi: int) -> torch.Tensor:
+    """Slice a tensor along dim 1 (sequence dim).
+
+    Workaround for a Spyre seq-dim narrowed-view read bug. See module
+    docstring "Known Spyre bugs". On Spyre we slice on host, then transfer.
+    """
+    if t.device.type == "spyre":
+        return t.cpu()[:, lo:hi, :].contiguous().to(t.device)
+    return t[:, lo:hi, :]
+
+
+def _elemwise_max(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    """torch.maximum with optional CPU fallback.
+
+    The hybrid path round-trips a/b through CPU because the Spyre inductor
+    lowering for torch.maximum fails codegen with 'UnimplementedOp'.
+    """
+    if ALLOW_CPU_FALLBACK and a.device.type != "cpu":
+        return torch.maximum(a.cpu(), b.cpu()).to(a.device)
+    return torch.maximum(a, b)
+
+
+# ---------------------------------------------------------------------------
+# Fused Tiled Attention
+# ---------------------------------------------------------------------------
+
+def fused_tiled_attention(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    scale: float,
+    q_tile_size: int,
+    kv_tile_size: int,
+) -> torch.Tensor:
+    """FlashAttention-style fused tiled attention with online softmax.
+
+    Single implementation; `_elemwise_max` and `_seq_slice` adapt to the
+    target device. KV tiles are sliced once and reused across Q tiles to
+    avoid redundant host round-trips on Spyre.
+    """
+    num_heads, seq_len_q, head_size = query.shape
+    _, seq_len_kv, _ = key.shape
+
+    num_q_tiles = (seq_len_q + q_tile_size - 1) // q_tile_size
+    num_kv_tiles = (seq_len_kv + kv_tile_size - 1) // kv_tile_size
+
+    # Pre-slice KV tiles once: independent of the Q-tile loop, so on Spyre
+    # this saves (num_q_tiles - 1) host round-trips per KV tile per tensor.
+    kv_tiles = []
+    for kv_idx in range(num_kv_tiles):
+        kv_start = kv_idx * kv_tile_size
+        kv_end = min(kv_start + kv_tile_size, seq_len_kv)
+        kv_tiles.append(
+            (
+                _seq_slice(key, kv_start, kv_end),
+                _seq_slice(value, kv_start, kv_end),
+            )
+        )
+
+    output = torch.zeros_like(query)
+
+    for q_idx in range(num_q_tiles):
+        q_start = q_idx * q_tile_size
+        q_end = min(q_start + q_tile_size, seq_len_q)
+        q_tile = _seq_slice(query, q_start, q_end)
+        q_tile_len = q_end - q_start
+
+        tile_max = None  # initialized on the first KV iteration
+        tile_sum = torch.zeros(
+            (num_heads, q_tile_len, 1), dtype=query.dtype, device=query.device,
+        )
+        tile_output = torch.zeros(
+            (num_heads, q_tile_len, head_size),
+            dtype=query.dtype,
+            device=query.device,
+        )
+
+        for kv_idx, (k_tile, v_tile) in enumerate(kv_tiles):
+            scores = torch.bmm(q_tile, k_tile.transpose(-2, -1)) * scale
+            scores_max = scores.max(dim=-1, keepdim=True)[0]
+
+            if kv_idx == 0:
+                # First tile: skip the rescale step. Avoids -inf arithmetic
+                # and one set of multiplies on tile_output / tile_sum.
+                tile_max = scores_max
+                tile_probs = torch.exp(scores - tile_max)
+                tile_output = torch.bmm(tile_probs, v_tile)
+                tile_sum = tile_probs.sum(dim=-1, keepdim=True)
+            else:
+                old_max = tile_max
+                tile_max = _elemwise_max(tile_max, scores_max)
+                rescale = torch.exp(old_max - tile_max)
+                tile_output = tile_output * rescale
+                tile_sum = tile_sum * rescale
+                tile_probs = torch.exp(scores - tile_max)
+                tile_output = tile_output + torch.bmm(tile_probs, v_tile)
+                tile_sum = tile_sum + tile_probs.sum(dim=-1, keepdim=True)
+
+        output[:, q_start:q_end, :] = tile_output / tile_sum
+
+    return output
+
+
+def standard_attention(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    """Reference attention that materializes the full attention matrix."""
+    scores = torch.bmm(query, key.transpose(-2, -1)) * scale
+    probs = torch.nn.functional.softmax(scores, dim=-1)
+    return torch.bmm(probs, value)
+
+
+# ---------------------------------------------------------------------------
+# CPU validation
+# ---------------------------------------------------------------------------
+
+print("\nCreating test inputs:")
+print(f"  Query: [{NUM_HEADS}, {SEQ_LEN_Q}, {HEAD_SIZE}]")
+print(f"  Key:   [{NUM_HEADS}, {SEQ_LEN_KV}, {HEAD_SIZE}]")
+print(f"  Value: [{NUM_HEADS}, {SEQ_LEN_KV}, {HEAD_SIZE}]")
+
+torch.manual_seed(42)
+query_cpu = torch.randn(NUM_HEADS, SEQ_LEN_Q, HEAD_SIZE, dtype=torch.float32)
+key_cpu = torch.randn(NUM_HEADS, SEQ_LEN_KV, HEAD_SIZE, dtype=torch.float32)
+value_cpu = torch.randn(NUM_HEADS, SEQ_LEN_KV, HEAD_SIZE, dtype=torch.float32)
+
+print("\nComputing reference attention (standard unfused, CPU)...")
+reference_output = standard_attention(query_cpu, key_cpu, value_cpu, SCALE)
+
+print(f"Computing fused tiled attention (Q_tile={Q_TILE_SIZE}, KV_tile={KV_TILE_SIZE}, CPU)...")
+fused_output_cpu = fused_tiled_attention(
+    query_cpu, key_cpu, value_cpu, SCALE, Q_TILE_SIZE, KV_TILE_SIZE,
+)
+
+max_diff_cpu = torch.max(torch.abs(reference_output - fused_output_cpu)).item()
+mean_diff_cpu = torch.mean(torch.abs(reference_output - fused_output_cpu)).item()
+print("\nCPU Validation:")
+print(f"  Max difference:  {max_diff_cpu:.2e}")
+print(f"  Mean difference: {mean_diff_cpu:.2e}")
+print("  Matches reference!" if max_diff_cpu < 1e-5
+      else f"  Differs from reference (max_diff={max_diff_cpu:.2e})")
+
+# ---------------------------------------------------------------------------
+# Spyre run
+# ---------------------------------------------------------------------------
+
+print("\n" + "=" * 60)
+print("Testing on Spyre Device")
+print("=" * 60)
+
+query_fp16 = query_cpu.to(dtype=torch.float16)
+key_fp16 = key_cpu.to(dtype=torch.float16)
+value_fp16 = value_cpu.to(dtype=torch.float16)
+
+
+def create_qkv_layout(num_heads: int, seq_len: int, head_size: int):
+    """Stickified layout on the head_size dimension.
+
+    `dim_map` is only passed when the installed SpyreTensorLayout accepts
+    it. SpyreTensorLayout is a pybind11 class so `inspect.signature` can't
+    introspect it; instead we capability-probe by trying with dim_map and
+    falling back on TypeError.
+    """
+    common = dict(
+        device_size=[num_heads, seq_len, head_size // 64, 64],
+        stride_map=[seq_len * head_size, head_size, 64, 1],
+        device_dtype=get_device_dtype(torch.float16),
+    )
+    try:
+        return SpyreTensorLayout(dim_map=[0, 1, 2, 2], **common)
+    except TypeError:
+        return SpyreTensorLayout(**common)
+
+
+print("\nCreating Spyre tensor layouts and transferring inputs...")
+query_layout = create_qkv_layout(NUM_HEADS, SEQ_LEN_Q, HEAD_SIZE)
+key_layout = create_qkv_layout(NUM_HEADS, SEQ_LEN_KV, HEAD_SIZE)
+value_layout = create_qkv_layout(NUM_HEADS, SEQ_LEN_KV, HEAD_SIZE)
+
+query_spyre = query_fp16.to(DEVICE, device_layout=query_layout)
+key_spyre = key_fp16.to(DEVICE, device_layout=key_layout)
+value_spyre = value_fp16.to(DEVICE, device_layout=value_layout)
+
+print(f"  Query: {query_spyre.shape}, device={query_spyre.device}")
+print(f"  Key:   {key_spyre.shape}, device={key_spyre.device}")
+print(f"  Value: {value_spyre.shape}, device={value_spyre.device}")
+
+print(
+    f"\nComputing fused tiled attention on Spyre "
+    f"({'CPU fallback' if ALLOW_CPU_FALLBACK else 'native Spyre'} for torch.maximum)..."
+)
+try:
+    fused_output_spyre = fused_tiled_attention(
+        query_spyre, key_spyre, value_spyre, SCALE, Q_TILE_SIZE, KV_TILE_SIZE,
+    )
+    fused_output_spyre_cpu = fused_output_spyre.cpu().to(dtype=torch.float32)
+
+    max_diff_spyre = torch.max(torch.abs(reference_output - fused_output_spyre_cpu)).item()
+    mean_diff_spyre = torch.mean(torch.abs(reference_output - fused_output_spyre_cpu)).item()
+    print("\nSpyre Validation:")
+    print(f"  Max difference:  {max_diff_spyre:.2e}")
+    print(f"  Mean difference: {mean_diff_spyre:.2e}")
+    if max_diff_spyre < FP16_TOL:
+        print(f"  Matches reference within fp16 tolerance ({FP16_TOL:.0e})")
+    else:
+        print(f"  Differs from reference (max_diff={max_diff_spyre:.2e})")
+        print(f"    Reference sample: {reference_output[0, 0, :5]}")
+        print(f"    Spyre sample:     {fused_output_spyre_cpu[0, 0, :5]}")
+except Exception:
+    print("  Error during Spyre computation:")
+    traceback.print_exc()
+
+print("\n" + "=" * 60)
+print("Test Complete")
+print("=" * 60)
+print("Spyre operation support summary:")
+print("  Supported: bmm, mul, add, sub, div, exp, sum(dim=-1), max(dim=-1)")
+print("  Blocker:   torch.maximum (UnimplementedOp at codegen)")
+print("  Blocker:   seq-dim narrowed-view reads on Spyre (bmm yields garbage)")
+print("                workaround: slice on host then transfer (_seq_slice)")

--- a/examples/experimental/spyre_online_softmax_check.py
+++ b/examples/experimental/spyre_online_softmax_check.py
@@ -39,16 +39,18 @@ Online Softmax Algorithm (per query tile):
     Normalize: output = output / sum
 
 OPERATION DETECTION
-    The detection probe runs torch.maximum() on Spyre once and inspects the
-    error. If the probe surfaces an InductorError ("UnimplementedOp"), the
-    hybrid path runs torch.maximum on CPU via host round-trips.
+    At startup, the script probes multiple operations on Spyre to detect runtime
+    support. For torch.maximum(), if the probe detects it is not supported (e.g.,
+    InductorError with "UnimplementedOp"), the hybrid path automatically routes
+    torch.maximum calls through CPU via host round-trips.
 
     Manual override via environment variable (optional):
         SPYRE_ONLINE_SOFTMAX_ALLOW_CPU_FALLBACK=0/1
 
 KNOWN SPYRE BUGS THIS SCRIPT WORKS AROUND
-    1. torch.maximum() — recognized by the Spyre compiler but fails inductor
-       codegen with 'UnimplementedOp'. Hybrid path performs the op on CPU.
+    1. torch.maximum() — May be recognized by the Spyre compiler but can fail
+       inductor codegen with 'UnimplementedOp'. When detected as unsupported,
+       the hybrid path automatically performs the op on CPU.
     2. Seq-dim narrowed-view reads — slicing a Spyre tensor along the seq
        dimension at a non-zero offset (e.g. q[:, 32:64, :]) produces wrong
        data when consumed by bmm. .clone() and .contiguous() on the device
@@ -83,20 +85,71 @@ print("=" * 60)
 print("\nDetecting Spyre operation support...")
 
 
-def _probe_torch_maximum() -> bool:
-    """Return True iff torch.maximum() works on Spyre."""
-    a = torch.tensor([[1.0, 2.0]], dtype=torch.float16, device=DEVICE)
-    b = torch.tensor([[1.5, 1.0]], dtype=torch.float16, device=DEVICE)
+def _probe_operation(op_name: str, test_fn) -> bool:
+    """Probe if an operation works on Spyre.
+    
+    Args:
+        op_name: Human-readable operation name for display
+        test_fn: Callable that performs the operation test
+        
+    Returns:
+        True if operation is supported, False otherwise
+    """
     try:
-        torch.maximum(a, b).cpu()
-        print("  ✅ torch.maximum() — Supported")
+        test_fn()
+        print(f"  {op_name} — Supported")
         return True
     except Exception as e:
-        print(f"  torch.maximum() — Not supported: {type(e).__name__}")
+        print(f"  {op_name} — Not supported: {type(e).__name__}")
         return False
 
 
-MAXIMUM_SUPPORTED = _probe_torch_maximum()
+def _test_torch_maximum():
+    """Test torch.maximum() on Spyre."""
+    a = torch.tensor([[1.0, 2.0]], dtype=torch.float16, device=DEVICE)
+    b = torch.tensor([[1.5, 1.0]], dtype=torch.float16, device=DEVICE)
+    torch.maximum(a, b).cpu()
+
+
+def _test_bmm():
+    """Test torch.bmm() on Spyre."""
+    a = torch.randn(2, 3, 4, dtype=torch.float16, device=DEVICE)
+    b = torch.randn(2, 4, 5, dtype=torch.float16, device=DEVICE)
+    torch.bmm(a, b).cpu()
+
+
+def _test_exp():
+    """Test torch.exp() on Spyre."""
+    a = torch.randn(2, 3, 4, dtype=torch.float16, device=DEVICE)
+    torch.exp(a).cpu()
+
+
+def _test_max_reduction():
+    """Test torch.max(dim=-1) on Spyre."""
+    a = torch.randn(2, 3, 4, dtype=torch.float16, device=DEVICE)
+    a.max(dim=-1, keepdim=True)[0].cpu()
+
+
+def _test_sum_reduction():
+    """Test torch.sum(dim=-1) on Spyre."""
+    a = torch.randn(2, 3, 4, dtype=torch.float16, device=DEVICE)
+    a.sum(dim=-1, keepdim=True).cpu()
+
+
+def _test_arithmetic():
+    """Test basic arithmetic (mul, add, sub, div) on Spyre."""
+    a = torch.randn(2, 3, 4, dtype=torch.float16, device=DEVICE)
+    b = torch.randn(2, 3, 4, dtype=torch.float16, device=DEVICE)
+    ((a * b + a - b) / (b + 1e-6)).cpu()
+
+
+# Probe all operations
+MAXIMUM_SUPPORTED = _probe_operation("torch.maximum()", _test_torch_maximum)
+BMM_SUPPORTED = _probe_operation("torch.bmm()", _test_bmm)
+EXP_SUPPORTED = _probe_operation("torch.exp()", _test_exp)
+MAX_REDUCTION_SUPPORTED = _probe_operation("torch.max(dim=-1)", _test_max_reduction)
+SUM_REDUCTION_SUPPORTED = _probe_operation("torch.sum(dim=-1)", _test_sum_reduction)
+ARITHMETIC_SUPPORTED = _probe_operation("arithmetic (mul, add, sub, div)", _test_arithmetic)
 
 ALLOW_CPU_FALLBACK = not MAXIMUM_SUPPORTED
 override = os.environ.get("SPYRE_ONLINE_SOFTMAX_ALLOW_CPU_FALLBACK")
@@ -378,7 +431,46 @@ print("\n" + "=" * 60)
 print("Test Complete")
 print("=" * 60)
 print("Spyre operation support summary:")
-print("  Supported: bmm, mul, add, sub, div, exp, sum(dim=-1), max(dim=-1)")
-print("  Blocker:   torch.maximum (UnimplementedOp at codegen)")
-print("  Blocker:   seq-dim narrowed-view reads on Spyre (bmm yields garbage)")
-print("                workaround: slice on host then transfer (_seq_slice)")
+
+# Dynamically report supported operations
+supported_ops = []
+if BMM_SUPPORTED:
+    supported_ops.append("bmm")
+if ARITHMETIC_SUPPORTED:
+    supported_ops.extend(["mul", "add", "sub", "div"])
+if EXP_SUPPORTED:
+    supported_ops.append("exp")
+if SUM_REDUCTION_SUPPORTED:
+    supported_ops.append("sum(dim=-1)")
+if MAX_REDUCTION_SUPPORTED:
+    supported_ops.append("max(dim=-1)")
+
+if supported_ops:
+    print(f"  Supported: {', '.join(supported_ops)}")
+else:
+    print("  Supported: (none detected)")
+
+# Dynamically report unsupported operations
+unsupported_ops = []
+if not MAXIMUM_SUPPORTED:
+    unsupported_ops.append("torch.maximum")
+if not BMM_SUPPORTED:
+    unsupported_ops.append("bmm")
+if not EXP_SUPPORTED:
+    unsupported_ops.append("exp")
+if not MAX_REDUCTION_SUPPORTED:
+    unsupported_ops.append("max(dim=-1)")
+if not SUM_REDUCTION_SUPPORTED:
+    unsupported_ops.append("sum(dim=-1)")
+if not ARITHMETIC_SUPPORTED:
+    unsupported_ops.append("arithmetic")
+
+if unsupported_ops:
+    print(f"  Not supported: {', '.join(unsupported_ops)}")
+else:
+    print("  Not supported: (none detected)")
+
+# Known bugs/workarounds
+print("\n  Known bugs requiring workarounds:")
+print("    - seq-dim narrowed-view reads on Spyre (bmm yields garbage)")
+print("      workaround: slice on host then transfer (_seq_slice)")


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

This PR adds a test script to validate Spyre device support for operations required by the online softmax algorithm used in FlashAttention-style fused tiled attention. The script automatically detects unsupported operations (e.g., `torch.maximum`) and implements CPU fallback, enabling full algorithm validation even when certain operations are not yet available on Spyre hardware.

## Related Issues

#121, #147 

## Test Plan

The test plan is integrated into the standalone script, which automatically executes a validation suite including: (1) operation support detection at startup, (2) CPU validation against reference implementation, (3) Spyre execution with hybrid mode, and (4) numerical accuracy verification. Simply run the script to get a report on Spyre's operation support status and algorithm correctness.

## Checklist

- [X] I have read the [contributing guidelines](https://torch-spyre.github.io/spyre-inference/contributing/)
- [X] My code follows the project's code style (run `bash format.sh`)
- [X] I have added tests for my changes (if applicable)
- [X] I have updated the documentation (if applicable)
- [X] My commits include a `Signed-off-by:` line (DCO compliance)
