### PR TITLE
feat: chunked lm_head matmul on Spyre for large vocab models

### DIFF
--- a/examples/offline_inference/torch_spyre_inference.py
+++ b/examples/offline_inference/torch_spyre_inference.py
@@ -42,7 +42,7 @@ def parse_args():
         "--max-num-batched-tokens", type=int, default=2, dest="max_num_batched_tokens"
     )
     parser.add_argument(
-        "--num_gpu_blocks_override", type=int, default=None, dest="--num-gpu-blocks-override"
+        "--num-gpu-blocks-override", type=int, default=None, dest="num_gpu_blocks_override"
     )
     parser.add_argument("--tp", type=int, default=1)
     parser.add_argument("-n", "--num-prompts", type=int, default=3, dest="num_prompts")

--- a/spyre_inference/custom_ops/lm_head_common.py
+++ b/spyre_inference/custom_ops/lm_head_common.py
@@ -1,0 +1,336 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared lm_head matmul helpers for SpyreParallelLMHead.
+
+Supports two execution shapes:
+
+1. Single-chunk: one padded F.linear on Spyre. Used for small vocab × hidden
+   matmuls (e.g. Granite 4.1).
+2. N-chunk: weight split along vocab dim, one F.linear per chunk, concat on CPU.
+   Required for large vocab × hidden (e.g. Qwen3-8B 151936×4096) because the
+   single matmul exceeds torch-spyre's per-core 256 MB EAR span limit
+   (see torch_spyre/_inductor/work_division.py).
+
+Chunk count selection:
+- SPYRE_LM_HEAD_NUM_CHUNKS env var overrides everything (e.g. "1", "8").
+- Otherwise: 1 chunk if weight bytes <= SPYRE_LM_HEAD_SINGLE_THRESHOLD_MIB
+  (default 200 MiB), else SPYRE_LM_HEAD_DEFAULT_CHUNKS (default 8) — mirroring
+  hf_adapters/hf_common.py chunk_lm_head.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Callable
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from vllm.logger import init_logger
+from vllm.model_executor.custom_op import CustomOp
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    UnquantizedEmbeddingMethod,
+)
+
+from .utils import convert
+
+logger = init_logger(__name__)
+
+# Defaults match hf_adapters chunk_lm_head behavior.
+_DEFAULT_CHUNKS_FALLBACK = 8
+_DEFAULT_SINGLE_THRESHOLD_MIB = 200
+
+
+@dataclass
+class LmHeadMatmulState:
+    """Prepared lm_head sub-weights for a Spyre F.linear logits matmul.
+
+    chunks[i] is the i-th padded sub-weight (shape [padded_rows_i, hidden]).
+    real_sizes[i] is the unpadded row count for chunk i (used to slice logits).
+    forward_fn is the compiled per-chunk F.linear.
+    """
+
+    chunks: list[torch.Tensor] = field(default_factory=list)
+    real_sizes: list[int] = field(default_factory=list)
+    forward_fn: Callable[[torch.Tensor, torch.Tensor, torch.Tensor | None], torch.Tensor] | None = (
+        None
+    )
+
+    @property
+    def num_chunks(self) -> int:
+        return len(self.chunks)
+
+
+def compute_chunk_padding(num_rows: int) -> int:
+    """Return additional padding rows for torch-spyre matmul shape rules.
+
+    Rule: row count must be a multiple of ``64 * 32 = 2048``.
+    """
+    if num_rows % 64 != 0:
+        raise ValueError(
+            f"lm_head chunk row count {num_rows} is not a multiple of 64; "
+            "upstream vocab padding should have aligned it."
+        )
+    blocks = num_rows // 64
+    rem = blocks % 32
+    if rem == 0:
+        return 0
+    return (32 - rem) * 64
+
+
+def _resolve_num_chunks(weight: torch.Tensor) -> int:
+    """Pick chunk count from SPYRE_LM_HEAD_NUM_CHUNKS or size heuristic."""
+    env = os.environ.get("SPYRE_LM_HEAD_NUM_CHUNKS")
+    if env is not None:
+        try:
+            n = int(env)
+        except ValueError as exc:
+            raise ValueError(f"SPYRE_LM_HEAD_NUM_CHUNKS must be an integer, got {env!r}") from exc
+        return max(1, n)
+
+    try:
+        threshold_mib = int(
+            os.environ.get(
+                "SPYRE_LM_HEAD_SINGLE_THRESHOLD_MIB",
+                _DEFAULT_SINGLE_THRESHOLD_MIB,
+            )
+        )
+    except ValueError:
+        threshold_mib = _DEFAULT_SINGLE_THRESHOLD_MIB
+
+    weight_bytes = weight.numel() * weight.element_size()
+    if weight_bytes <= threshold_mib * 1024 * 1024:
+        return 1
+
+    try:
+        default_chunks = int(
+            os.environ.get(
+                "SPYRE_LM_HEAD_DEFAULT_CHUNKS",
+                _DEFAULT_CHUNKS_FALLBACK,
+            )
+        )
+    except ValueError:
+        default_chunks = _DEFAULT_CHUNKS_FALLBACK
+    return max(1, default_chunks)
+
+
+def build_lm_head_chunks(
+    weight: torch.Tensor,
+    num_chunks: int,
+    layer_name: str,
+) -> tuple[list[torch.Tensor], list[int]]:
+    """Split weight along dim 0 into ``num_chunks`` padded sub-weights.
+
+    Each chunk is sized in units of 64 rows ("sticks") so it remains 64-aligned
+    (required by torch-spyre), then padded so its row count is a multiple of
+    ``64 * 32`` to satisfy the F.linear shape rule. Stick-count remainder is
+    distributed across the first chunks so chunk sizes differ by at most 64
+    rows.
+
+    Returns ``(chunks, real_sizes)`` where ``real_sizes[i]`` is the unpadded
+    row count of chunk i (used to slice logits after the matmul).
+    """
+    vocab = weight.shape[0]
+    if num_chunks < 1:
+        raise ValueError(f"num_chunks must be >= 1, got {num_chunks}")
+    if vocab % 64 != 0:
+        raise ValueError(
+            f"{layer_name}: lm_head vocab dim {vocab} must be a multiple of 64 "
+            "(upstream pad_vocab_size_to_multiple_of should align it)."
+        )
+
+    total_sticks = vocab // 64
+    if num_chunks > total_sticks:
+        raise ValueError(
+            f"num_chunks={num_chunks} exceeds total 64-row sticks ({total_sticks}) for {layer_name}"
+        )
+
+    sticks_base = total_sticks // num_chunks
+    sticks_remainder = total_sticks % num_chunks
+
+    chunks: list[torch.Tensor] = []
+    real_sizes: list[int] = []
+    cursor = 0
+    for i in range(num_chunks):
+        sticks = sticks_base + (1 if i < sticks_remainder else 0)
+        real_rows = sticks * 64
+        end = cursor + real_rows
+        sub = weight[cursor:end].clone()
+        cursor = end
+        # 64*32-block alignment for torch-spyre's F.linear work_division.
+        pad_rows = compute_chunk_padding(sub.shape[0])
+        if pad_rows > 0:
+            sub = F.pad(sub, (0, 0, 0, pad_rows))
+        chunks.append(sub)
+        real_sizes.append(real_rows)
+
+    if cursor != vocab:
+        raise AssertionError(
+            f"lm_head chunking lost rows for {layer_name}: cursor={cursor}, vocab={vocab}"
+        )
+
+    if num_chunks > 1 or chunks[0].shape[0] != vocab:
+        # warning_once hashes *args for dedup, so pass tuples (not lists).
+        logger.warning_once(
+            "%s: lm_head split into %d chunk(s); real_sizes=%s, padded_sizes=%s "
+            "(torch-spyre 256 MB per-core span workaround) — expect numerical "
+            "differences to upstream vLLM.",
+            layer_name,
+            num_chunks,
+            tuple(real_sizes),
+            tuple(c.shape[0] for c in chunks),
+        )
+    return chunks, real_sizes
+
+
+def _make_forward_spyre() -> Callable[
+    [torch.Tensor, torch.Tensor, torch.Tensor | None], torch.Tensor
+]:
+    def forward_spyre(
+        x: torch.Tensor,
+        w: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        return F.linear(x, w, bias)
+
+    return forward_spyre
+
+
+def build_lm_head_matmul_state(
+    weight: torch.Tensor,
+    layer_name: str,
+    compile_owner: nn.Module,
+    num_chunks: int | None = None,
+) -> LmHeadMatmulState:
+    """Build chunks + compiled F.linear for an lm_head weight."""
+    n = num_chunks if num_chunks is not None else _resolve_num_chunks(weight)
+    chunks, real_sizes = build_lm_head_chunks(weight, n, layer_name)
+    forward_fn = maybe_compile_spyre_linear(compile_owner, _make_forward_spyre())
+    return LmHeadMatmulState(chunks=chunks, real_sizes=real_sizes, forward_fn=forward_fn)
+
+
+def setup_lm_head_padding(layer: nn.Module) -> None:
+    """Build LmHeadMatmulState on a ParallelLMHead layer.
+
+    Stores the state at ``layer._spyre_matmul_state``. For the single-chunk
+    no-padding case, the first chunk aliases ``layer.weight`` to avoid a
+    duplicate vocab-sized allocation.
+    """
+    state = build_lm_head_matmul_state(layer.weight, layer.__class__.__name__, layer)
+    if state.num_chunks == 1 and state.chunks[0].shape[0] == state.real_sizes[0]:
+        state.chunks[0] = layer.weight
+    layer._spyre_matmul_state = state
+
+
+def forward_lm_head_matmul(
+    state: LmHeadMatmulState,
+    x: torch.Tensor,
+    bias: torch.Tensor | None,
+) -> torch.Tensor:
+    """Run lm_head F.linear on Spyre; input x is typically on CPU.
+
+    For chunked paths, runs one F.linear per chunk and concatenates on CPU.
+    """
+    if state.forward_fn is None or not state.chunks:
+        raise RuntimeError(
+            "LmHeadMatmulState is not initialized; call build_lm_head_matmul_state first."
+        )
+
+    x_device = x.device
+    weight_device = state.chunks[0].device
+    x_spyre = convert(x, device=weight_device)
+
+    if state.num_chunks == 1:
+        chunk = state.chunks[0]
+        real_size = state.real_sizes[0]
+        padding = chunk.shape[0] - real_size
+        if bias is not None and padding > 0:
+            bias_chunk = convert(F.pad(bias, (0, padding)), device=weight_device)
+        elif bias is not None:
+            bias_chunk = convert(bias, device=weight_device)
+        else:
+            bias_chunk = None
+        out = state.forward_fn(x_spyre, chunk.data, bias_chunk)
+        out_cpu = convert(out, device="cpu")
+        out_cpu_unpadded = out_cpu[..., :real_size] if padding > 0 else out_cpu
+        return convert(out_cpu_unpadded, device=x_device)
+
+    # N-chunk path: F.linear adds bias to the full (padded) chunk output, so
+    # the per-chunk bias must be padded to chunk.shape[0]. Bias indexes into
+    # the real (unpadded) vocab; pad rows get zero bias.
+    parts: list[torch.Tensor] = []
+    bias_cursor = 0
+    for chunk, real_size in zip(state.chunks, state.real_sizes):
+        if bias is not None:
+            real_slice = bias[bias_cursor : bias_cursor + real_size]
+            bias_cursor += real_size
+            pad_len = chunk.shape[0] - real_size
+            if pad_len > 0:
+                bias_chunk = F.pad(real_slice, (0, pad_len))
+            else:
+                bias_chunk = real_slice
+            bias_chunk = convert(bias_chunk, device=weight_device)
+        else:
+            bias_chunk = None
+        out = state.forward_fn(x_spyre, chunk.data, bias_chunk)
+        out_cpu = convert(out, device="cpu")
+        parts.append(out_cpu[..., :real_size])
+    logits = torch.cat(parts, dim=-1)
+    return convert(logits, device=x_device)
+
+
+def forward_lm_head_oot(
+    layer: nn.Module,
+    x: torch.Tensor,
+    bias: torch.Tensor | None,
+) -> torch.Tensor:
+    """ParallelLMHead path — dispatches to ``layer._spyre_matmul_state``."""
+    state: LmHeadMatmulState | None = getattr(layer, "_spyre_matmul_state", None)
+    if state is None:
+        raise RuntimeError(
+            f"{layer.__class__.__name__}: _spyre_matmul_state not built; "
+            "process_weights_after_loading must run before forward_oot."
+        )
+    return forward_lm_head_matmul(state, x, bias)
+
+
+class SpyreUnquantizedLMHeadMethod(UnquantizedEmbeddingMethod):
+    """Routes ParallelLMHead logits through layer.forward_oot()."""
+
+    def apply(self, layer, x, bias=None):
+        return layer.forward_oot(x, bias)
+
+    def process_weights_after_loading(self, layer):
+        super().process_weights_after_loading(layer)
+        setup_lm_head_padding(layer)
+
+
+def maybe_compile_spyre_linear(layer: nn.Module, fn):
+    """Compile helper for SpyreParallelLMHead's F.linear.
+
+    Spyre runs with ``enforce_eager=True`` today (CompilationMode.NONE), so any
+    maybe_compile wrapping is effectively a no-op. We still route through
+    ``layer.maybe_compile`` for CustomOp owners so the hook is kept consistent
+    with the rest of spyre-inference. The fallback handles non-CustomOp
+    owners defensively.
+    """
+    if isinstance(layer, CustomOp):
+        try:
+            return layer.maybe_compile(fn)
+        except Exception:
+            return fn
+    return fn

--- a/spyre_inference/custom_ops/parallel_lm_head.py
+++ b/spyre_inference/custom_ops/parallel_lm_head.py
@@ -19,10 +19,13 @@ Executes the lm_head matmul (hidden_states @ weight.T) on Spyre.
 Architecture:
     - OOT Registration: @ParallelLMHead.register_oot() replaces upstream
       at instantiation
-    - forward_oot(): Entry point for OOT dispatch, handles device conversion
-      and runs the compiled F.linear on Spyre
-    - Separate Compilation: forward_spyre is compiled independently via
-      maybe_compile (no opaque custom-op boundary)
+    - forward_oot(): Entry point for OOT dispatch, defers to shared
+      forward_lm_head_oot which uses ``layer._spyre_matmul_state``
+    - Chunked matmul: LmHeadMatmulState splits the weight along the vocab
+      dim into N padded sub-weights (driven by SPYRE_LM_HEAD_NUM_CHUNKS),
+      runs one F.linear per chunk on Spyre, and concatenates on CPU. This
+      sidesteps torch-spyre's per-core 256 MB EAR span limit for large
+      lm_head matmuls (e.g. Qwen3-8B 151936×4096).
     - quant_method override: SpyreUnquantizedLMHeadMethod.apply() calls
       forward_oot() so that LogitsProcessor._get_logits() routes through
       the Spyre path
@@ -34,62 +37,34 @@ Spyre Device Constraints:
 References:
     - Upstream ParallelLMHead:
       vllm/model_executor/layers/vocab_parallel_embedding.py
+    - Chunking pattern: hf_adapters/hf_common.py chunk_lm_head
 """
 
 import torch
-import torch.nn.functional as F
 
 from vllm.logger import init_logger
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
-    UnquantizedEmbeddingMethod,
 )
 
-from .utils import convert
+from .lm_head_common import (
+    SpyreUnquantizedLMHeadMethod,
+    forward_lm_head_oot,
+)
+
+__all__ = ["SpyreParallelLMHead", "SpyreUnquantizedLMHeadMethod"]
 
 logger = init_logger(__name__)
-
-
-class SpyreUnquantizedLMHeadMethod(UnquantizedEmbeddingMethod):
-    """Routes lm_head computation through SpyreParallelLMHead.forward_oot()."""
-
-    def apply(self, layer, x, bias=None):
-        return layer.forward_oot(x, bias)
-
-    def process_weights_after_loading(self, layer):
-        super().process_weights_after_loading(layer)
-
-        # torch-spyre currently has a limitation with the work division of larger
-        # matmuls. The shapes needs to be a multiple of 64 * (k * 32), where k is
-        # an integer.
-        layer.padding = 0
-        pad_1 = layer.weight.shape[0] % 64
-        if pad_1 != 0:
-            raise ValueError("The weight dimension must be a multiple of 64.")
-        pad_2 = (layer.weight.shape[0] // 64) % 32
-        if pad_2 > 0:
-            pad_2 = 32 - pad_2
-            layer.padding = pad_2 * 64
-            layer.padded_weight = F.pad(layer.weight, (0, 0, 0, layer.padding))
-            logger.warning_once(
-                "%s: weights padded from %d to %d (torch-spyre limitation) "
-                "expect numerical differences to upstream vLLM.",
-                layer.__class__.__name__,
-                layer.weight.shape[0],
-                layer.padded_weight.shape[0],
-            )
-        else:
-            layer.padded_weight = layer.weight
 
 
 @ParallelLMHead.register_oot(name="ParallelLMHead")
 class SpyreParallelLMHead(ParallelLMHead):
     """OOT ParallelLMHead that executes the lm_head matmul on Spyre.
 
-    Weights reside on Spyre after model.to(spyre_device).
-    The quant_method is replaced so that LogitsProcessor._get_logits()
-    routes through forward_oot, which handles device conversion
-    and runs F.linear on Spyre.
+    Weights reside on Spyre after model.to(spyre_device). The shared
+    LmHeadMatmulState (built in process_weights_after_loading) holds the
+    padded weight chunks and compiled F.linear; forward_oot iterates over
+    them and concatenates logits on CPU.
     """
 
     def __init__(self, *args, **kwargs):
@@ -110,42 +85,27 @@ class SpyreParallelLMHead(ParallelLMHead):
 
         logger.debug("Building custom ParallelLMHead for Spyre")
 
-        # Set the custom quantization method to route through spyre
+        # Set the custom quantization method to route through spyre.
+        # The chunked LmHeadMatmulState is materialized in
+        # SpyreUnquantizedLMHeadMethod.process_weights_after_loading once the
+        # checkpoint values are loaded into self.weight.
         self.quant_method = SpyreUnquantizedLMHeadMethod()
 
     def _apply(self, fn, recurse=True):
         super()._apply(fn, recurse=recurse)
-        self.padded_weight = fn(self.padded_weight)
+        # Move every padded chunk to the new device; chunks that alias
+        # self.weight are already handled by super().
+        state = getattr(self, "_spyre_matmul_state", None)
+        if state is not None:
+            new_chunks = []
+            for chunk in state.chunks:
+                if chunk is self.weight:
+                    new_chunks.append(self.weight)
+                else:
+                    new_chunks.append(fn(chunk))
+            state.chunks = new_chunks
         return self
 
     def forward_oot(self, x: torch.Tensor, bias: torch.Tensor | None = None) -> torch.Tensor:
-        """OOT forward pass — lm_head matmul on Spyre.
-
-        Called by SpyreUnquantizedLMHeadMethod.apply() from within
-        LogitsProcessor._get_logits(). Converts x (arriving on cpu)
-        to the weight device (residing on spyre), runs the compiled F.linear on spyre
-        and converts back to the x device (cpu).
-
-        Args:
-            x: Hidden states tensor [num_tokens, hidden_dim]
-            bias: Optional bias tensor
-
-        Returns:
-            Logits tensor [num_tokens, vocab_size] on the input device
-        """
-        x_device = x.device
-
-        # Due to indexing operations inside the ModelRunner, which have
-        # to be carried out on cpu due to a torch-spyre limitation,
-        # the input to the SpyreParallelLMHead resides on CPU.
-        # Due to a second limitation of torch-spyre regarding sizes that can be used
-        # in a F.linear layer, the original weights need to be padded
-        out = F.linear(
-            convert(x, device=self.weight.device),
-            self.padded_weight.data,
-            bias,
-        )
-
-        out_cpu = convert(out, device="cpu")
-        out_cpu_no_pad = out_cpu[:, : -self.padding] if self.padding > 0 else out_cpu
-        return convert(out_cpu_no_pad, device=x_device)
+        """OOT forward pass — chunked lm_head matmul on Spyre."""
+        return forward_lm_head_oot(self, x, bias)

--- a/spyre_inference/v1/worker/spyre_model_runner.py
+++ b/spyre_inference/v1/worker/spyre_model_runner.py
@@ -118,8 +118,8 @@ class _SpyreModelWrapper:
     Output conversion (Spyre → CPU):
         The model's final hidden_states come out on Spyre. Downstream
         operations (indexing via logits_indices, sampling) run on CPU.
-        The lm_head matmul runs on Spyre via SpyreParallelLMHead,
-        which handles H2D/D2H for the sample_hidden_states subset.
+        Logits matmul runs on Spyre via SpyreParallelLMHead, which handles
+        the H2D/D2H transfers around its compiled F.linear chunks.
 
     Wrapping at the model level ensures ALL call sites get the right
     device — both execute_model (via _model_forward) and _dummy_run
@@ -255,7 +255,7 @@ class TorchSpyreModelRunner(GPUModelRunner):
         # Wrap model so ALL forward() calls to the entire model,
         # for example in execute_model, _dummy_run, etc.,
         # automatically convert Spyre outputs to CPU. This ensures downstream
-        # indexing (logits_indices), lm_head (CPU weights), and sampling all
+        # indexing (logits_indices), sampling, and logits outputs all
         # receive CPU tensors without needing per-call-site overrides.
         self.model = _SpyreModelWrapper(self.model, self._spyre_device)
 

--- a/tests/test_parallel_lm_head.py
+++ b/tests/test_parallel_lm_head.py
@@ -89,18 +89,18 @@ def test_spyre_parallel_lm_head_matches_reference(tp_group, num_tokens, vocab_si
         (51200, False, 51200),  # 51200 = 64 * (25 * 32) → already aligned, no padding
     ],
 )
-def test_padded_weight_reflects_loaded_weight(
+def test_padded_chunk_reflects_loaded_weight(
     tp_group, vocab_size, expect_padding, expect_padded_shape
 ):
-    """padded_weight must hold the loaded checkpoint values, not uninitialized data.
+    """The single-chunk padded weight must hold the loaded checkpoint values.
 
     Regression guard: padded_weight was previously snapshotted in __init__,
     before load_weights ran, so it held whatever torch.empty produced. It is
-    now materialized in process_weights_after_loading instead.
+    now materialized in process_weights_after_loading via LmHeadMatmulState.
 
-    Also asserts the no-padding path: when the weight row count is already a
-    multiple of 64 * 32, process_weights_after_loading must leave padded_weight
-    identical to the weight Parameter (no F.pad, no extra allocation).
+    Also asserts the no-padding path: when the row count is already a
+    multiple of 64 * 32, the chunk aliases ``layer.weight`` so no extra
+    vocab-sized allocation is made.
     """
     from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
 
@@ -112,32 +112,30 @@ def test_padded_weight_reflects_loaded_weight(
 
     layer.quant_method.process_weights_after_loading(layer)
 
+    state = layer._spyre_matmul_state
+    assert state is not None
+    assert state.num_chunks == 1
+    chunk = state.chunks[0]
+    real_size = state.real_sizes[0]
+
     if expect_padding:
-        assert layer.padding > 0
-        assert layer.padded_weight.shape == (
-            expect_padded_shape,
-            embedding_dim,
-        )
+        assert real_size == vocab_size
+        assert chunk.shape == (expect_padded_shape, embedding_dim)
         # Top slice mirrors the loaded weight bit-for-bit.
         torch.testing.assert_close(
-            layer.padded_weight[: layer.weight.shape[0]],
+            chunk[:vocab_size],
             layer.weight,
             atol=0.0,
             rtol=0.0,
         )
         # Padding rows are zeros (F.pad default), so they contribute 0 to logits.
-        assert torch.all(layer.padded_weight[layer.weight.shape[0] :] == 0)
+        assert torch.all(chunk[vocab_size:] == 0)
     else:
-        # Aligned shape: no padding applied, padded_weight aliases the weight
+        # Aligned shape: no padding applied, the chunk aliases the weight
         # Parameter so we don't allocate or copy a second vocab-sized tensor.
-        assert layer.padding == 0
-        assert layer.padded_weight is layer.weight
-        torch.testing.assert_close(
-            layer.padded_weight,
-            layer.weight,
-            atol=0.0,
-            rtol=0.0,
-        )
+        assert chunk is layer.weight
+        assert real_size == chunk.shape[0]
+        torch.testing.assert_close(chunk, layer.weight, atol=0.0, rtol=0.0)
 
 
 @pytest.mark.spyre
@@ -176,6 +174,126 @@ def test_invalid_weight_shape_raises(tp_group):
 
     with pytest.raises(ValueError, match="multiple of 64"):
         layer.quant_method.process_weights_after_loading(layer)
+
+
+# ---------------------------------------------------------------------------
+# Chunked lm_head workaround
+#
+# torch-spyre's F.linear lowering has a per-core EAR span limit of 256 MB
+# (torch_spyre/_inductor/work_division.py). Large lm_heads (e.g. Qwen3-8B
+# 151936 × 4096 fp16 → 300 MB per core after split across 8 cores) overflow
+# and abort with SIGABRT during compilation. The chunked path splits the
+# matmul along the vocab dim into N smaller F.linears that each fit under
+# the span limit, mirroring hf_adapters/hf_common.py chunk_lm_head.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.spyre
+@pytest.mark.parallel_lm_head
+@pytest.mark.parametrize("num_chunks", [1, 2, 4, 8])
+def test_chunked_lm_head_matches_reference(tp_group, monkeypatch, num_chunks):
+    """Chunked SpyreParallelLMHead matches plain F.linear for any chunk count."""
+    from spyre_inference.custom_ops.parallel_lm_head import SpyreParallelLMHead
+    from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
+
+    monkeypatch.setenv("SPYRE_LM_HEAD_NUM_CHUNKS", str(num_chunks))
+    torch.manual_seed(0)
+
+    vocab_size = 51200
+    embedding_dim = 64
+    num_tokens = 4
+
+    layer = ParallelLMHead(vocab_size, embedding_dim, params_dtype=torch.float16)
+    assert isinstance(layer, SpyreParallelLMHead)
+
+    loaded = torch.randn(layer.weight.shape, dtype=torch.float16)
+    layer.weight.data.copy_(loaded)
+
+    layer.quant_method.process_weights_after_loading(layer)
+
+    state = layer._spyre_matmul_state
+    assert state is not None
+    assert state.num_chunks == num_chunks
+    assert sum(state.real_sizes) == vocab_size
+
+    x = torch.randn(num_tokens, embedding_dim, dtype=torch.float16)
+    expected = reference_lm_head(x, layer.weight.data)
+    actual = layer.forward_oot(x)
+
+    assert actual.shape == (num_tokens, vocab_size)
+    torch.testing.assert_close(actual.float(), expected.float(), atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.spyre
+@pytest.mark.parallel_lm_head
+def test_chunked_lm_head_handles_uneven_split(tp_group, monkeypatch):
+    """Vocab whose stick count isn't divisible by num_chunks still covers all rows."""
+    from spyre_inference.custom_ops.parallel_lm_head import SpyreParallelLMHead
+    from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
+
+    # 49216 = 64 * 769; 769 / 8 = 96 r 1 -> first chunk gets the extra stick.
+    monkeypatch.setenv("SPYRE_LM_HEAD_NUM_CHUNKS", "8")
+    torch.manual_seed(0)
+
+    vocab_size = 49216
+    embedding_dim = 64
+
+    layer = ParallelLMHead(vocab_size, embedding_dim, params_dtype=torch.float16)
+    assert isinstance(layer, SpyreParallelLMHead)
+
+    loaded = torch.randn(layer.weight.shape, dtype=torch.float16)
+    layer.weight.data.copy_(loaded)
+    layer.quant_method.process_weights_after_loading(layer)
+
+    state = layer._spyre_matmul_state
+    assert state is not None
+    assert state.num_chunks == 8
+    assert sum(state.real_sizes) == vocab_size
+    # First chunk gets the extra 64-row stick.
+    assert state.real_sizes[0] == state.real_sizes[-1] + 64
+
+    x = torch.randn(3, embedding_dim, dtype=torch.float16)
+    expected = reference_lm_head(x, layer.weight.data)
+    actual = layer.forward_oot(x)
+
+    torch.testing.assert_close(actual.float(), expected.float(), atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.spyre
+@pytest.mark.parallel_lm_head
+def test_chunk_count_env_override(tp_group, monkeypatch):
+    """SPYRE_LM_HEAD_NUM_CHUNKS forces the chunk count regardless of weight size."""
+    from spyre_inference.custom_ops.lm_head_common import build_lm_head_matmul_state
+
+    torch.manual_seed(0)
+    weight = torch.randn(64 * 16, 8, dtype=torch.float16)
+
+    monkeypatch.setenv("SPYRE_LM_HEAD_NUM_CHUNKS", "4")
+    state = build_lm_head_matmul_state(weight, "test", torch.nn.Identity())
+    assert state.num_chunks == 4
+
+    monkeypatch.setenv("SPYRE_LM_HEAD_NUM_CHUNKS", "1")
+    state = build_lm_head_matmul_state(weight, "test", torch.nn.Identity())
+    assert state.num_chunks == 1
+
+
+@pytest.mark.spyre
+@pytest.mark.parallel_lm_head
+def test_chunk_count_size_heuristic(tp_group, monkeypatch):
+    """Without an env override, small weights stay single-chunk; big ones split."""
+    from spyre_inference.custom_ops.lm_head_common import build_lm_head_matmul_state
+
+    monkeypatch.delenv("SPYRE_LM_HEAD_NUM_CHUNKS", raising=False)
+    monkeypatch.setenv("SPYRE_LM_HEAD_SINGLE_THRESHOLD_MIB", "1")
+    monkeypatch.setenv("SPYRE_LM_HEAD_DEFAULT_CHUNKS", "4")
+
+    small = torch.randn(64, 8, dtype=torch.float16)  # 1 KiB
+    state = build_lm_head_matmul_state(small, "small", torch.nn.Identity())
+    assert state.num_chunks == 1
+
+    big = torch.randn(64 * 16, 4096, dtype=torch.float16)  # 8 MiB > 1 MiB
+    state = build_lm_head_matmul_state(big, "big", torch.nn.Identity())
+    assert state.num_chunks == 4
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description
Run Qwen3-8B on Spyre via the spyre-inference plugin.

Problem
-------
Qwen3-8B's lm_head matmul (vocab=151936 x hidden=4096, fp16) exceeds torch-spyre's per-core EAR span limit (~256 MB; see torch_spyre/_inductor/work_division.py). A single F.linear at this size aborts during compilation with SIGABRT, so the model never starts.

Solution
--------
Add a shared LmHeadMatmulState in custom_ops/lm_head_common.py that splits the lm_head weight along the vocab dim into N padded sub-weights, runs one F.linear per chunk on Spyre, and concatenates the per-chunk logits on CPU. Each chunk is sized in 64-row sticks and padded to a multiple of 64*32 to satisfy torch-spyre's F.linear shape rules. The approach mirrors hf_adapters/hf_common.py chunk_lm_head.

SpyreParallelLMHead is reworked to materialize the chunked state in process_weights_after_loading (via SpyreUnquantizedLMHeadMethod) and dispatch forward_oot through forward_lm_head_oot. For the single-chunk no-padding case, the chunk aliases layer.weight so we don't allocate a second vocab-sized tensor.

Knobs
-----
- SPYRE_LM_HEAD_NUM_CHUNKS         override chunk count (e.g. "1", "8")
- SPYRE_LM_HEAD_SINGLE_THRESHOLD_MIB  single-chunk size cap (default 200)
- SPYRE_LM_HEAD_DEFAULT_CHUNKS     chunk count when over the cap (default 8)

## Related Issues
Fixes #212

<!-- Link related issues, e.g., `Fixes #` or `Relates to #456` -->

## Test Plan
- tests/test_parallel_lm_head.py: chunked matmul matches reference F.linear for 1/2/4/8 chunks, uneven splits, env override, and the size heuristic.

Verified on the dev box: Qwen3-8B loads and generates with VLLM_CPU_KVCACHE_SPACE=4 SPYRE_LM_HEAD_NUM_CHUNKS=8.

## Checklist

- [x] I have read the [contributing guidelines](https://torch-spyre.github.io/spyre-inference/contributing/)
- [x] My code follows the project's code style (run `bash format.sh`)
- [x] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
