### PR TITLE
✨  Add initial distributed device setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ extra-build-variables = { vllm = { VLLM_TARGET_DEVICE = "cpu" } }
 # NB: torch-spyre can only be compiled where `sendnn` is available
 [tool.uv.sources]
 vllm = { git = "https://github.com/vllm-project/vllm", rev = "v0.20.1" }
-torch-spyre = { git = "https://github.com/torch-spyre/torch-spyre", rev = "539a1a0c2d54b228c19c982ee80044e210bcde98" }
+torch-spyre = { git = "https://github.com/torch-spyre/torch-spyre", rev = "c124a56ed06b3d31099f825c5ffaa350007d6809" }
 torch = [
   { index = "pytorch-cpu" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ extra-build-variables = { vllm = { VLLM_TARGET_DEVICE = "cpu" } }
 # NB: torch-spyre can only be compiled where `sendnn` is available
 [tool.uv.sources]
 vllm = { git = "https://github.com/vllm-project/vllm", rev = "v0.20.1" }
-torch-spyre = { git = "https://github.com/torch-spyre/torch-spyre", rev = "c124a56ed06b3d31099f825c5ffaa350007d6809" }
+torch-spyre = { git = "https://github.com/torch-spyre/torch-spyre", rev = "ee37a9de5aaa33995fcbeac36ca1b1131677ce6f" }
 torch = [
   { index = "pytorch-cpu" },
 ]

--- a/spyre_inference/__init__.py
+++ b/spyre_inference/__init__.py
@@ -14,8 +14,16 @@
 
 import importlib.metadata
 import json
+import os
 from logging.config import dictConfig
 from typing import Any
+
+# Defer torch_spyre's autoload until we explicitly trigger it inside
+# `TorchSpyreWorker.init_device`. Autoload loads `libspyre_comms.so`,
+# which captures `RANK`/`WORLD_SIZE`/`LOCAL_RANK`/`LOCAL_WORLD_SIZE`
+# at dlopen time — those env vars are only known per-worker, so the
+# library can't load before init_device runs.
+os.environ.setdefault("TORCH_DEVICE_BACKEND_AUTOLOAD", "0")
 
 from vllm.envs import VLLM_CONFIGURE_LOGGING, VLLM_LOGGING_CONFIG_PATH
 from vllm.logger import DEFAULT_LOGGING_CONFIG

--- a/spyre_inference/distributed/__init__.py
+++ b/spyre_inference/distributed/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/spyre_inference/distributed/spyre_communicator.py
+++ b/spyre_inference/distributed/spyre_communicator.py
@@ -1,0 +1,190 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""DeviceCommunicator override for IBM Spyre devices.
+
+The installed `libspyre_comms.so` (1.0.0-0.main.1+27.5f812da on this pod)
+has only `barrier`, `broadcast`, single-tensor `allgather(Tensor&,Tensor&)`,
+and pairwise `send`/`recv` actually implemented. The list-form `allgather`,
+`allreduce`, `gather`, and `reduce` are throw-stubs in
+`spyre_comms_internal::SpyreCommsContext`. The `_allgather_base` entry point
+on the torch-spyre side is also stubbed regardless of the comms lib.
+
+That means the base `DeviceCommunicatorBase` collectives that route through
+`dist.all_reduce`, `dist.all_gather_into_tensor`, `dist.all_gather` (list),
+and `dist.gather` will all throw at runtime when the device_group's backend
+is `spyreccl`.
+
+This class supplies a hand-rolled fallback for `all_reduce` that works for
+TP=2 by using send/recv + broadcast (all of which ARE implemented), so the
+TP forward path can run end-to-end on two ranks without waiting for the
+upstream comms-side implementations to land. Other collectives raise a
+clear NotImplementedError that names the upstream PR they're blocked on.
+
+REPLACE-WITH-NATIVE markers below identify each fallback that should be
+removed once the corresponding upstream change lands. The intent is that
+when the comms library catches up, this whole file can be deleted (or
+reduced to a couple of overrides for ops we genuinely want to do
+differently for perf), and the platform's
+`get_device_communicator_cls` can revert to the base class.
+
+Upstream tracking:
+  - all_reduce        : github.ibm.com/ai-chip-toolchain/spyre-comms PR #97
+                        (dsolt/allreduce_work). Currently *draft* and
+                        conflicting with main.
+  - gather            : github.ibm.com/ai-chip-toolchain/spyre-comms PR #101
+                        (dsolt/concat_based_gather). Open, non-draft, awaiting
+                        review + Jenkins CI.
+  - all_gather (list) : no PR identified at time of writing. The single-
+                        tensor `allgather(Tensor&,Tensor&)` IS implemented
+                        in libspyre_comms.so but is not exposed via
+                        torch-spyre's spyre_ccl backend.
+  - reduce            : no PR. `src/coll/reduce.cpp` doesn't exist either,
+                        so the underlying algorithm is missing too. Note
+                        that `reduce` is not on the standard TP forward
+                        path; we don't need it for #137.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.distributed as dist
+
+from vllm.distributed.device_communicators.base_device_communicator import (
+    DeviceCommunicatorBase,
+)
+
+
+# Spyre comms enforces a per-message minimum size (matches
+# `InvalidTensorSizeException(message_size_bytes, 128)` in
+# spyre-comms/src/context.cpp). Every TP all_reduce we expect to see in
+# inference is on a hidden-state shard that comfortably exceeds this
+# threshold (hidden_size float16 = 2 KB for hidden_size=1024), so we
+# don't pad here. If something smaller hits this path, the fallback
+# will surface the comms-layer error verbatim and we add padding then.
+
+
+def _spyre_p2p_unsupported_message(op_name: str, world_size: int, pr: str | None) -> str:
+    parts = [
+        f"SpyreCommunicator: {op_name} is not natively available in the "
+        "installed libspyre_comms.so (the corresponding "
+        f"SpyreCommsContext::{op_name} method throws). ",
+    ]
+    if pr is not None:
+        parts.append(f"Upstream tracking: {pr}. ")
+    parts.append(
+        f"No fallback is implemented for world_size={world_size}. Either "
+        "wait for the upstream implementation to land + a comms RPM rebuild, "
+        "or extend SpyreCommunicator with an additional manual fallback."
+    )
+    return "".join(parts)
+
+
+class SpyreCommunicator(DeviceCommunicatorBase):
+    """Spyre-specific DeviceCommunicator with manual fallbacks.
+
+    See the module docstring for the full picture. In short:
+      - `all_reduce` is overridden with a TP=2-only manual reduce-to-root
+        + broadcast that uses send/recv. TP>2 raises.
+      - All other broken collectives raise NotImplementedError with a
+        pointer to the upstream PR that will fix them.
+    """
+
+    def all_reduce(self, input_: torch.Tensor) -> torch.Tensor:
+        # World size 1 is a no-op for all_reduce; the base class doesn't
+        # short-circuit here, so do it ourselves.
+        if self.world_size == 1:
+            return input_
+
+        if self.world_size != 2:
+            # REPLACE-WITH-NATIVE (spyre-comms PR #97): once `dist.all_reduce`
+            # works on the spyreccl-backed device_group, delete this entire
+            # `all_reduce` override and let the base class call
+            # `dist.all_reduce(input_, group=self.device_group)`.
+            raise NotImplementedError(
+                _spyre_p2p_unsupported_message(
+                    "allreduce",
+                    self.world_size,
+                    "github.ibm.com/ai-chip-toolchain/spyre-comms#97",
+                )
+            )
+
+        # TP=2 manual all_reduce.
+        #
+        # We verified on this pod that:
+        #   - dist.send / dist.recv on the spyreccl group work for paired
+        #     ranks at world_size=2.
+        #   - dist.broadcast works on the spyreccl group at any world size.
+        #   - The Spyre comms message matcher requires every p2p message
+        #     to have an immediate matching counterpart across all ranks;
+        #     only world_size=2 trivially satisfies that constraint with a
+        #     single send/recv pair.
+        #
+        # Pattern:
+        #   Rank 1 -> Rank 0 (send/recv).
+        #   Rank 0 sums in place.
+        #   Rank 0 -> all (broadcast).
+        #
+        # REPLACE-WITH-NATIVE: spyre-comms PR #97 makes
+        # SpyreCommsContext::allreduce real; once a comms RPM containing
+        # that change is available, drop this branch.
+        other = 1 - self.rank_in_group
+        if self.rank_in_group == 0:
+            scratch = torch.empty_like(input_)
+            dist.recv(scratch, src=self.ranks[other], group=self.device_group)
+            input_.add_(scratch)
+        else:
+            dist.send(input_, dst=self.ranks[other], group=self.device_group)
+        dist.broadcast(input_, src=self.ranks[0], group=self.device_group)
+        return input_
+
+    def all_gather(self, input_: torch.Tensor, dim: int = -1) -> torch.Tensor:
+        # REPLACE-WITH-NATIVE: when SpyreCommsContext::allgather(vector<>)
+        # is implemented (no PR yet) and a comms RPM exposes it, delete
+        # this override and let the base class use
+        # `dist.all_gather_into_tensor`. Note the base class also relies
+        # on `_allgather_base` being implemented in spyre_ccl.cpp itself,
+        # which is currently a separate stub on the torch-spyre side.
+        if self.world_size == 1:
+            return input_
+        raise NotImplementedError(
+            _spyre_p2p_unsupported_message("allgather", self.world_size, None)
+        )
+
+    def gather(
+        self, input_: torch.Tensor, dst: int = 0, dim: int = -1
+    ) -> torch.Tensor | None:
+        # REPLACE-WITH-NATIVE: spyre-comms PR #101 wires up
+        # SpyreCommsContext::gather. Once landed + RPM rebuilt, delete
+        # this override.
+        if self.world_size == 1:
+            return input_
+        raise NotImplementedError(
+            _spyre_p2p_unsupported_message(
+                "gather",
+                self.world_size,
+                "github.ibm.com/ai-chip-toolchain/spyre-comms#101",
+            )
+        )
+
+    def reduce_scatter(self, input_: torch.Tensor, dim: int = -1) -> torch.Tensor:
+        # Not on the standard TP path; raise loudly if anything tries it.
+        if self.world_size == 1:
+            return input_
+        raise NotImplementedError(
+            _spyre_p2p_unsupported_message("reduce_scatter", self.world_size, None)
+        )
+
+    # `broadcast`, `send`, `recv` from DeviceCommunicatorBase route through
+    # ops that are implemented in libspyre_comms.so, so we leave them alone.

--- a/spyre_inference/distributed/spyre_communicator.py
+++ b/spyre_inference/distributed/spyre_communicator.py
@@ -14,12 +14,12 @@
 
 """DeviceCommunicator override for IBM Spyre devices.
 
-The installed `libspyre_comms.so` (1.0.0-0.main.1+27.5f812da on this pod)
-has only `barrier`, `broadcast`, single-tensor `allgather(Tensor&,Tensor&)`,
-and pairwise `send`/`recv` actually implemented. The list-form `allgather`,
-`allreduce`, `gather`, and `reduce` are throw-stubs in
-`spyre_comms_internal::SpyreCommsContext`. The `_allgather_base` entry point
-on the torch-spyre side is also stubbed regardless of the comms lib.
+The currently-installed `libspyre_comms.so` only has `barrier`, `broadcast`,
+single-tensor `allgather(Tensor&,Tensor&)`, and pairwise `send`/`recv`
+actually implemented. The list-form `allgather`, `allreduce`, `gather`,
+and `reduce` overrides on `SpyreCommsContext` are throw-stubs. The
+`_allgather_base` entry point on the torch-spyre side is also stubbed
+regardless of the comms lib.
 
 That means the base `DeviceCommunicatorBase` collectives that route through
 `dist.all_reduce`, `dist.all_gather_into_tensor`, `dist.all_gather` (list),
@@ -30,30 +30,30 @@ This class supplies a hand-rolled fallback for `all_reduce` that works for
 TP=2 by using send/recv + broadcast (all of which ARE implemented), so the
 TP forward path can run end-to-end on two ranks without waiting for the
 upstream comms-side implementations to land. Other collectives raise a
-clear NotImplementedError that names the upstream PR they're blocked on.
+clear NotImplementedError describing what's needed to unblock them.
 
 REPLACE-WITH-NATIVE markers below identify each fallback that should be
-removed once the corresponding upstream change lands. The intent is that
-when the comms library catches up, this whole file can be deleted (or
-reduced to a couple of overrides for ops we genuinely want to do
-differently for perf), and the platform's
+removed once libspyre_comms gains the corresponding native impl. The
+intent is that when the comms library catches up, this whole file can
+be deleted (or reduced to a couple of overrides for ops we genuinely
+want to do differently for perf), and the platform's
 `get_device_communicator_cls` can revert to the base class.
 
-Upstream tracking:
-  - all_reduce        : github.ibm.com/ai-chip-toolchain/spyre-comms PR #97
-                        (dsolt/allreduce_work). Currently *draft* and
-                        conflicting with main.
-  - gather            : github.ibm.com/ai-chip-toolchain/spyre-comms PR #101
-                        (dsolt/concat_based_gather). Open, non-draft, awaiting
-                        review + Jenkins CI.
-  - all_gather (list) : no PR identified at time of writing. The single-
+Per-op blockers:
+  - all_reduce        : libspyre_comms native allreduce.
+  - gather            : libspyre_comms native gather.
+  - all_gather (list) : libspyre_comms list-form allgather. The single-
                         tensor `allgather(Tensor&,Tensor&)` IS implemented
-                        in libspyre_comms.so but is not exposed via
-                        torch-spyre's spyre_ccl backend.
-  - reduce            : no PR. `src/coll/reduce.cpp` doesn't exist either,
-                        so the underlying algorithm is missing too. Note
-                        that `reduce` is not on the standard TP forward
-                        path; we don't need it for #137.
+                        in libspyre_comms but is not exposed via
+                        torch-spyre's spyreccl backend.
+  - reduce            : libspyre_comms native reduce. Not on the standard
+                        TP forward path; we don't need it for #137.
+
+The companion test file `tests/test_spyre_comms_native_probes.py` runs
+each native collective on a real spyreccl device_group and is xfail-strict.
+When a comms RPM lands an impl, the corresponding probe flips to passing,
+the strict-xfail fails CI, and that's the signal to delete the override
+here.
 """
 
 from __future__ import annotations
@@ -66,23 +66,24 @@ from vllm.distributed.device_communicators.base_device_communicator import (
 )
 
 
-# Spyre comms enforces a per-message minimum size (matches
-# `InvalidTensorSizeException(message_size_bytes, 128)` in
-# spyre-comms/src/context.cpp). Every TP all_reduce we expect to see in
-# inference is on a hidden-state shard that comfortably exceeds this
-# threshold (hidden_size float16 = 2 KB for hidden_size=1024), so we
-# don't pad here. If something smaller hits this path, the fallback
-# will surface the comms-layer error verbatim and we add padding then.
+# libspyre_comms enforces a per-message minimum size (128 bytes). Every
+# TP all_reduce we expect to see in inference is on a hidden-state shard
+# that comfortably exceeds this threshold (hidden_size=1024 float16 =
+# 2048 bytes, well above the 128-byte threshold), so we don't pad here.
+# If something smaller hits this path, the fallback will surface the
+# comms-layer error verbatim and we add padding then.
 
 
-def _spyre_p2p_unsupported_message(op_name: str, world_size: int, pr: str | None) -> str:
+def _spyre_collective_unsupported_message(
+    op_name: str, world_size: int, blocker: str | None = None
+) -> str:
     parts = [
         f"SpyreCommunicator: {op_name} is not natively available in the "
-        "installed libspyre_comms.so (the corresponding "
+        "installed libspyre_comms (the corresponding "
         f"SpyreCommsContext::{op_name} method throws). ",
     ]
-    if pr is not None:
-        parts.append(f"Upstream tracking: {pr}. ")
+    if blocker is not None:
+        parts.append(f"Blocked on: {blocker}. ")
     parts.append(
         f"No fallback is implemented for world_size={world_size}. Either "
         "wait for the upstream implementation to land + a comms RPM rebuild, "
@@ -97,8 +98,8 @@ class SpyreCommunicator(DeviceCommunicatorBase):
     See the module docstring for the full picture. In short:
       - `all_reduce` is overridden with a TP=2-only manual reduce-to-root
         + broadcast that uses send/recv. TP>2 raises.
-      - All other broken collectives raise NotImplementedError with a
-        pointer to the upstream PR that will fix them.
+      - All other broken collectives raise NotImplementedError describing
+        what's needed to unblock them.
     """
 
     def all_reduce(self, input_: torch.Tensor) -> torch.Tensor:
@@ -108,17 +109,24 @@ class SpyreCommunicator(DeviceCommunicatorBase):
             return input_
 
         if self.world_size != 2:
-            # REPLACE-WITH-NATIVE (spyre-comms PR #97): once `dist.all_reduce`
-            # works on the spyreccl-backed device_group, delete this entire
-            # `all_reduce` override and let the base class call
-            # `dist.all_reduce(input_, group=self.device_group)`.
+            # REPLACE-WITH-NATIVE: once libspyre_comms supports allreduce
+            # natively, delete this entire `all_reduce` override and let
+            # the base class call `dist.all_reduce(input_, group=self.device_group)`.
             raise NotImplementedError(
-                _spyre_p2p_unsupported_message(
+                _spyre_collective_unsupported_message(
                     "allreduce",
                     self.world_size,
-                    "github.ibm.com/ai-chip-toolchain/spyre-comms#97",
+                    blocker="libspyre_comms native allreduce impl",
                 )
             )
+
+        # We hand `input_` directly to dist.send/dist.recv, which require
+        # contiguous storage. The base class's dist.all_reduce path has
+        # its own internal handling, but ours doesn't.
+        assert input_.is_contiguous(), (
+            "SpyreCommunicator.all_reduce requires a contiguous input tensor; "
+            f"got tensor with shape={tuple(input_.shape)} stride={input_.stride()}"
+        )
 
         # TP=2 manual all_reduce.
         #
@@ -136,9 +144,8 @@ class SpyreCommunicator(DeviceCommunicatorBase):
         #   Rank 0 sums in place.
         #   Rank 0 -> all (broadcast).
         #
-        # REPLACE-WITH-NATIVE: spyre-comms PR #97 makes
-        # SpyreCommsContext::allreduce real; once a comms RPM containing
-        # that change is available, drop this branch.
+        # REPLACE-WITH-NATIVE: when libspyre_comms gains a native allreduce
+        # and a comms RPM containing it is available, drop this branch.
         other = 1 - self.rank_in_group
         if self.rank_in_group == 0:
             scratch = torch.empty_like(input_)
@@ -150,31 +157,32 @@ class SpyreCommunicator(DeviceCommunicatorBase):
         return input_
 
     def all_gather(self, input_: torch.Tensor, dim: int = -1) -> torch.Tensor:
-        # REPLACE-WITH-NATIVE: when SpyreCommsContext::allgather(vector<>)
-        # is implemented (no PR yet) and a comms RPM exposes it, delete
-        # this override and let the base class use
-        # `dist.all_gather_into_tensor`. Note the base class also relies
-        # on `_allgather_base` being implemented in spyre_ccl.cpp itself,
-        # which is currently a separate stub on the torch-spyre side.
+        # REPLACE-WITH-NATIVE: when libspyre_comms exposes the list-form
+        # SpyreCommsContext::allgather (and torch-spyre's spyreccl backend
+        # wires up `_allgather_base`), delete this override and let the
+        # base class use `dist.all_gather_into_tensor`.
         if self.world_size == 1:
             return input_
         raise NotImplementedError(
-            _spyre_p2p_unsupported_message("allgather", self.world_size, None)
+            _spyre_collective_unsupported_message(
+                "allgather",
+                self.world_size,
+                blocker="libspyre_comms list-form allgather + torch-spyre _allgather_base",
+            )
         )
 
     def gather(
         self, input_: torch.Tensor, dst: int = 0, dim: int = -1
     ) -> torch.Tensor | None:
-        # REPLACE-WITH-NATIVE: spyre-comms PR #101 wires up
-        # SpyreCommsContext::gather. Once landed + RPM rebuilt, delete
-        # this override.
+        # REPLACE-WITH-NATIVE: when libspyre_comms supports gather natively,
+        # delete this override.
         if self.world_size == 1:
             return input_
         raise NotImplementedError(
-            _spyre_p2p_unsupported_message(
+            _spyre_collective_unsupported_message(
                 "gather",
                 self.world_size,
-                "github.ibm.com/ai-chip-toolchain/spyre-comms#101",
+                blocker="libspyre_comms native gather impl",
             )
         )
 
@@ -183,8 +191,8 @@ class SpyreCommunicator(DeviceCommunicatorBase):
         if self.world_size == 1:
             return input_
         raise NotImplementedError(
-            _spyre_p2p_unsupported_message("reduce_scatter", self.world_size, None)
+            _spyre_collective_unsupported_message("reduce_scatter", self.world_size)
         )
 
     # `broadcast`, `send`, `recv` from DeviceCommunicatorBase route through
-    # ops that are implemented in libspyre_comms.so, so we leave them alone.
+    # ops that are implemented in libspyre_comms, so we leave them alone.

--- a/spyre_inference/distributed/spyre_communicator.py
+++ b/spyre_inference/distributed/spyre_communicator.py
@@ -171,9 +171,7 @@ class SpyreCommunicator(DeviceCommunicatorBase):
             )
         )
 
-    def gather(
-        self, input_: torch.Tensor, dst: int = 0, dim: int = -1
-    ) -> torch.Tensor | None:
+    def gather(self, input_: torch.Tensor, dst: int = 0, dim: int = -1) -> torch.Tensor | None:
         # REPLACE-WITH-NATIVE: when libspyre_comms supports gather natively,
         # delete this override.
         if self.world_size == 1:

--- a/spyre_inference/platform.py
+++ b/spyre_inference/platform.py
@@ -59,6 +59,16 @@ class TorchSpyrePlatform(CpuPlatform):
     # so dispatch works regardless of tensor device.
     dispatch_key: str = "CPU"
 
+    # Multi-backend init string consumed by both vllm's
+    # `init_distributed_environment` and `torch.distributed.new_group`.
+    # `gloo` handles CPU tensors (used by vllm's parallel-state cpu_group
+    # and any host-side coordination); `spyreccl` handles Spyre tensors
+    # for the device_group. Registered by `torch_spyre._autoload()` on
+    # `import torch`. See
+    # /home/senuser/spyre-inference/.venv/.../torch_spyre/__init__.py
+    # `dist.Backend.register_backend(DISTRIBUTED_BACKEND_NAME, ...)`.
+    dist_backend: str = "cpu:gloo,spyre:spyreccl"
+
     # Register the PyTorch Native Attention implementation as the CUSTOM backend
     register_backend(
         AttentionBackendEnum.CUSTOM,
@@ -122,6 +132,16 @@ class TorchSpyrePlatform(CpuPlatform):
         # This must be set here as the default, otherwise all usage (including test fixtures) would
         # require setting the dtype.
         vllm_config.model_config.dtype = torch.float16
+
+    @classmethod
+    def get_device_communicator_cls(cls) -> str:
+        # The base `CpuPlatform` returns `CpuCommunicator`, which delegates
+        # to gloo collectives. With `dist_backend = "cpu:gloo,spyre:spyreccl"`
+        # the device_group is bound to spyreccl, so we need a Spyre-aware
+        # communicator that knows which collectives the comms library
+        # actually implements (and falls back manually for the rest).
+        # See `spyre_inference/distributed/spyre_communicator.py`.
+        return "spyre_inference.distributed.spyre_communicator.SpyreCommunicator"
 
     @classmethod
     def get_attn_backend_cls(cls, selected_backend, *args, **kwargs) -> str:

--- a/spyre_inference/platform.py
+++ b/spyre_inference/platform.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import torch
-import sys
-from typing import TYPE_CHECKING
-from string import Template
-import multiprocessing
 import importlib.metadata
+import multiprocessing
+import os
+import sys
+from string import Template
+from typing import TYPE_CHECKING
+
+import torch
 
 from spyre_inference import envs
 
@@ -193,6 +195,18 @@ class TorchSpyrePlatform(CpuPlatform):
         # scheduler_class = "spyre_inference.v1.core.scheduler.TorchSpyreScheduler"
         logger.info("Loading scheduler from: %s", scheduler_class)
         scheduler_config.scheduler_cls = scheduler_class
+
+        # CPUWorker derives its KV-cache budget from host RAM, but on Spyre
+        # the cache lives on-device — the host-RAM math is meaningless and
+        # `gpu_memory_utilization * total_RAM` typically exceeds available
+        # RAM on Spyre boxes, tripping CPUWorker.__init__'s preflight check.
+        # Setting VLLM_CPU_KVCACHE_SPACE makes CpuPlatform.check_and_update_config
+        # populate `cache_config.kv_cache_memory_bytes` below, which both
+        # bypasses the preflight check and short-circuits the host-RSS math
+        # in CPUWorker.determine_available_memory. Skip when the user has
+        # explicitly supplied --kv-cache-memory-bytes so we don't clobber it.
+        if vllm_config.cache_config.kv_cache_memory_bytes is None:
+            os.environ.setdefault("VLLM_CPU_KVCACHE_SPACE", "4")
 
         # call CpuPlatform.check_and_update_config()
         super().check_and_update_config(vllm_config)

--- a/spyre_inference/platform.py
+++ b/spyre_inference/platform.py
@@ -63,10 +63,8 @@ class TorchSpyrePlatform(CpuPlatform):
     # `init_distributed_environment` and `torch.distributed.new_group`.
     # `gloo` handles CPU tensors (used by vllm's parallel-state cpu_group
     # and any host-side coordination); `spyreccl` handles Spyre tensors
-    # for the device_group. Registered by `torch_spyre._autoload()` on
-    # `import torch`. See
-    # /home/senuser/spyre-inference/.venv/.../torch_spyre/__init__.py
-    # `dist.Backend.register_backend(DISTRIBUTED_BACKEND_NAME, ...)`.
+    # for the device_group. See `torch_spyre._autoload` (registers
+    # DISTRIBUTED_BACKEND_NAME via `dist.Backend.register_backend`).
     dist_backend: str = "cpu:gloo,spyre:spyreccl"
 
     # Register the PyTorch Native Attention implementation as the CUSTOM backend
@@ -162,8 +160,19 @@ class TorchSpyrePlatform(CpuPlatform):
                 f"but was specified to be {vllm_config.model_config.dtype}"
             )
 
-        # ---- worker ----
         parallel_config = vllm_config.parallel_config
+
+        # Spyre does not currently support data parallelism. The worker's
+        # WORLD_SIZE / RANK derivation in spyre_worker.init_device assumes a
+        # single DP replica, and the spyre-comms global rank space has not
+        # been validated for DP×TP configurations.
+        if parallel_config.data_parallel_size > 1:
+            raise ValueError(
+                f"Spyre does not support data_parallel_size > 1 "
+                f"(got {parallel_config.data_parallel_size})."
+            )
+
+        # ---- worker ----
         if parallel_config.worker_cls == "auto":
             # "auto" defaults to the CPUWorker as we inherit from the CpuPlatform
             # Override with TorchSpyreWorker for Spyre-specific functionality

--- a/spyre_inference/v1/worker/spyre_worker.py
+++ b/spyre_inference/v1/worker/spyre_worker.py
@@ -79,8 +79,7 @@ class TorchSpyreWorker(CPUWorker):
 
         # `libspyre_comms.so::SpyreDeviceInfo` reads RANK / WORLD_SIZE /
         # LOCAL_RANK / LOCAL_WORLD_SIZE from the environment when the
-        # spyreccl backend is constructed (see
-        # spyre-comms/src/device.cpp `get_env_var(...)`) and throws
+        # spyreccl backend is constructed and throws
         # `EnvironmentVariableException` if any are unset. vllm's
         # MultiprocExecutor uses TCP-based init (`tcp://...`) and does
         # NOT set those env vars, so we populate them here before
@@ -88,9 +87,11 @@ class TorchSpyreWorker(CPUWorker):
         # worker is launched via torchrun the env vars are already set
         # and `setdefault` leaves them alone.
         #
-        # Single-node TP only: LOCAL_WORLD_SIZE == WORLD_SIZE. Once
-        # multi-node TP is supported, derive LOCAL_WORLD_SIZE from the
-        # node-local rank count.
+        # DP>1 is rejected in TorchSpyrePlatform.check_and_update_config,
+        # so parallel_config.world_size (TP*PP*PCP) is the global rank
+        # count here, and on a single node LOCAL_WORLD_SIZE == WORLD_SIZE.
+        # Once multi-node TP is supported, derive LOCAL_WORLD_SIZE from
+        # the node-local rank count.
         world_size = self.vllm_config.parallel_config.world_size
         os.environ.setdefault("RANK", str(self.rank))
         os.environ.setdefault("WORLD_SIZE", str(world_size))

--- a/spyre_inference/v1/worker/spyre_worker.py
+++ b/spyre_inference/v1/worker/spyre_worker.py
@@ -14,7 +14,19 @@
 
 """A Torch Spyre worker class."""
 
+import os
+
 import torch
+
+# `import torch_spyre` triggers the autoload that calls
+# `torch.utils.rename_privateuse1_backend("spyre")`, registers the
+# `spyre` device module, and registers the `spyreccl` distributed
+# backend with torch.distributed. This must run before vllm's
+# `init_distributed_environment` calls `dist.is_backend_available` /
+# `dist.init_process_group` with the platform's
+# `dist_backend = "cpu:gloo,spyre:spyreccl"` string. The
+# `# noqa: F401` is intentional — we only import for the side effect.
+import torch_spyre  # noqa: F401
 
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
@@ -57,16 +69,50 @@ class TorchSpyreWorker(CPUWorker):
         register_all()
 
     def init_device(self) -> None:
-        # Patch the CPUModelRunner with the TorchSpyreModelRunner
+        # Pin this worker process to its assigned Spyre card before any
+        # Spyre runtime / spyreccl backend construction occurs. The
+        # spyreccl backend creator (in torch_spyre/__init__.py) calls
+        # `torch.spyre._impl._lazy_init()` against `current_device()`,
+        # so this must happen before `super().init_device()` runs the
+        # `dist.init_process_group(...)` that materializes spyreccl.
+        torch.spyre.set_device(self.local_rank)
+
+        # `libspyre_comms.so::SpyreDeviceInfo` reads RANK / WORLD_SIZE /
+        # LOCAL_RANK / LOCAL_WORLD_SIZE from the environment when the
+        # spyreccl backend is constructed (see
+        # spyre-comms/src/device.cpp `get_env_var(...)`) and throws
+        # `EnvironmentVariableException` if any are unset. vllm's
+        # MultiprocExecutor uses TCP-based init (`tcp://...`) and does
+        # NOT set those env vars, so we populate them here before
+        # `super().init_device()` runs init_process_group. When the
+        # worker is launched via torchrun the env vars are already set
+        # and `setdefault` leaves them alone.
+        #
+        # Single-node TP only: LOCAL_WORLD_SIZE == WORLD_SIZE. Once
+        # multi-node TP is supported, derive LOCAL_WORLD_SIZE from the
+        # node-local rank count.
+        world_size = self.vllm_config.parallel_config.world_size
+        os.environ.setdefault("RANK", str(self.rank))
+        os.environ.setdefault("WORLD_SIZE", str(world_size))
+        os.environ.setdefault("LOCAL_RANK", str(self.local_rank))
+        os.environ.setdefault("LOCAL_WORLD_SIZE", str(world_size))
+
+        # Patch the CPUModelRunner with the TorchSpyreModelRunner.
+        # We pass the unindexed `torch.device("spyre")` because the
+        # current device for this process is already pinned via
+        # `set_device(local_rank)` above; tensors created on
+        # `torch.device("spyre")` will land on that card.
         original = cpu_worker_module.CPUModelRunner
         cpu_worker_module.CPUModelRunner = lambda *a, **kw: TorchSpyreModelRunner(
             self.vllm_config,
             torch.device("spyre"),
         )
         try:
-            # We will invoke the upstream init_device method with the
-            # CPUModelRunner patched. This will ensure that everything for the CPUWorker is setup,
-            # but the spyre-specific model runner is instantiated instead.
+            # Invoke the upstream init_device method with the
+            # CPUModelRunner patched. This wires up the distributed
+            # environment via vllm's init_worker_distributed_environment,
+            # which uses TorchSpyrePlatform.dist_backend
+            # ("cpu:gloo,spyre:spyreccl") to build the world / TP groups.
             super().init_device()
         finally:
             cpu_worker_module.CPUModelRunner = original

--- a/spyre_inference/v1/worker/spyre_worker.py
+++ b/spyre_inference/v1/worker/spyre_worker.py
@@ -18,21 +18,19 @@ import os
 
 import torch
 
-# `import torch_spyre` triggers the autoload that calls
-# `torch.utils.rename_privateuse1_backend("spyre")`, registers the
-# `spyre` device module, and registers the `spyreccl` distributed
-# backend with torch.distributed. This must run before vllm's
-# `init_distributed_environment` calls `dist.is_backend_available` /
-# `dist.init_process_group` with the platform's
-# `dist_backend = "cpu:gloo,spyre:spyreccl"` string. The
-# `# noqa: F401` is intentional — we only import for the side effect.
-import torch_spyre  # noqa: F401
+# `import torch_spyre` is intentionally deferred to inside `init_device`.
+# Importing it loads `libspyre_comms.so`, which captures
+# `RANK` / `WORLD_SIZE` / `LOCAL_RANK` / `LOCAL_WORLD_SIZE` via
+# `std::getenv` at dlopen time and caches them. Those env vars are only
+# known per-worker, so they must be populated before the C library
+# loads. `spyre_inference/__init__.py` sets
+# `TORCH_DEVICE_BACKEND_AUTOLOAD=0` so torch's `[torch.backends]`
+# autoload doesn't trigger the load at `import torch` time.
 
-from vllm.config import VllmConfig
+import vllm.v1.worker.cpu_worker as cpu_worker_module
 from vllm.logger import init_logger
 from vllm.v1.worker.cpu_worker import CPUWorker
 from vllm.v1.worker.worker_base import CompilationTimes
-import vllm.v1.worker.cpu_worker as cpu_worker_module
 
 from spyre_inference.custom_ops import register_all
 from spyre_inference.v1.worker.spyre_model_runner import TorchSpyreModelRunner
@@ -47,56 +45,35 @@ class TorchSpyreWorker(CPUWorker):
     - Create a TorchSpyreModelRunner with torch.device("spyre")
     """
 
-    def __init__(
-        self,
-        vllm_config: VllmConfig,
-        local_rank: int,
-        rank: int,
-        distributed_init_method: str,
-        is_driver_worker: bool = False,
-    ) -> None:
-        super().__init__(
-            vllm_config,
-            local_rank,
-            rank,
-            distributed_init_method,
-            is_driver_worker,
-        )
-
-        # Register all the custom ops here when a worker is created.
-        # This has to happen before the model is loaded, so that all the
-        # layers will be swapped out with the custom implementations for spyre.
-        register_all()
-
     def init_device(self) -> None:
-        # Pin this worker process to its assigned Spyre card before any
-        # Spyre runtime / spyreccl backend construction occurs. The
-        # spyreccl backend creator (in torch_spyre/__init__.py) calls
-        # `torch.spyre._impl._lazy_init()` against `current_device()`,
-        # so this must happen before `super().init_device()` runs the
-        # `dist.init_process_group(...)` that materializes spyreccl.
-        torch.spyre.set_device(self.local_rank)
-
-        # `libspyre_comms.so::SpyreDeviceInfo` reads RANK / WORLD_SIZE /
-        # LOCAL_RANK / LOCAL_WORLD_SIZE from the environment when the
-        # spyreccl backend is constructed and throws
-        # `EnvironmentVariableException` if any are unset. vllm's
-        # MultiprocExecutor uses TCP-based init (`tcp://...`) and does
-        # NOT set those env vars, so we populate them here before
-        # `super().init_device()` runs init_process_group. When the
-        # worker is launched via torchrun the env vars are already set
-        # and `setdefault` leaves them alone.
-        #
+        # Populate the env vars that `libspyre_comms.so` reads at dlopen
+        # time. `setdefault` leaves torchrun-supplied values intact.
         # DP>1 is rejected in TorchSpyrePlatform.check_and_update_config,
-        # so parallel_config.world_size (TP*PP*PCP) is the global rank
-        # count here, and on a single node LOCAL_WORLD_SIZE == WORLD_SIZE.
-        # Once multi-node TP is supported, derive LOCAL_WORLD_SIZE from
-        # the node-local rank count.
+        # so parallel_config.world_size is the global rank count and
+        # LOCAL_WORLD_SIZE == WORLD_SIZE on a single node. Revisit once
+        # multi-node TP is supported.
         world_size = self.vllm_config.parallel_config.world_size
         os.environ.setdefault("RANK", str(self.rank))
         os.environ.setdefault("WORLD_SIZE", str(world_size))
         os.environ.setdefault("LOCAL_RANK", str(self.local_rank))
         os.environ.setdefault("LOCAL_WORLD_SIZE", str(world_size))
+
+        # Trigger torch_spyre's autoload manually now that the env vars
+        # are set. Autoload registers the `spyre` device and the
+        # `spyreccl` distributed backend, and imports
+        # `torch_spyre._C` (which loads `libspyre_comms.so`).
+        import torch_spyre
+
+        torch_spyre._autoload()
+
+        # Pin this worker to its assigned card before the spyreccl
+        # backend is constructed in `init_process_group`.
+        torch.spyre.set_device(self.local_rank)
+
+        # Register all the custom ops here when a worker is created.
+        # This has to happen before the model is loaded, so that all the
+        # layers will be swapped out with the custom implementations for spyre.
+        register_all()
 
         # Patch the CPUModelRunner with the TorchSpyreModelRunner.
         # We pass the unindexed `torch.device("spyre")` because the
@@ -109,11 +86,6 @@ class TorchSpyreWorker(CPUWorker):
             torch.device("spyre"),
         )
         try:
-            # Invoke the upstream init_device method with the
-            # CPUModelRunner patched. This wires up the distributed
-            # environment via vllm's init_worker_distributed_environment,
-            # which uses TorchSpyrePlatform.dist_backend
-            # ("cpu:gloo,spyre:spyreccl") to build the world / TP groups.
             super().init_device()
         finally:
             cpu_worker_module.CPUModelRunner = original
@@ -121,6 +93,8 @@ class TorchSpyreWorker(CPUWorker):
     def compile_or_warm_up_model(self) -> CompilationTimes:
         # FIXME: Work around for https://github.com/torch-spyre/torch-spyre/issues/1420
         # Ensure registration of Spyre decompositions before FX Graph tracing
+        import time
+
         import torch._inductor.decomposition
         from torch_spyre._inductor.decompositions import spyre_decompositions  # ty: ignore[unresolved-import]
 
@@ -130,7 +104,6 @@ class TorchSpyreWorker(CPUWorker):
                     "FIXME: Adding %s decomposition to work-around torch-spyre crash", op.name()
                 )
                 torch._inductor.decomposition.decompositions[op] = impl
-        import time
 
         warmup_start_time = time.perf_counter()
         self.model_runner.warming_up_model()

--- a/tests/plugin/spyre_testing_plugin/pytest_plugin.py
+++ b/tests/plugin/spyre_testing_plugin/pytest_plugin.py
@@ -50,6 +50,7 @@ from __future__ import annotations
 import fnmatch
 import os
 import re
+import socket
 import subprocess
 import sys
 import tempfile
@@ -763,6 +764,71 @@ def tp_group(_distributed_init):
     ps._TP = group
     yield group
     ps._TP = original_tp
+
+
+def _free_tcp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture
+def run_tp_probe(pytestconfig):
+    """Spawn one subprocess per rank running `tp_probe.py --probe NAME`.
+
+    The probe body lives in `tests/probes/tp_probe.py`. Tests pass the
+    probe name and world size; this fixture handles port allocation,
+    env-rendezvous setup, and process collection. If any rank exits
+    non-zero (or times out), the test fails with stdout/stderr tails
+    from the failing ranks.
+    """
+    probe_script = pytestconfig.rootpath / "tests" / "probes" / "tp_probe.py"
+
+    def _run(probe_name: str, *, world_size: int, timeout: float = 300.0) -> None:
+        port = _free_tcp_port()
+        procs = []
+        for rank in range(world_size):
+            env = {
+                **os.environ,
+                "RANK": str(rank),
+                "WORLD_SIZE": str(world_size),
+                "LOCAL_RANK": str(rank),
+                "LOCAL_WORLD_SIZE": str(world_size),
+                "MASTER_ADDR": "127.0.0.1",
+                "MASTER_PORT": str(port),
+                "PYTHONUNBUFFERED": "1",
+            }
+            procs.append(
+                subprocess.Popen(  # noqa: S603
+                    [sys.executable, str(probe_script), "--probe", probe_name],
+                    env=env,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                )
+            )
+
+        results: list[tuple[int, str, str]] = []
+        for p in procs:
+            try:
+                out, err = p.communicate(timeout=timeout)
+                results.append((p.returncode, out or "", err or ""))
+            except subprocess.TimeoutExpired:
+                p.kill()
+                out, err = p.communicate()
+                results.append((-1, out or "", err or ""))
+
+        failed = [(i, rc, out, err) for i, (rc, out, err) in enumerate(results) if rc != 0]
+        if failed:
+            msg = "\n".join(
+                f"--- rank {i} (rc={rc}) ---\n"
+                f"stdout (tail):\n{out[-2000:]}\n"
+                f"stderr (tail):\n{err[-2000:]}"
+                for i, rc, out, err in failed
+            )
+            pytest.fail(f"probe {probe_name!r} ranks failed:\n{msg}")
+
+    return _run
 
 
 @pytest.fixture()

--- a/tests/plugin/spyre_testing_plugin/upstream_tests.yaml
+++ b/tests/plugin/spyre_testing_plugin/upstream_tests.yaml
@@ -83,19 +83,3 @@ tests:
           fixture_names:
           - "patch_backend_list"
 
-    # Pipeline-parallel partition logic (`get_pp_indices`). Pure unit
-    # tests, no distributed setup, no GPU. We don't run pipeline
-    # parallelism on Spyre yet, but exercising the partition utility
-    # gives us a cheap upstream smoke test we can land before #137's
-    # follow-ups, and catches regressions in
-    # `vllm.distributed.utils.get_pp_indices` that would otherwise only
-    # surface when PP support is implemented.
-    - rel_path: tests/distributed/test_pipeline_partition.py
-      allow_list:
-        - test: "test_custom_layer_partition"
-          mode: mandatory_pass
-          tags: [pp_partition, upstream]
-        - test: "test_uneven_auto_partition"
-          mode: mandatory_pass
-          tags: [pp_partition, upstream]
-

--- a/tests/plugin/spyre_testing_plugin/upstream_tests.yaml
+++ b/tests/plugin/spyre_testing_plugin/upstream_tests.yaml
@@ -83,3 +83,19 @@ tests:
           fixture_names:
           - "patch_backend_list"
 
+    # Pipeline-parallel partition logic (`get_pp_indices`). Pure unit
+    # tests, no distributed setup, no GPU. We don't run pipeline
+    # parallelism on Spyre yet, but exercising the partition utility
+    # gives us a cheap upstream smoke test we can land before #137's
+    # follow-ups, and catches regressions in
+    # `vllm.distributed.utils.get_pp_indices` that would otherwise only
+    # surface when PP support is implemented.
+    - rel_path: tests/distributed/test_pipeline_partition.py
+      allow_list:
+        - test: "test_custom_layer_partition"
+          mode: mandatory_pass
+          tags: [pp_partition, upstream]
+        - test: "test_uneven_auto_partition"
+          mode: mandatory_pass
+          tags: [pp_partition, upstream]
+

--- a/tests/probes/tp_probe.py
+++ b/tests/probes/tp_probe.py
@@ -1,0 +1,167 @@
+"""TP=N probe dispatcher.
+
+Each probe exercises one collective on a real spyreccl device_group.
+The shared `main()` prologue handles env-rendezvous, vllm config, and
+worker-distributed-env init, then dispatches to the requested probe.
+
+Tests invoke this via the `run_tp_probe` fixture in tests/conftest.py,
+which spawns one subprocess per rank. To run a probe directly for
+debugging:
+
+    RANK=0 WORLD_SIZE=2 LOCAL_RANK=0 LOCAL_WORLD_SIZE=2 \\
+    MASTER_ADDR=127.0.0.1 MASTER_PORT=29500 \\
+    python tests/probes/tp_probe.py --probe native_all_reduce
+
+(Spawn a second shell with RANK=1 to actually complete the collective.)
+
+This file is run as a script in a subprocess; it is never imported by
+the main pytest process. That keeps `torch_spyre` out of the parent
+process — same architectural rule as the rest of the spyre-touching
+tests in this directory.
+"""
+
+import argparse
+import os
+
+import torch
+import torch.distributed as dist
+
+
+def probe_tp_all_reduce(device, device_group, world_size, rank):
+    """High-level vllm `tensor_model_parallel_all_reduce` (via SpyreCommunicator).
+
+    Verifies the manual TP fallback in SpyreCommunicator.all_reduce on
+    a 1-D probe and a (seq, hidden) slab. `device_group` is unused —
+    `tensor_model_parallel_all_reduce` resolves the group from
+    `_TP.device_communicator` itself.
+    """
+    import vllm.distributed.parallel_state as ps
+    from vllm.distributed.communication_op import tensor_model_parallel_all_reduce
+
+    comm_cls = type(ps._TP.device_communicator).__name__
+    assert comm_cls == "SpyreCommunicator", f"got {comm_cls}"
+
+    expected = float(sum(range(1, world_size + 1)))
+    for shape in [(128,), (16, 1024)]:
+        t = torch.full(shape, float(rank + 1), dtype=torch.float16, device=device)
+        out = tensor_model_parallel_all_reduce(t)
+        cpu = out.cpu()
+        torch.testing.assert_close(cpu, torch.full_like(cpu, expected))
+        dist.barrier(device_ids=[device.index])
+
+
+def probe_native_all_reduce(device, device_group, world_size, rank):
+    """Raw `dist.all_reduce` on the spyreccl device_group."""
+    t = torch.full((1024,), float(rank + 1), dtype=torch.float16, device=device)
+    dist.all_reduce(t, group=device_group)
+    expected = float(sum(range(1, world_size + 1)))
+    torch.testing.assert_close(t.cpu(), torch.full_like(t.cpu(), expected))
+
+
+def probe_native_all_gather_into_tensor(device, device_group, world_size, rank):
+    """Raw `dist.all_gather_into_tensor` on the spyreccl device_group."""
+    t = torch.full((1024,), float(rank + 1), dtype=torch.float16, device=device)
+    out = torch.empty((world_size * 1024,), dtype=torch.float16, device=device)
+    dist.all_gather_into_tensor(out, t, group=device_group)
+    out_cpu = out.cpu()
+    for r in range(world_size):
+        torch.testing.assert_close(
+            out_cpu[r * 1024 : (r + 1) * 1024],
+            torch.full((1024,), float(r + 1), dtype=torch.float16),
+        )
+
+
+def probe_native_all_gather_list(device, device_group, world_size, rank):
+    """Raw `dist.all_gather` (list form) on the spyreccl device_group."""
+    t = torch.full((1024,), float(rank + 1), dtype=torch.float16, device=device)
+    out_list = [
+        torch.empty((1024,), dtype=torch.float16, device=device)
+        for _ in range(world_size)
+    ]
+    dist.all_gather(out_list, t, group=device_group)
+    for r, o in enumerate(out_list):
+        torch.testing.assert_close(
+            o.cpu(), torch.full((1024,), float(r + 1), dtype=torch.float16)
+        )
+
+
+def probe_native_gather(device, device_group, world_size, rank):
+    """Raw `dist.gather` to rank 0 on the spyreccl device_group."""
+    t = torch.full((1024,), float(rank + 1), dtype=torch.float16, device=device)
+    if rank == 0:
+        gather_list = [
+            torch.empty((1024,), dtype=torch.float16, device=device)
+            for _ in range(world_size)
+        ]
+    else:
+        gather_list = None
+    dist.gather(t, gather_list, dst=0, group=device_group)
+    if rank == 0:
+        for r, o in enumerate(gather_list):
+            torch.testing.assert_close(
+                o.cpu(), torch.full((1024,), float(r + 1), dtype=torch.float16)
+            )
+
+
+PROBES = {
+    "tp_all_reduce": probe_tp_all_reduce,
+    "native_all_reduce": probe_native_all_reduce,
+    "native_all_gather_into_tensor": probe_native_all_gather_into_tensor,
+    "native_all_gather_list": probe_native_all_gather_list,
+    "native_gather": probe_native_gather,
+}
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--probe", required=True, choices=sorted(PROBES))
+    args = parser.parse_args()
+
+    os.environ["VLLM_PLUGINS"] = "spyre_inference,spyre_inference_ops"
+    os.environ.setdefault("VLLM_USE_AOT_COMPILE", "0")
+
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    local_rank = int(os.environ["LOCAL_RANK"])
+
+    import torch_spyre  # noqa: F401  (registers spyreccl backend + spyre device)
+
+    torch.spyre.set_device(local_rank)
+
+    from vllm.config import set_current_vllm_config
+    from vllm.engine.arg_utils import EngineArgs
+    from vllm.platforms import current_platform
+    from vllm.plugins import load_general_plugins
+    from vllm.v1.worker.gpu_worker import init_worker_distributed_environment
+
+    load_general_plugins()
+
+    cfg = EngineArgs(
+        model="facebook/opt-125m",
+        tensor_parallel_size=world_size,
+        dtype="float16",
+        enforce_eager=True,
+        distributed_executor_backend="external_launcher",
+    ).create_engine_config()
+
+    with set_current_vllm_config(cfg):
+        init_worker_distributed_environment(
+            cfg,
+            rank,
+            distributed_init_method="env://",
+            local_rank=local_rank,
+            backend=current_platform.dist_backend,
+        )
+
+        import vllm.distributed.parallel_state as ps
+
+        device_group = ps._TP.device_group
+        device = torch.device(f"spyre:{local_rank}")
+
+        PROBES[args.probe](device, device_group, world_size, rank)
+
+    dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/probes/tp_probe.py
+++ b/tests/probes/tp_probe.py
@@ -1,3 +1,16 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """TP=N probe dispatcher.
 
 Each probe exercises one collective on a real spyreccl device_group.
@@ -74,15 +87,10 @@ def probe_native_all_gather_into_tensor(device, device_group, world_size, rank):
 def probe_native_all_gather_list(device, device_group, world_size, rank):
     """Raw `dist.all_gather` (list form) on the spyreccl device_group."""
     t = torch.full((1024,), float(rank + 1), dtype=torch.float16, device=device)
-    out_list = [
-        torch.empty((1024,), dtype=torch.float16, device=device)
-        for _ in range(world_size)
-    ]
+    out_list = [torch.empty((1024,), dtype=torch.float16, device=device) for _ in range(world_size)]
     dist.all_gather(out_list, t, group=device_group)
     for r, o in enumerate(out_list):
-        torch.testing.assert_close(
-            o.cpu(), torch.full((1024,), float(r + 1), dtype=torch.float16)
-        )
+        torch.testing.assert_close(o.cpu(), torch.full((1024,), float(r + 1), dtype=torch.float16))
 
 
 def probe_native_gather(device, device_group, world_size, rank):
@@ -90,8 +98,7 @@ def probe_native_gather(device, device_group, world_size, rank):
     t = torch.full((1024,), float(rank + 1), dtype=torch.float16, device=device)
     if rank == 0:
         gather_list = [
-            torch.empty((1024,), dtype=torch.float16, device=device)
-            for _ in range(world_size)
+            torch.empty((1024,), dtype=torch.float16, device=device) for _ in range(world_size)
         ]
     else:
         gather_list = None

--- a/tests/probes/tp_probe.py
+++ b/tests/probes/tp_probe.py
@@ -131,7 +131,13 @@ def main():
     world_size = int(os.environ["WORLD_SIZE"])
     local_rank = int(os.environ["LOCAL_RANK"])
 
-    import torch_spyre  # noqa: F401  (registers spyreccl backend + spyre device)
+    # spyre_inference/__init__.py sets TORCH_DEVICE_BACKEND_AUTOLOAD=0 to
+    # control when libspyre_comms.so is loaded (it captures RANK/WORLD_SIZE
+    # at dlopen time). Trigger torch_spyre's autoload manually here, after
+    # the env vars set by the parent fixture are in place.
+    import torch_spyre
+
+    torch_spyre._autoload()
 
     torch.spyre.set_device(local_rank)
 

--- a/tests/test_distributed_tp2.py
+++ b/tests/test_distributed_tp2.py
@@ -29,13 +29,14 @@ import pytest
 def _spyre_device_count() -> int:
     """Return the number of visible Spyre cards, or 0 if unavailable.
 
-    Counts numeric entries under /dev/vfio rather than calling
-    `torch.spyre.device_count()`, because `uses_subprocess` tests must
-    not touch the Spyre runtime in the main pytest process.
+    Reads AIU_WORLD_SIZE (set by the Spyre runtime environment when
+    cards are visible) instead of touching the Spyre runtime, so
+    `uses_subprocess` tests don't import torch_spyre in the main
+    pytest process.
     """
     try:
-        return sum(1 for n in os.listdir("/dev/vfio") if n.isdigit())
-    except OSError:
+        return int(os.environ.get("AIU_WORLD_SIZE", "0"))
+    except ValueError:
         return 0
 
 
@@ -45,6 +46,14 @@ def _free_tcp_port() -> int:
         return s.getsockname()[1]
 
 
+# TEMPORARY: this test exercises the low-level distributed init path
+# directly (subprocess + env-rendezvous + init_worker_distributed_environment
+# + manual all_reduce probe) because the higher-level LLM(tp=2) tests
+# below are xfail-strict on #134/#135. Once those land and
+# test_tp2_llm_construction / test_tp2_llm_generate_matches_tp1 pass,
+# this test is redundant — delete it (and _TP_ALLREDUCE_CODE) along
+# with the xfail markers on the LLM tests.
+#
 # Inner-rank script for `test_tp2_tensor_model_parallel_all_reduce`.
 # Launched once per rank as a fresh `python -c` subprocess with
 # RANK / WORLD_SIZE / LOCAL_RANK / LOCAL_WORLD_SIZE / MASTER_{ADDR,PORT}
@@ -68,12 +77,10 @@ _TP_ALLREDUCE_CODE = textwrap.dedent(
     from vllm.plugins import load_general_plugins
     load_general_plugins()
 
-    from vllm.platforms import PlatformEnum, current_platform
-    type(current_platform)._enum = PlatformEnum.OOT
-
     from vllm.engine.arg_utils import EngineArgs
     from vllm.config import set_current_vllm_config
     from vllm.v1.worker.gpu_worker import init_worker_distributed_environment
+    from vllm.platforms import current_platform
 
     cfg = EngineArgs(
         model="facebook/opt-125m",
@@ -217,19 +224,24 @@ def test_tp2_llm_construction() -> None:
     _spyre_device_count() < 2,
     reason="needs >=2 Spyre cards; skipping TP=2 distributed test",
 )
+# xfail-strict here can mask a TP=1 regression in the body of this test;
+# accepted because the marker will be deleted when #134/#135 land.
 @pytest.mark.xfail(
     strict=True,
     reason=(
         "needs #134, #135, and a TP=2 fallback for all_gather "
         "(LM head logits gather hits unimplemented _allgather_base). "
-        "When all three land, TP=1 vs TP=2 token outputs should match."
+        "When all three land, TP=1 vs TP=2 should match on the first "
+        "few decoded tokens."
     ),
 )
 def test_tp2_llm_generate_matches_tp1() -> None:
-    """TP=1 vs TP=2 greedy-decode golden test on opt-125m.
+    """TP=1 vs TP=2 greedy-decode prefix-match test on opt-125m.
 
     Runs identical prompts at TP=1 and TP=2 with `temperature=0` and
-    asserts equal output token IDs. xfail-strict so it surfaces the
+    asserts the first 2 output tokens match per prompt. Later divergence
+    is expected from float16 reduction-order differences between the
+    TP=1 and TP=2 paths. xfail-strict so the test flips to passing the
     moment end-to-end TP=2 forward correctness lands.
     """
     from vllm import LLM, SamplingParams
@@ -248,10 +260,23 @@ def test_tp2_llm_generate_matches_tp1() -> None:
         )
         outs = llm.generate(prompts, sp)
         result = [list(o.outputs[0].token_ids) for o in outs]
+        # vllm doesn't expose an explicit LLM.shutdown(); rely on GC +
+        # child-process reaping. Revisit if this flakes.
         del llm
         gc.collect()
         return result
 
+    def _matching_prefix_len(a: list[int], b: list[int]) -> int:
+        for i, (x, y) in enumerate(zip(a, b)):
+            if x != y:
+                return i
+        return min(len(a), len(b))
+
     tp1 = run(1)
     tp2 = run(2)
-    assert tp1 == tp2, f"tp1 != tp2: {tp1} vs {tp2}"
+    for i, (a, b) in enumerate(zip(tp1, tp2)):
+        n = _matching_prefix_len(a, b)
+        assert n >= 2, (
+            f"prompt {i}: tp1 and tp2 diverged at token {n} "
+            f"(expected >=2 matching tokens). tp1={a} tp2={b}"
+        )

--- a/tests/test_distributed_tp2.py
+++ b/tests/test_distributed_tp2.py
@@ -148,8 +148,8 @@ def test_tp2_llm_generate_matches_tp1() -> None:
                 return i
         return min(len(a), len(b))
 
-    tp1 = run(1)
-    tp2 = run(2)
+    tp1 = run(tp=1)
+    tp2 = run(tp=2)
     for i, (a, b) in enumerate(zip(tp1, tp2)):
         n = _matching_prefix_len(a, b)
         assert n >= 2, (

--- a/tests/test_distributed_tp2.py
+++ b/tests/test_distributed_tp2.py
@@ -18,10 +18,6 @@ from __future__ import annotations
 
 import gc
 import os
-import socket
-import subprocess
-import sys
-import textwrap
 
 import pytest
 
@@ -40,96 +36,19 @@ def _spyre_device_count() -> int:
         return 0
 
 
-def _free_tcp_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
-
-
 # TEMPORARY: this test exercises the low-level distributed init path
-# directly (subprocess + env-rendezvous + init_worker_distributed_environment
-# + manual all_reduce probe) because the higher-level LLM(tp=2) tests
-# below are xfail-strict on #134/#135. Once those land and
+# directly because the higher-level LLM(tp=2) tests below are
+# xfail-strict on #134/#135. Once those land and
 # test_tp2_llm_construction / test_tp2_llm_generate_matches_tp1 pass,
-# this test is redundant — delete it (and _TP_ALLREDUCE_CODE) along
-# with the xfail markers on the LLM tests.
-#
-# Inner-rank script for `test_tp2_tensor_model_parallel_all_reduce`.
-# Launched once per rank as a fresh `python -c` subprocess with
-# RANK / WORLD_SIZE / LOCAL_RANK / LOCAL_WORLD_SIZE / MASTER_{ADDR,PORT}
-# set in the environment (env://-style rendezvous, same as torchrun).
-_TP_ALLREDUCE_CODE = textwrap.dedent(
-    """
-    import os
-    os.environ["VLLM_PLUGINS"] = "spyre_inference,spyre_inference_ops"
-    os.environ.setdefault("VLLM_USE_AOT_COMPILE", "0")
-
-    rank = int(os.environ["RANK"])
-    world_size = int(os.environ["WORLD_SIZE"])
-    local_rank = int(os.environ["LOCAL_RANK"])
-
-    import torch
-    import torch.distributed as dist
-    import torch_spyre  # registers spyreccl backend
-
-    torch.spyre.set_device(local_rank)
-
-    from vllm.plugins import load_general_plugins
-    load_general_plugins()
-
-    from vllm.engine.arg_utils import EngineArgs
-    from vllm.config import set_current_vllm_config
-    from vllm.v1.worker.gpu_worker import init_worker_distributed_environment
-    from vllm.platforms import current_platform
-
-    cfg = EngineArgs(
-        model="facebook/opt-125m",
-        tensor_parallel_size=world_size,
-        dtype="float16",
-        enforce_eager=True,
-        distributed_executor_backend="external_launcher",
-    ).create_engine_config()
-
-    with set_current_vllm_config(cfg):
-        init_worker_distributed_environment(
-            cfg, rank,
-            distributed_init_method="env://",
-            local_rank=local_rank,
-            backend=current_platform.dist_backend,
-        )
-
-        import vllm.distributed.parallel_state as ps
-        comm_cls = type(ps._TP.device_communicator).__name__
-        assert comm_cls == "SpyreCommunicator", f"got {comm_cls}"
-
-        from vllm.distributed.communication_op import (
-            tensor_model_parallel_all_reduce,
-        )
-
-        device = torch.device(f"spyre:{local_rank}")
-        for shape in [(128,), (16, 1024)]:
-            t = torch.full(
-                shape, float(rank + 1),
-                dtype=torch.float16, device=device,
-            )
-            out = tensor_model_parallel_all_reduce(t)
-            expected = float(sum(range(1, world_size + 1)))
-            cpu = out.cpu()
-            torch.testing.assert_close(cpu, torch.full_like(cpu, expected))
-            dist.barrier(device_ids=[local_rank])
-
-    dist.destroy_process_group()
-    """
-)
-
-
+# this test is redundant — delete it along with the xfail markers on
+# the LLM tests.
 @pytest.mark.spyre
 @pytest.mark.uses_subprocess
 @pytest.mark.skipif(
     _spyre_device_count() < 2,
     reason="needs >=2 Spyre cards; skipping TP=2 distributed test",
 )
-def test_tp2_tensor_model_parallel_all_reduce() -> None:
+def test_tp2_tensor_model_parallel_all_reduce(run_tp_probe) -> None:
     """End-to-end TP=2 `tensor_model_parallel_all_reduce` on real Spyre cards.
 
     Spawns one subprocess per rank, each running through vllm's real
@@ -137,50 +56,7 @@ def test_tp2_tensor_model_parallel_all_reduce() -> None:
     then verifies SpyreCommunicator's manual TP=2 fallback returns
     numerically correct results on a 1-D probe and a (seq, hidden) slab.
     """
-    port = _free_tcp_port()
-    world_size = 2
-    procs = []
-    for rank in range(world_size):
-        env = {
-            **os.environ,
-            "RANK": str(rank),
-            "WORLD_SIZE": str(world_size),
-            "LOCAL_RANK": str(rank),
-            "LOCAL_WORLD_SIZE": str(world_size),
-            "MASTER_ADDR": "127.0.0.1",
-            "MASTER_PORT": str(port),
-            "PYTHONUNBUFFERED": "1",
-        }
-        procs.append(
-            subprocess.Popen(  # noqa: S603
-                [sys.executable, "-c", _TP_ALLREDUCE_CODE],
-                env=env,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-            )
-        )
-
-    results: list[tuple[int, str, str]] = []
-    for p in procs:
-        try:
-            out, err = p.communicate(timeout=300)
-        except subprocess.TimeoutExpired:
-            p.kill()
-            out, err = p.communicate()
-            results.append((-1, out or "", err or ""))
-        else:
-            results.append((p.returncode, out or "", err or ""))
-
-    failed = [(i, rc, out, err) for i, (rc, out, err) in enumerate(results) if rc != 0]
-    if failed:
-        msg = "\n".join(
-            f"--- rank {i} (rc={rc}) ---\n"
-            f"stdout (tail):\n{out[-2000:]}\n"
-            f"stderr (tail):\n{err[-2000:]}"
-            for i, rc, out, err in failed
-        )
-        pytest.fail(f"TP=2 ranks failed:\n{msg}")
+    run_tp_probe("tp_all_reduce", world_size=2)
 
 
 @pytest.mark.spyre

--- a/tests/test_distributed_tp2.py
+++ b/tests/test_distributed_tp2.py
@@ -1,0 +1,257 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""TP=2 distributed tests"""
+
+from __future__ import annotations
+
+import gc
+import os
+import socket
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+def _spyre_device_count() -> int:
+    """Return the number of visible Spyre cards, or 0 if unavailable.
+
+    Counts numeric entries under /dev/vfio rather than calling
+    `torch.spyre.device_count()`, because `uses_subprocess` tests must
+    not touch the Spyre runtime in the main pytest process.
+    """
+    try:
+        return sum(1 for n in os.listdir("/dev/vfio") if n.isdigit())
+    except OSError:
+        return 0
+
+
+def _free_tcp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+# Inner-rank script for `test_tp2_tensor_model_parallel_all_reduce`.
+# Launched once per rank as a fresh `python -c` subprocess with
+# RANK / WORLD_SIZE / LOCAL_RANK / LOCAL_WORLD_SIZE / MASTER_{ADDR,PORT}
+# set in the environment (env://-style rendezvous, same as torchrun).
+_TP_ALLREDUCE_CODE = textwrap.dedent(
+    """
+    import os
+    os.environ["VLLM_PLUGINS"] = "spyre_inference,spyre_inference_ops"
+    os.environ.setdefault("VLLM_USE_AOT_COMPILE", "0")
+
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    local_rank = int(os.environ["LOCAL_RANK"])
+
+    import torch
+    import torch.distributed as dist
+    import torch_spyre  # registers spyreccl backend
+
+    torch.spyre.set_device(local_rank)
+
+    from vllm.plugins import load_general_plugins
+    load_general_plugins()
+
+    from vllm.platforms import PlatformEnum, current_platform
+    type(current_platform)._enum = PlatformEnum.OOT
+
+    from vllm.engine.arg_utils import EngineArgs
+    from vllm.config import set_current_vllm_config
+    from vllm.v1.worker.gpu_worker import init_worker_distributed_environment
+
+    cfg = EngineArgs(
+        model="facebook/opt-125m",
+        tensor_parallel_size=world_size,
+        dtype="float16",
+        enforce_eager=True,
+        distributed_executor_backend="external_launcher",
+    ).create_engine_config()
+
+    with set_current_vllm_config(cfg):
+        init_worker_distributed_environment(
+            cfg, rank,
+            distributed_init_method="env://",
+            local_rank=local_rank,
+            backend=current_platform.dist_backend,
+        )
+
+        import vllm.distributed.parallel_state as ps
+        comm_cls = type(ps._TP.device_communicator).__name__
+        assert comm_cls == "SpyreCommunicator", f"got {comm_cls}"
+
+        from vllm.distributed.communication_op import (
+            tensor_model_parallel_all_reduce,
+        )
+
+        device = torch.device(f"spyre:{local_rank}")
+        for shape in [(128,), (16, 1024)]:
+            t = torch.full(
+                shape, float(rank + 1),
+                dtype=torch.float16, device=device,
+            )
+            out = tensor_model_parallel_all_reduce(t)
+            expected = float(sum(range(1, world_size + 1)))
+            cpu = out.cpu()
+            torch.testing.assert_close(cpu, torch.full_like(cpu, expected))
+            dist.barrier(device_ids=[local_rank])
+
+    dist.destroy_process_group()
+    """
+)
+
+
+@pytest.mark.spyre
+@pytest.mark.uses_subprocess
+@pytest.mark.skipif(
+    _spyre_device_count() < 2,
+    reason="needs >=2 Spyre cards; skipping TP=2 distributed test",
+)
+def test_tp2_tensor_model_parallel_all_reduce() -> None:
+    """End-to-end TP=2 `tensor_model_parallel_all_reduce` on real Spyre cards.
+
+    Spawns one subprocess per rank, each running through vllm's real
+    `init_worker_distributed_environment` against a real `VllmConfig`,
+    then verifies SpyreCommunicator's manual TP=2 fallback returns
+    numerically correct results on a 1-D probe and a (seq, hidden) slab.
+    """
+    port = _free_tcp_port()
+    world_size = 2
+    procs = []
+    for rank in range(world_size):
+        env = {
+            **os.environ,
+            "RANK": str(rank),
+            "WORLD_SIZE": str(world_size),
+            "LOCAL_RANK": str(rank),
+            "LOCAL_WORLD_SIZE": str(world_size),
+            "MASTER_ADDR": "127.0.0.1",
+            "MASTER_PORT": str(port),
+            "PYTHONUNBUFFERED": "1",
+        }
+        procs.append(
+            subprocess.Popen(  # noqa: S603
+                [sys.executable, "-c", _TP_ALLREDUCE_CODE],
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        )
+
+    results: list[tuple[int, str, str]] = []
+    for p in procs:
+        try:
+            out, err = p.communicate(timeout=300)
+        except subprocess.TimeoutExpired:
+            p.kill()
+            out, err = p.communicate()
+            results.append((-1, out or "", err or ""))
+        else:
+            results.append((p.returncode, out or "", err or ""))
+
+    failed = [(i, rc, out, err) for i, (rc, out, err) in enumerate(results) if rc != 0]
+    if failed:
+        msg = "\n".join(
+            f"--- rank {i} (rc={rc}) ---\n"
+            f"stdout (tail):\n{out[-2000:]}\n"
+            f"stderr (tail):\n{err[-2000:]}"
+            for i, rc, out, err in failed
+        )
+        pytest.fail(f"TP=2 ranks failed:\n{msg}")
+
+
+@pytest.mark.spyre
+@pytest.mark.uses_subprocess
+@pytest.mark.skipif(
+    _spyre_device_count() < 2,
+    reason="needs >=2 Spyre cards; skipping TP=2 distributed test",
+)
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "needs TP-aware Spyre custom linear layers (#134) and "
+        "TP-aware vocab embedding / LM head (#135). "
+        "MultiprocExecutor + spyreccl init succeed; failure is at "
+        "SpyreQKVParallelLinear NotImplementedError(TP>1)."
+    ),
+)
+def test_tp2_llm_construction() -> None:
+    """Construct `vllm.LLM(tensor_parallel_size=2)` end-to-end.
+
+    Goes through the real `MultiprocExecutor` worker-spawn path that
+    `vllm serve --tensor-parallel-size 2` uses. Today fails at TP-naive
+    layer construction; xfail-strict here so the test flips to passing
+    automatically when #134/#135 land.
+    """
+    from vllm import LLM
+
+    LLM(
+        model="facebook/opt-125m",
+        tensor_parallel_size=2,
+        dtype="float16",
+        enforce_eager=True,
+        max_model_len=128,
+        max_num_seqs=2,
+    )
+
+
+@pytest.mark.spyre
+@pytest.mark.uses_subprocess
+@pytest.mark.skipif(
+    _spyre_device_count() < 2,
+    reason="needs >=2 Spyre cards; skipping TP=2 distributed test",
+)
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "needs #134, #135, and a TP=2 fallback for all_gather "
+        "(LM head logits gather hits unimplemented _allgather_base). "
+        "When all three land, TP=1 vs TP=2 token outputs should match."
+    ),
+)
+def test_tp2_llm_generate_matches_tp1() -> None:
+    """TP=1 vs TP=2 greedy-decode golden test on opt-125m.
+
+    Runs identical prompts at TP=1 and TP=2 with `temperature=0` and
+    asserts equal output token IDs. xfail-strict so it surfaces the
+    moment end-to-end TP=2 forward correctness lands.
+    """
+    from vllm import LLM, SamplingParams
+
+    prompts = ["Hello, world!", "The capital of France is"]
+    sp = SamplingParams(max_tokens=8, temperature=0.0)
+
+    def run(tp: int) -> list[list[int]]:
+        llm = LLM(
+            model="facebook/opt-125m",
+            tensor_parallel_size=tp,
+            dtype="float16",
+            enforce_eager=True,
+            max_model_len=128,
+            max_num_seqs=2,
+        )
+        outs = llm.generate(prompts, sp)
+        result = [list(o.outputs[0].token_ids) for o in outs]
+        del llm
+        gc.collect()
+        return result
+
+    tp1 = run(1)
+    tp2 = run(2)
+    assert tp1 == tp2, f"tp1 != tp2: {tp1} vs {tp2}"

--- a/tests/test_spyre_attn.py
+++ b/tests/test_spyre_attn.py
@@ -163,13 +163,7 @@ def ref_attn(
     "num_heads",
     [
         pytest.param((32, 8), id="GQA"),
-        pytest.param(
-            (32, 32),
-            id="MHA",
-            marks=pytest.mark.skip(
-                "Most MHA cases fail to compile, see https://github.com/torch-spyre/torch-spyre/issues/2195"
-            ),
-        ),
+        pytest.param((32, 32), id="MHA"),
         pytest.param((32, 1), id="MQA"),
     ],
 )

--- a/tests/test_spyre_attn.py
+++ b/tests/test_spyre_attn.py
@@ -163,7 +163,7 @@ def ref_attn(
     "num_heads",
     [
         pytest.param((32, 8), id="GQA"),
-        pytest.param((32, 32), id="MHA"),
+        pytest.param((32, 32), id="MHA", marks=pytest.mark.skip("Most MHA cases fail to compile, see https://github.com/torch-spyre/torch-spyre/issues/2195")),
         pytest.param((32, 1), id="MQA"),
     ],
 )
@@ -209,12 +209,6 @@ def test_spyre_attn(
 ) -> None:
     """Validate SpyreAttentionImpl against a reference implementation."""
     num_query_heads, num_kv_heads = num_heads
-    if not use_sdpa and num_query_heads == num_kv_heads:
-        # torch-spyre regression introduced by #2083 (commit f23fe0c): the
-        # fused softmax+matmul kernel fails SDSC compilation
-        # ("must fit in LX for SuperDSC: 1_batchmatmul") whenever q, k, and v
-        # all share a size-1 second dimension, which is the MHA layout.
-        pytest.skip("MHA + manual softmax: torch-spyre compile regression (#2083)")
     torch.set_default_device("cpu")
     set_random_seed(0)
 

--- a/tests/test_spyre_attn.py
+++ b/tests/test_spyre_attn.py
@@ -126,13 +126,19 @@ def test_spyre_attn(
     use_sdpa: bool,
 ) -> None:
     """Validate SpyreAttentionImpl against a reference implementation."""
+    num_query_heads, num_kv_heads = num_heads
+    if not use_sdpa and num_query_heads == num_kv_heads:
+        # torch-spyre regression introduced by #2083 (commit f23fe0c): the
+        # fused softmax+matmul kernel fails SDSC compilation
+        # ("must fit in LX for SuperDSC: 1_batchmatmul") whenever q, k, and v
+        # all share a size-1 second dimension, which is the MHA layout.
+        pytest.skip("MHA + manual softmax: torch-spyre compile regression (#2083)")
     torch.set_default_device("cpu")
     set_random_seed(0)
 
     num_seqs = len(seq_lens)
     query_lens = [x[0] for x in seq_lens]
     kv_lens = [x[1] for x in seq_lens]
-    num_query_heads, num_kv_heads = num_heads
     assert num_query_heads % num_kv_heads == 0
     max_query_len = max(query_lens)
     max_kv_len = max(kv_lens)

--- a/tests/test_spyre_attn.py
+++ b/tests/test_spyre_attn.py
@@ -163,7 +163,13 @@ def ref_attn(
     "num_heads",
     [
         pytest.param((32, 8), id="GQA"),
-        pytest.param((32, 32), id="MHA", marks=pytest.mark.skip("Most MHA cases fail to compile, see https://github.com/torch-spyre/torch-spyre/issues/2195")),
+        pytest.param(
+            (32, 32),
+            id="MHA",
+            marks=pytest.mark.skip(
+                "Most MHA cases fail to compile, see https://github.com/torch-spyre/torch-spyre/issues/2195"
+            ),
+        ),
         pytest.param((32, 1), id="MQA"),
     ],
 )

--- a/tests/test_spyre_comms_native_probes.py
+++ b/tests/test_spyre_comms_native_probes.py
@@ -1,0 +1,317 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Native libspyre_comms collective probes.
+
+Each test attempts a *native* base-class collective on a real spyreccl
+device_group at TP=2. Today every probe fails because the corresponding
+SpyreCommsContext method (or torch-spyre stub) throws. They are
+xfail(strict=True) so when libspyre_comms gains the native impl and a
+comms RPM is rebuilt, the probe flips to passing, the strict-xfail
+fails CI, and that's the signal to delete the matching manual fallback
+in `spyre_inference.distributed.spyre_communicator` and (optionally)
+revert `TorchSpyrePlatform.get_device_communicator_cls` to the base
+class.
+
+These tests are cheap to maintain but each spawns its own pair of
+subprocesses, which is slow. They are gated on `>=2` Spyre cards so
+they only run on the 2-card pods where the rest of TP=2 testing lives.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+def _spyre_device_count() -> int:
+    """Return the number of visible Spyre cards, or 0 if unavailable.
+
+    Reads AIU_WORLD_SIZE (set by the Spyre runtime environment when
+    cards are visible) instead of touching the Spyre runtime, so
+    `uses_subprocess` tests don't import torch_spyre in the main
+    pytest process.
+    """
+    try:
+        return int(os.environ.get("AIU_WORLD_SIZE", "0"))
+    except ValueError:
+        return 0
+
+
+def _free_tcp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+# Each probe runs the same setup boilerplate (env-rendezvous, vllm
+# config, init_worker_distributed_environment) and then a small probe
+# body specific to the collective being tested. The shared prologue is
+# templated below; each probe substitutes `__PROBE_BODY__`.
+_PROBE_TEMPLATE = textwrap.dedent(
+    """
+    import os
+    os.environ["VLLM_PLUGINS"] = "spyre_inference,spyre_inference_ops"
+    os.environ.setdefault("VLLM_USE_AOT_COMPILE", "0")
+
+    rank = int(os.environ["RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+    local_rank = int(os.environ["LOCAL_RANK"])
+
+    import torch
+    import torch.distributed as dist
+    import torch_spyre  # registers spyreccl backend
+
+    torch.spyre.set_device(local_rank)
+
+    from vllm.plugins import load_general_plugins
+    load_general_plugins()
+
+    from vllm.engine.arg_utils import EngineArgs
+    from vllm.config import set_current_vllm_config
+    from vllm.v1.worker.gpu_worker import init_worker_distributed_environment
+    from vllm.platforms import current_platform
+
+    cfg = EngineArgs(
+        model="facebook/opt-125m",
+        tensor_parallel_size=world_size,
+        dtype="float16",
+        enforce_eager=True,
+        distributed_executor_backend="external_launcher",
+    ).create_engine_config()
+
+    with set_current_vllm_config(cfg):
+        init_worker_distributed_environment(
+            cfg, rank,
+            distributed_init_method="env://",
+            local_rank=local_rank,
+            backend=current_platform.dist_backend,
+        )
+
+        import vllm.distributed.parallel_state as ps
+        device_group = ps._TP.device_group
+        device = torch.device(f"spyre:{local_rank}")
+
+        __PROBE_BODY__
+
+    dist.destroy_process_group()
+    """
+)
+
+
+_ALL_REDUCE_BODY = textwrap.dedent(
+    """
+        # Probe native dist.all_reduce on the spyreccl device_group.
+        # Should fail today because SpyreCommsContext::allreduce throws.
+        t = torch.full((1024,), float(rank + 1),
+                       dtype=torch.float16, device=device)
+        dist.all_reduce(t, group=device_group)
+        expected = float(sum(range(1, world_size + 1)))
+        torch.testing.assert_close(
+            t.cpu(), torch.full_like(t.cpu(), expected)
+        )
+    """
+).strip()
+
+
+_ALL_GATHER_INTO_TENSOR_BODY = textwrap.dedent(
+    """
+        # Probe native dist.all_gather_into_tensor (single-tensor
+        # allgather) on the spyreccl device_group. Should fail today
+        # because torch-spyre's spyreccl backend stubs `_allgather_base`.
+        t = torch.full((1024,), float(rank + 1),
+                       dtype=torch.float16, device=device)
+        out = torch.empty((world_size * 1024,),
+                          dtype=torch.float16, device=device)
+        dist.all_gather_into_tensor(out, t, group=device_group)
+        out_cpu = out.cpu()
+        for r in range(world_size):
+            torch.testing.assert_close(
+                out_cpu[r * 1024 : (r + 1) * 1024],
+                torch.full((1024,), float(r + 1), dtype=torch.float16),
+            )
+    """
+).strip()
+
+
+_ALL_GATHER_LIST_BODY = textwrap.dedent(
+    """
+        # Probe native dist.all_gather (list form) on the spyreccl
+        # device_group. Should fail today because the list-form
+        # SpyreCommsContext::allgather throws.
+        t = torch.full((1024,), float(rank + 1),
+                       dtype=torch.float16, device=device)
+        out_list = [
+            torch.empty((1024,), dtype=torch.float16, device=device)
+            for _ in range(world_size)
+        ]
+        dist.all_gather(out_list, t, group=device_group)
+        for r, o in enumerate(out_list):
+            torch.testing.assert_close(
+                o.cpu(), torch.full((1024,), float(r + 1), dtype=torch.float16),
+            )
+    """
+).strip()
+
+
+_GATHER_BODY = textwrap.dedent(
+    """
+        # Probe native dist.gather on the spyreccl device_group. Should
+        # fail today because SpyreCommsContext::gather throws.
+        t = torch.full((1024,), float(rank + 1),
+                       dtype=torch.float16, device=device)
+        if rank == 0:
+            gather_list = [
+                torch.empty((1024,), dtype=torch.float16, device=device)
+                for _ in range(world_size)
+            ]
+        else:
+            gather_list = None
+        dist.gather(t, gather_list, dst=0, group=device_group)
+        if rank == 0:
+            for r, o in enumerate(gather_list):
+                torch.testing.assert_close(
+                    o.cpu(),
+                    torch.full((1024,), float(r + 1), dtype=torch.float16),
+                )
+    """
+).strip()
+
+
+def _run_probe(probe_body: str) -> None:
+    """Spawn TP=2 subprocesses running `probe_body` and assert both pass."""
+    code = _PROBE_TEMPLATE.replace("__PROBE_BODY__", probe_body)
+    port = _free_tcp_port()
+    world_size = 2
+    procs = []
+    for rank in range(world_size):
+        env = {
+            **os.environ,
+            "RANK": str(rank),
+            "WORLD_SIZE": str(world_size),
+            "LOCAL_RANK": str(rank),
+            "LOCAL_WORLD_SIZE": str(world_size),
+            "MASTER_ADDR": "127.0.0.1",
+            "MASTER_PORT": str(port),
+            "PYTHONUNBUFFERED": "1",
+        }
+        procs.append(
+            subprocess.Popen(  # noqa: S603
+                [sys.executable, "-c", code],
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        )
+
+    results: list[tuple[int, str, str]] = []
+    for p in procs:
+        try:
+            out, err = p.communicate(timeout=300)
+        except subprocess.TimeoutExpired:
+            p.kill()
+            out, err = p.communicate()
+            results.append((-1, out or "", err or ""))
+        else:
+            results.append((p.returncode, out or "", err or ""))
+
+    failed = [(i, rc, out, err) for i, (rc, out, err) in enumerate(results) if rc != 0]
+    if failed:
+        msg = "\n".join(
+            f"--- rank {i} (rc={rc}) ---\n"
+            f"stdout (tail):\n{out[-2000:]}\n"
+            f"stderr (tail):\n{err[-2000:]}"
+            for i, rc, out, err in failed
+        )
+        pytest.fail(f"native probe ranks failed:\n{msg}")
+
+
+@pytest.mark.spyre
+@pytest.mark.uses_subprocess
+@pytest.mark.skipif(
+    _spyre_device_count() < 2,
+    reason="needs >=2 Spyre cards; skipping TP=2 native-probe test",
+)
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "libspyre_comms does not yet implement native allreduce; "
+        "SpyreCommsContext::allreduce throws. When this flips to passing, "
+        "delete SpyreCommunicator.all_reduce."
+    ),
+)
+def test_native_all_reduce_works() -> None:
+    _run_probe(_ALL_REDUCE_BODY)
+
+
+@pytest.mark.spyre
+@pytest.mark.uses_subprocess
+@pytest.mark.skipif(
+    _spyre_device_count() < 2,
+    reason="needs >=2 Spyre cards; skipping TP=2 native-probe test",
+)
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "torch-spyre's spyreccl backend stubs _allgather_base, so "
+        "dist.all_gather_into_tensor fails even though libspyre_comms "
+        "implements single-tensor allgather. When this flips to passing, "
+        "the base DeviceCommunicatorBase.all_gather can replace "
+        "SpyreCommunicator.all_gather."
+    ),
+)
+def test_native_all_gather_into_tensor_works() -> None:
+    _run_probe(_ALL_GATHER_INTO_TENSOR_BODY)
+
+
+@pytest.mark.spyre
+@pytest.mark.uses_subprocess
+@pytest.mark.skipif(
+    _spyre_device_count() < 2,
+    reason="needs >=2 Spyre cards; skipping TP=2 native-probe test",
+)
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "libspyre_comms does not implement list-form allgather; "
+        "SpyreCommsContext::allgather(vector<>) throws. When this flips "
+        "to passing, delete SpyreCommunicator.all_gather."
+    ),
+)
+def test_native_all_gather_list_works() -> None:
+    _run_probe(_ALL_GATHER_LIST_BODY)
+
+
+@pytest.mark.spyre
+@pytest.mark.uses_subprocess
+@pytest.mark.skipif(
+    _spyre_device_count() < 2,
+    reason="needs >=2 Spyre cards; skipping TP=2 native-probe test",
+)
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "libspyre_comms does not yet implement native gather; "
+        "SpyreCommsContext::gather throws. When this flips to passing, "
+        "delete SpyreCommunicator.gather."
+    ),
+)
+def test_native_gather_works() -> None:
+    _run_probe(_GATHER_BODY)

--- a/tests/test_spyre_comms_native_probes.py
+++ b/tests/test_spyre_comms_native_probes.py
@@ -27,15 +27,14 @@ class.
 These tests are cheap to maintain but each spawns its own pair of
 subprocesses, which is slow. They are gated on `>=2` Spyre cards so
 they only run on the 2-card pods where the rest of TP=2 testing lives.
+
+The probe bodies live in `tests/probes/tp_probe.py`; the subprocess
+plumbing lives in the `run_tp_probe` fixture in `tests/conftest.py`.
 """
 
 from __future__ import annotations
 
 import os
-import socket
-import subprocess
-import sys
-import textwrap
 
 import pytest
 
@@ -54,195 +53,6 @@ def _spyre_device_count() -> int:
         return 0
 
 
-def _free_tcp_port() -> int:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
-
-
-# Each probe runs the same setup boilerplate (env-rendezvous, vllm
-# config, init_worker_distributed_environment) and then a small probe
-# body specific to the collective being tested. The shared prologue is
-# templated below; each probe substitutes `__PROBE_BODY__`.
-_PROBE_TEMPLATE = textwrap.dedent(
-    """
-    import os
-    os.environ["VLLM_PLUGINS"] = "spyre_inference,spyre_inference_ops"
-    os.environ.setdefault("VLLM_USE_AOT_COMPILE", "0")
-
-    rank = int(os.environ["RANK"])
-    world_size = int(os.environ["WORLD_SIZE"])
-    local_rank = int(os.environ["LOCAL_RANK"])
-
-    import torch
-    import torch.distributed as dist
-    import torch_spyre  # registers spyreccl backend
-
-    torch.spyre.set_device(local_rank)
-
-    from vllm.plugins import load_general_plugins
-    load_general_plugins()
-
-    from vllm.engine.arg_utils import EngineArgs
-    from vllm.config import set_current_vllm_config
-    from vllm.v1.worker.gpu_worker import init_worker_distributed_environment
-    from vllm.platforms import current_platform
-
-    cfg = EngineArgs(
-        model="facebook/opt-125m",
-        tensor_parallel_size=world_size,
-        dtype="float16",
-        enforce_eager=True,
-        distributed_executor_backend="external_launcher",
-    ).create_engine_config()
-
-    with set_current_vllm_config(cfg):
-        init_worker_distributed_environment(
-            cfg, rank,
-            distributed_init_method="env://",
-            local_rank=local_rank,
-            backend=current_platform.dist_backend,
-        )
-
-        import vllm.distributed.parallel_state as ps
-        device_group = ps._TP.device_group
-        device = torch.device(f"spyre:{local_rank}")
-
-        __PROBE_BODY__
-
-    dist.destroy_process_group()
-    """
-)
-
-
-_ALL_REDUCE_BODY = textwrap.dedent(
-    """
-        # Probe native dist.all_reduce on the spyreccl device_group.
-        # Should fail today because SpyreCommsContext::allreduce throws.
-        t = torch.full((1024,), float(rank + 1),
-                       dtype=torch.float16, device=device)
-        dist.all_reduce(t, group=device_group)
-        expected = float(sum(range(1, world_size + 1)))
-        torch.testing.assert_close(
-            t.cpu(), torch.full_like(t.cpu(), expected)
-        )
-    """
-).strip()
-
-
-_ALL_GATHER_INTO_TENSOR_BODY = textwrap.dedent(
-    """
-        # Probe native dist.all_gather_into_tensor (single-tensor
-        # allgather) on the spyreccl device_group. Should fail today
-        # because torch-spyre's spyreccl backend stubs `_allgather_base`.
-        t = torch.full((1024,), float(rank + 1),
-                       dtype=torch.float16, device=device)
-        out = torch.empty((world_size * 1024,),
-                          dtype=torch.float16, device=device)
-        dist.all_gather_into_tensor(out, t, group=device_group)
-        out_cpu = out.cpu()
-        for r in range(world_size):
-            torch.testing.assert_close(
-                out_cpu[r * 1024 : (r + 1) * 1024],
-                torch.full((1024,), float(r + 1), dtype=torch.float16),
-            )
-    """
-).strip()
-
-
-_ALL_GATHER_LIST_BODY = textwrap.dedent(
-    """
-        # Probe native dist.all_gather (list form) on the spyreccl
-        # device_group. Should fail today because the list-form
-        # SpyreCommsContext::allgather throws.
-        t = torch.full((1024,), float(rank + 1),
-                       dtype=torch.float16, device=device)
-        out_list = [
-            torch.empty((1024,), dtype=torch.float16, device=device)
-            for _ in range(world_size)
-        ]
-        dist.all_gather(out_list, t, group=device_group)
-        for r, o in enumerate(out_list):
-            torch.testing.assert_close(
-                o.cpu(), torch.full((1024,), float(r + 1), dtype=torch.float16),
-            )
-    """
-).strip()
-
-
-_GATHER_BODY = textwrap.dedent(
-    """
-        # Probe native dist.gather on the spyreccl device_group. Should
-        # fail today because SpyreCommsContext::gather throws.
-        t = torch.full((1024,), float(rank + 1),
-                       dtype=torch.float16, device=device)
-        if rank == 0:
-            gather_list = [
-                torch.empty((1024,), dtype=torch.float16, device=device)
-                for _ in range(world_size)
-            ]
-        else:
-            gather_list = None
-        dist.gather(t, gather_list, dst=0, group=device_group)
-        if rank == 0:
-            for r, o in enumerate(gather_list):
-                torch.testing.assert_close(
-                    o.cpu(),
-                    torch.full((1024,), float(r + 1), dtype=torch.float16),
-                )
-    """
-).strip()
-
-
-def _run_probe(probe_body: str) -> None:
-    """Spawn TP=2 subprocesses running `probe_body` and assert both pass."""
-    code = _PROBE_TEMPLATE.replace("__PROBE_BODY__", probe_body)
-    port = _free_tcp_port()
-    world_size = 2
-    procs = []
-    for rank in range(world_size):
-        env = {
-            **os.environ,
-            "RANK": str(rank),
-            "WORLD_SIZE": str(world_size),
-            "LOCAL_RANK": str(rank),
-            "LOCAL_WORLD_SIZE": str(world_size),
-            "MASTER_ADDR": "127.0.0.1",
-            "MASTER_PORT": str(port),
-            "PYTHONUNBUFFERED": "1",
-        }
-        procs.append(
-            subprocess.Popen(  # noqa: S603
-                [sys.executable, "-c", code],
-                env=env,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-            )
-        )
-
-    results: list[tuple[int, str, str]] = []
-    for p in procs:
-        try:
-            out, err = p.communicate(timeout=300)
-        except subprocess.TimeoutExpired:
-            p.kill()
-            out, err = p.communicate()
-            results.append((-1, out or "", err or ""))
-        else:
-            results.append((p.returncode, out or "", err or ""))
-
-    failed = [(i, rc, out, err) for i, (rc, out, err) in enumerate(results) if rc != 0]
-    if failed:
-        msg = "\n".join(
-            f"--- rank {i} (rc={rc}) ---\n"
-            f"stdout (tail):\n{out[-2000:]}\n"
-            f"stderr (tail):\n{err[-2000:]}"
-            for i, rc, out, err in failed
-        )
-        pytest.fail(f"native probe ranks failed:\n{msg}")
-
-
 @pytest.mark.spyre
 @pytest.mark.uses_subprocess
 @pytest.mark.skipif(
@@ -257,8 +67,8 @@ def _run_probe(probe_body: str) -> None:
         "delete SpyreCommunicator.all_reduce."
     ),
 )
-def test_native_all_reduce_works() -> None:
-    _run_probe(_ALL_REDUCE_BODY)
+def test_native_all_reduce_works(run_tp_probe) -> None:
+    run_tp_probe("native_all_reduce", world_size=2)
 
 
 @pytest.mark.spyre
@@ -277,8 +87,8 @@ def test_native_all_reduce_works() -> None:
         "SpyreCommunicator.all_gather."
     ),
 )
-def test_native_all_gather_into_tensor_works() -> None:
-    _run_probe(_ALL_GATHER_INTO_TENSOR_BODY)
+def test_native_all_gather_into_tensor_works(run_tp_probe) -> None:
+    run_tp_probe("native_all_gather_into_tensor", world_size=2)
 
 
 @pytest.mark.spyre
@@ -295,8 +105,8 @@ def test_native_all_gather_into_tensor_works() -> None:
         "to passing, delete SpyreCommunicator.all_gather."
     ),
 )
-def test_native_all_gather_list_works() -> None:
-    _run_probe(_ALL_GATHER_LIST_BODY)
+def test_native_all_gather_list_works(run_tp_probe) -> None:
+    run_tp_probe("native_all_gather_list", world_size=2)
 
 
 @pytest.mark.spyre
@@ -313,5 +123,5 @@ def test_native_all_gather_list_works() -> None:
         "delete SpyreCommunicator.gather."
     ),
 )
-def test_native_gather_works() -> None:
-    _run_probe(_GATHER_BODY)
+def test_native_gather_works(run_tp_probe) -> None:
+    run_tp_probe("native_gather", world_size=2)

--- a/uv.lock
+++ b/uv.lock
@@ -7377,7 +7377,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "torch", index = "https://download.pytorch.org/whl/cpu" },
-    { name = "torch-spyre", git = "https://github.com/torch-spyre/torch-spyre?rev=c124a56ed06b3d31099f825c5ffaa350007d6809" },
+    { name = "torch-spyre", git = "https://github.com/torch-spyre/torch-spyre?rev=ee37a9de5aaa33995fcbeac36ca1b1131677ce6f" },
     { name = "torchvision", index = "https://download.pytorch.org/whl/cpu" },
     { name = "vllm", git = "https://github.com/vllm-project/vllm?rev=v0.20.1" },
 ]
@@ -8138,7 +8138,7 @@ wheels = [
 [[package]]
 name = "torch-spyre"
 version = "0.0.1"
-source = { git = "https://github.com/torch-spyre/torch-spyre?rev=c124a56ed06b3d31099f825c5ffaa350007d6809#c124a56ed06b3d31099f825c5ffaa350007d6809" }
+source = { git = "https://github.com/torch-spyre/torch-spyre?rev=ee37a9de5aaa33995fcbeac36ca1b1131677ce6f#ee37a9de5aaa33995fcbeac36ca1b1131677ce6f" }
 dependencies = [
     { name = "numpy" },
     { name = "psutil" },

--- a/uv.lock
+++ b/uv.lock
@@ -7377,7 +7377,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "torch", index = "https://download.pytorch.org/whl/cpu" },
-    { name = "torch-spyre", git = "https://github.com/torch-spyre/torch-spyre?rev=539a1a0c2d54b228c19c982ee80044e210bcde98" },
+    { name = "torch-spyre", git = "https://github.com/torch-spyre/torch-spyre?rev=c124a56ed06b3d31099f825c5ffaa350007d6809" },
     { name = "torchvision", index = "https://download.pytorch.org/whl/cpu" },
     { name = "vllm", git = "https://github.com/vllm-project/vllm?rev=v0.20.1" },
 ]
@@ -8138,7 +8138,7 @@ wheels = [
 [[package]]
 name = "torch-spyre"
 version = "0.0.1"
-source = { git = "https://github.com/torch-spyre/torch-spyre?rev=539a1a0c2d54b228c19c982ee80044e210bcde98#539a1a0c2d54b228c19c982ee80044e210bcde98" }
+source = { git = "https://github.com/torch-spyre/torch-spyre?rev=c124a56ed06b3d31099f825c5ffaa350007d6809#c124a56ed06b3d31099f825c5ffaa350007d6809" }
 dependencies = [
     { name = "numpy" },
     { name = "psutil" },


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Initial TP support: lands the distributed-init half (process-group setup, platform overrides, Spyre-aware DeviceCommunicator) so a TP=2 worker brings up `init_process_group` + spyreccl + a working forward-path
`all_reduce`.

Does **not** yet land working TP>1 end-to-end forward — that needs the TP-aware custom layers (#134, #135) and an `all_gather` fallback.

## Changes

- **torch-spyre bump** to pick up the `spyreccl` distributed backend.
- **Platform** (`spyre_inference/platform.py`):
    - `dist_backend = "cpu:gloo,spyre:spyreccl"` so `cpu_group` (gloo) and
      `device_group` (spyreccl) coexist.
    - `get_device_communicator_cls() -> SpyreCommunicator`.
    - Reject `data_parallel_size > 1`; DP+TP not validated yet.
- **Worker** (`spyre_inference/v1/worker/spyre_worker.py`):
    - Pin each worker to its card via `torch.spyre.set_device` before
      spyreccl init.
    - Populate `RANK` / `WORLD_SIZE` / `LOCAL_RANK` / `LOCAL_WORLD_SIZE`
      before `init_process_group`. libspyre_comms reads these via
      `getenv` and throws if unset; vllm's `MultiprocExecutor` uses
      TCP-based init and doesn't set them.
- **SpyreCommunicator** (`spyre_inference/distributed/spyre_communicator.py`):
    - TP=2 manual `all_reduce` via send/recv + broadcast (the only
      collectives implemented in the installed libspyre_comms). TP>2
      raises.
    - `all_gather`, `gather`, `reduce_scatter` raise NotImplementedError
      describing what's needed to unblock each.


## Related Issues

Closes #137 

## Test Plan

- `tests/test_distributed_tp2.py` (new):
    - `test_tp2_tensor_model_parallel_all_reduce` — passes today.
      Subprocess + env-rendezvous + real `init_worker_distributed_environment`
      + manual `all_reduce` probe.
    - `test_tp2_llm_construction` — xfail-strict. `LLM(tp=2)` end-to-end;
      flips when #134/#135 land.
    - `test_tp2_llm_generate_matches_tp1` — xfail-strict. Greedy-decodes
      opt-125m at TP=1 and TP=2, asserts first 2 tokens match per prompt
      (later divergence expected from float16 reduction-order).
- `tests/test_spyre_comms_native_probes.py` (new): four xfail-strict
  probes (`all_reduce`, `all_gather_into_tensor`, `all_gather` list,
  `gather`) on a real spyreccl device_group. When libspyre_comms gains
  a native impl and a comms RPM lands, the corresponding probe flips to
  passing → strict-xfail fails CI → signal to delete the matching
  fallback in SpyreCommunicator.

## Checklist

- [ ] I have read the [contributing guidelines](https://torch-spyre.github.io/spyre-inference/contributing/)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
