### PR TITLE
[Custom Ops] Implement TP in linear layers

### DIFF
--- a/spyre_inference/custom_ops/linear.py
+++ b/spyre_inference/custom_ops/linear.py
@@ -33,7 +33,7 @@ Spyre Device Constraints:
     - Computations performed in torch.float16:
       Input (dtype defined by model / user) converted to torch.float16 for
       operations on spyre and then converted back to original dtype for cpu.
-    - Tensor parallelism: TP=1 assumed (single Spyre device)
+    - Tensor parallelism: TP>=1 supported with all_reduce collectives
 
 References:
     - Upstream linear layers:   vllm/model_executor/layers/linear.py
@@ -42,6 +42,10 @@ References:
 import torch.nn.functional as F
 
 from vllm.logger import init_logger
+
+from spyre_inference.distributed.spyre_communicator import (
+    _spyre_collective_unsupported_message,
+)
 from vllm.model_executor.layers.linear import (
     MergedColumnParallelLinear,
     QKVParallelLinear,
@@ -58,7 +62,7 @@ class SpyreUnquantizedLinearMethod(UnquantizedLinearMethod):
     """Spyre-specific linear method: F.linear without platform GEMM dispatch.
 
     Replaces the default UnquantizedLinearMethod so that upstream forward()
-    methods work unchanged on Spyre at TP=1.
+    methods work unchanged on Spyre at any TP size.
 
     - create_weights() is inherited — standard ModelWeightParameter works.
     - apply() does F.linear directly (no platform-specific GEMM dispatch).
@@ -73,31 +77,67 @@ class SpyreUnquantizedLinearMethod(UnquantizedLinearMethod):
 
 
 class SpyreLinearBase:
-    """Shared initialization for Spyre linear layers at TP=1."""
+    """Shared initialization for Spyre linear layers supporting TP>=1."""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if self.tp_size > 1:
-            raise NotImplementedError(
-                f"{self.__class__.__name__} only supports TP=1, got TP={self.tp_size}"
-            )
 
         if isinstance(self.quant_method, UnquantizedLinearMethod):
             self.quant_method = SpyreUnquantizedLinearMethod()
 
+        logger.debug_once(
+            "Initialized %s with TP=%d, rank=%d",
+            self.__class__.__name__,
+            self.tp_size,
+            self.tp_rank,
+        )
+
 
 @MergedColumnParallelLinear.register_oot(name="MergedColumnParallelLinear")
 class SpyreMergedColumnParallelLinear(SpyreLinearBase, MergedColumnParallelLinear):
-    """Spyre MergedColumnParallelLinear (TP=1 only)."""
+    """Spyre MergedColumnParallelLinear with TP support.
+
+    Supports TP>=1 with weight sharding along output dimension.
+    Note: gather_output is not supported (all_gather not yet implemented).
+    Outputs remain sharded across ranks.
+    """
+
+    def forward(self, input_):
+        if self.gather_output and self.tp_size > 1:
+            raise NotImplementedError(
+                _spyre_collective_unsupported_message(
+                    "allgather",
+                    self.tp_size,
+                    blocker="libspyre_comms list-form allgather + torch-spyre",
+                )
+            )
+        return super().forward(input_)
 
 
 @QKVParallelLinear.register_oot(name="QKVParallelLinear")
 class SpyreQKVParallelLinear(SpyreLinearBase, QKVParallelLinear):
-    """Spyre QKVParallelLinear (TP=1 only)."""
+    """Spyre QKVParallelLinear with TP support.
+
+    Supports TP>=1 with weight sharding for Q, K, V projections.
+    Performs device transfers (D2H) after F.linear since downstream .split()
+    cannot handle strided views on Spyre.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # QKVParallelLinear hardcodes gather_output=False; all_gather is not yet
+        # supported on Spyre, so we rely on this invariant holding.
+        assert not self.gather_output, (
+            f"{self.__class__.__name__} requires gather_output=False; "
+            "all_gather is not yet supported on Spyre"
+        )
 
     def forward(self, input_):
         result = super().forward(input_)
-        # D2H before downstream .split() — Spyre can't handle strided views
+        # D2H so that GraniteAttention's qkv.split() and the subsequent
+        # v.view() + kv_cache scatter-write run on CPU. Spyre rejects a
+        # non-contiguous tensor as a scatter source; see
+        # test_spyre_strided_scatter_source for the minimal reproduction.
         if self.return_bias:
             return convert(result[0], device="cpu"), result[1]
         return convert(result, device="cpu")
@@ -105,11 +145,13 @@ class SpyreQKVParallelLinear(SpyreLinearBase, QKVParallelLinear):
 
 @RowParallelLinear.register_oot(name="RowParallelLinear")
 class SpyreRowParallelLinear(SpyreLinearBase, RowParallelLinear):
-    """Spyre RowParallelLinear (TP=1 only).
-    RowParallelLinear is currently invoked from `GraniteAttention` where
-    `input_` is on `cpu` and from `GraniteMLP` where `input_` is on spyre.
-    Thus, we always convert the `input_` to `spyre`, which is a NoOp in
-    case of `GraniteMLP`.
+    """Spyre RowParallelLinear with TP support.
+
+    Supports TP>=1 with weight sharding along input dimension and
+    all_reduce for aggregating results across ranks when reduce_results=True.
+
+    RowParallelLinear is invoked from GraniteAttention (input on cpu) and
+    GraniteMLP (input on spyre); H2D is a no-op in the latter case.
     """
 
     def forward(self, input_):

--- a/spyre_inference/custom_ops/linear.py
+++ b/spyre_inference/custom_ops/linear.py
@@ -43,9 +43,6 @@ import torch.nn.functional as F
 
 from vllm.logger import init_logger
 
-from spyre_inference.distributed.spyre_communicator import (
-    _spyre_collective_unsupported_message,
-)
 from vllm.model_executor.layers.linear import (
     MergedColumnParallelLinear,
     QKVParallelLinear,
@@ -97,21 +94,9 @@ class SpyreLinearBase:
 class SpyreMergedColumnParallelLinear(SpyreLinearBase, MergedColumnParallelLinear):
     """Spyre MergedColumnParallelLinear with TP support.
 
-    Supports TP>=1 with weight sharding along output dimension.
-    Note: gather_output is not supported (all_gather not yet implemented).
-    Outputs remain sharded across ranks.
+    Supports TP>=1 with weight sharding along output dimension. Inherits
+    forward() unchanged; the SpyreLinearBase mixin swaps in SpyreUnquantizedLinearMethod.
     """
-
-    def forward(self, input_):
-        if self.gather_output and self.tp_size > 1:
-            raise NotImplementedError(
-                _spyre_collective_unsupported_message(
-                    "allgather",
-                    self.tp_size,
-                    blocker="libspyre_comms list-form allgather + torch-spyre",
-                )
-            )
-        return super().forward(input_)
 
 
 @QKVParallelLinear.register_oot(name="QKVParallelLinear")

--- a/spyre_inference/distributed/spyre_communicator.py
+++ b/spyre_inference/distributed/spyre_communicator.py
@@ -156,21 +156,6 @@ class SpyreCommunicator(DeviceCommunicatorBase):
         dist.broadcast(input_, src=self.ranks[0], group=self.device_group)
         return input_
 
-    def all_gather(self, input_: torch.Tensor, dim: int = -1) -> torch.Tensor:
-        # REPLACE-WITH-NATIVE: when libspyre_comms exposes the list-form
-        # SpyreCommsContext::allgather (and torch-spyre's spyreccl backend
-        # wires up `_allgather_base`), delete this override and let the
-        # base class use `dist.all_gather_into_tensor`.
-        if self.world_size == 1:
-            return input_
-        raise NotImplementedError(
-            _spyre_collective_unsupported_message(
-                "allgather",
-                self.world_size,
-                blocker="libspyre_comms list-form allgather + torch-spyre _allgather_base",
-            )
-        )
-
     def gather(self, input_: torch.Tensor, dst: int = 0, dim: int = -1) -> torch.Tensor | None:
         # REPLACE-WITH-NATIVE: when libspyre_comms supports gather natively,
         # delete this override.

--- a/spyre_inference/distributed/spyre_communicator.py
+++ b/spyre_inference/distributed/spyre_communicator.py
@@ -156,11 +156,35 @@ class SpyreCommunicator(DeviceCommunicatorBase):
         dist.broadcast(input_, src=self.ranks[0], group=self.device_group)
         return input_
 
+    def all_gather(self, input_: torch.Tensor, dim: int = -1) -> torch.Tensor:
+        # CPU tensors dispatch through the gloo half of the multi-backend
+        # `cpu:gloo,spyre:spyreccl` device_group, which implements allgather
+        # fine. Only spyre tensors hit the spyreccl gap, so guard on device.
+        # REPLACE-WITH-NATIVE: when libspyre_comms exposes the list-form
+        # SpyreCommsContext::allgather (and torch-spyre's spyreccl backend
+        # wires up `_allgather_base`), delete this override and let the
+        # base class use `dist.all_gather_into_tensor`.
+        if self.world_size == 1:
+            return input_
+        if input_.device.type == "cpu":
+            return super().all_gather(input_, dim)
+        raise NotImplementedError(
+            _spyre_collective_unsupported_message(
+                "allgather",
+                self.world_size,
+                blocker="libspyre_comms list-form allgather + torch-spyre _allgather_base",
+            )
+        )
+
     def gather(self, input_: torch.Tensor, dst: int = 0, dim: int = -1) -> torch.Tensor | None:
+        # CPU tensors dispatch through gloo on the multi-backend device_group;
+        # only spyre tensors need the spyreccl native gather we don't have yet.
         # REPLACE-WITH-NATIVE: when libspyre_comms supports gather natively,
         # delete this override.
         if self.world_size == 1:
             return input_
+        if input_.device.type == "cpu":
+            return super().gather(input_, dst, dim)
         raise NotImplementedError(
             _spyre_collective_unsupported_message(
                 "gather",

--- a/tests/probes/tp_probe.py
+++ b/tests/probes/tp_probe.py
@@ -160,6 +160,146 @@ def probe_native_gather(device, device_group, world_size, rank):
             )
 
 
+def probe_merged_column_parallel_linear(device, device_group, world_size, rank):
+    """TP=N MergedColumnParallelLinear forward vs single-rank F.linear.
+    Constructs MergedColumnParallelLinear (OOT-swapped to SpyreMergedColumnParallelLinear),
+    loads each rank's output-dim shard from deterministic full weight, runs
+    forward, and asserts the result matches single-rank F.linear.
+
+    """
+    import torch.nn.functional as F
+    from vllm.model_executor.layers.linear import MergedColumnParallelLinear
+
+    from spyre_inference.custom_ops.linear import SpyreMergedColumnParallelLinear
+    from spyre_inference.custom_ops.utils import convert
+
+    input_size = 512
+    output_size = 1024
+
+    layer = MergedColumnParallelLinear(
+        input_size,
+        [output_size],
+        bias=False,
+        params_dtype=torch.float16,
+        gather_output=False,
+    )
+    assert isinstance(layer, SpyreMergedColumnParallelLinear), type(layer)
+
+    torch.manual_seed(42)
+    full_weight = torch.randn(output_size, input_size, dtype=torch.float16) * 0.02
+
+    output_size_per_partition = output_size // world_size
+    start = rank * output_size_per_partition
+    end = (rank + 1) * output_size_per_partition
+    layer.weight.data.copy_(full_weight[start:end])
+    layer.to(device)
+
+    torch.manual_seed(7)
+    x = torch.randn(16, input_size, dtype=torch.float16)
+
+    out, bias = layer(convert(x, device=device))
+    out = convert(out, device="cpu")
+    expected_full = F.linear(x, full_weight)
+    expected = expected_full[:, start:end]
+    torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+    dist.barrier(device_ids=[device.index])
+
+
+def probe_qkv_parallel_linear(device, device_group, world_size, rank):
+    """TP=N SpyreQKVParallelLinear forward vs single-rank F.linear.
+
+    Constructs QKVParallelLinear (OOT-swapped to SpyreQKVParallelLinear),
+    loads each rank's Q/K/V shard from deterministic full weight, runs
+    forward with gather_output=False, and asserts the result
+    matches single-rank F.linear.
+    """
+    import torch.nn.functional as F
+    from vllm.model_executor.layers.linear import QKVParallelLinear
+
+    from spyre_inference.custom_ops.linear import SpyreQKVParallelLinear
+    from spyre_inference.custom_ops.utils import convert
+
+    hidden_size = 512
+    num_heads = 8
+    head_dim = 64
+    total_num_heads = num_heads  # total_num_heads = num_heads + 2 * num_kv_heads
+
+    layer = QKVParallelLinear(
+        hidden_size,
+        head_dim,
+        total_num_heads,
+        bias=False,
+        params_dtype=torch.float16,
+    )
+    assert isinstance(layer, SpyreQKVParallelLinear), type(layer)
+
+    actual_output_size = layer.weight.shape[0] * world_size
+
+    torch.manual_seed(43)
+    full_weight = torch.randn(actual_output_size, hidden_size, dtype=torch.float16) * 0.02
+
+    qkv_size_per_partition = actual_output_size // world_size
+    start = rank * qkv_size_per_partition
+    end = (rank + 1) * qkv_size_per_partition
+    layer.weight.data.copy_(full_weight[start:end])
+    layer.to(device)
+
+    torch.manual_seed(8)
+    x = torch.randn(16, hidden_size, dtype=torch.float16)
+
+    out, bias = layer(convert(x, device=device))
+    out = convert(out, device="cpu")
+    expected_full = F.linear(x, full_weight)
+    expected = expected_full[:, start:end]
+    torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+    dist.barrier(device_ids=[device.index])
+
+
+def probe_row_parallel_linear(device, device_group, world_size, rank):
+    """TP=N SpyreRowParallelLinear forward vs single-rank F.linear.
+
+    Constructs RowParallelLinear (OOT-swapped to SpyreRowParallelLinear),
+    loads each rank's input-dim shard from deterministic full weight, runs
+    forward, and asserts the all-reduced result matches single-rank F.linear
+    (modulo float16 all_reduce noise).
+    """
+    import torch.nn.functional as F
+    from vllm.model_executor.layers.linear import RowParallelLinear
+
+    from spyre_inference.custom_ops.linear import SpyreRowParallelLinear
+    from spyre_inference.custom_ops.utils import convert
+
+    input_size = 1024
+    output_size = 512
+
+    layer = RowParallelLinear(
+        input_size,
+        output_size,
+        bias=False,
+        params_dtype=torch.float16,
+    )
+    assert isinstance(layer, SpyreRowParallelLinear), type(layer)
+
+    torch.manual_seed(44)
+    full_weight = torch.randn(output_size, input_size, dtype=torch.float16) * 0.02
+
+    input_size_per_partition = input_size // world_size
+    start = rank * input_size_per_partition
+    end = (rank + 1) * input_size_per_partition
+    layer.weight.data.copy_(full_weight[:, start:end])
+    layer.to(device)
+
+    torch.manual_seed(9)
+    x_full = torch.randn(16, input_size, dtype=torch.float16)
+    x = x_full[:, start:end]
+
+    out, bias = layer(convert(x, device=device))
+    out = convert(out, device="cpu")
+    expected = F.linear(x_full, full_weight)
+    torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+    dist.barrier(device_ids=[device.index])
+
+
 PROBES = {
     "tp_all_reduce": probe_tp_all_reduce,
     "native_all_reduce": probe_native_all_reduce,
@@ -167,6 +307,9 @@ PROBES = {
     "native_all_gather_list": probe_native_all_gather_list,
     "native_gather": probe_native_gather,
     "vocab_parallel_embedding": probe_vocab_parallel_embedding,
+    "merged_column_parallel_linear": probe_merged_column_parallel_linear,
+    "qkv_parallel_linear": probe_qkv_parallel_linear,
+    "row_parallel_linear": probe_row_parallel_linear,
 }
 
 

--- a/tests/probes/tp_probe.py
+++ b/tests/probes/tp_probe.py
@@ -161,11 +161,14 @@ def probe_native_gather(device, device_group, world_size, rank):
 
 
 def probe_merged_column_parallel_linear(device, device_group, world_size, rank):
-    """TP=N MergedColumnParallelLinear forward vs single-rank F.linear.
-    Constructs MergedColumnParallelLinear (OOT-swapped to SpyreMergedColumnParallelLinear),
-    loads each rank's output-dim shard from deterministic full weight, runs
-    forward, and asserts the result matches single-rank F.linear.
+    """TP=N SpyreMergedColumnParallelLinear forward vs single-rank F.linear.
 
+    Models the gate_up_proj usage: output_sizes=[gate, up], so the per-rank
+    weight is [gate_shard | up_shard] stacked rows-wise (each shard is the
+    rank's slice of the corresponding full matrix). The expected output is
+    the per-shard F.linear results concatenated along the output dim — a
+    naive contiguous row-slice would mask a layout bug, so we build the
+    weight shard-by-shard.
     """
     import torch.nn.functional as F
     from vllm.model_executor.layers.linear import MergedColumnParallelLinear
@@ -174,33 +177,35 @@ def probe_merged_column_parallel_linear(device, device_group, world_size, rank):
     from spyre_inference.custom_ops.utils import convert
 
     input_size = 512
-    output_size = 1024
+    output_size = 1024  # per-shard size (gate, up)
 
     layer = MergedColumnParallelLinear(
         input_size,
-        [output_size],
+        [output_size, output_size],
         bias=False,
         params_dtype=torch.float16,
-        gather_output=False,
     )
     assert isinstance(layer, SpyreMergedColumnParallelLinear), type(layer)
 
     torch.manual_seed(42)
-    full_weight = torch.randn(output_size, input_size, dtype=torch.float16) * 0.02
+    gate_full = torch.randn(output_size, input_size, dtype=torch.float16) * 0.02
+    up_full = torch.randn(output_size, input_size, dtype=torch.float16) * 0.02
 
-    output_size_per_partition = output_size // world_size
-    start = rank * output_size_per_partition
-    end = (rank + 1) * output_size_per_partition
-    layer.weight.data.copy_(full_weight[start:end])
+    shard = output_size // world_size
+    start = rank * shard
+    end = (rank + 1) * shard
+    layer.weight.data.copy_(torch.cat([gate_full[start:end], up_full[start:end]], dim=0))
     layer.to(device)
 
     torch.manual_seed(7)
     x = torch.randn(16, input_size, dtype=torch.float16)
 
-    out, bias = layer(convert(x, device=device))
+    out, _ = layer(convert(x, device=device))
     out = convert(out, device="cpu")
-    expected_full = F.linear(x, full_weight)
-    expected = expected_full[:, start:end]
+    expected = torch.cat(
+        [F.linear(x, gate_full)[:, start:end], F.linear(x, up_full)[:, start:end]],
+        dim=-1,
+    )
     torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
     dist.barrier(device_ids=[device.index])
 
@@ -208,10 +213,13 @@ def probe_merged_column_parallel_linear(device, device_group, world_size, rank):
 def probe_qkv_parallel_linear(device, device_group, world_size, rank):
     """TP=N SpyreQKVParallelLinear forward vs single-rank F.linear.
 
-    Constructs QKVParallelLinear (OOT-swapped to SpyreQKVParallelLinear),
-    loads each rank's Q/K/V shard from deterministic full weight, runs
-    forward with gather_output=False, and asserts the result
-    matches single-rank F.linear.
+    Uses GQA shape (total_num_heads != total_num_kv_heads) so a naive
+    "slice the full weight row-wise per rank" load — which would pass for
+    MHA — actually mismatches the real per-rank `[Q | K | V]` layout.
+    The probe loads each shard from its corresponding full Q/K/V matrix
+    using the same head/replica math QKVParallelLinear performs in
+    __init__, then asserts each rank's output matches the concatenation
+    of per-shard F.linear results.
     """
     import torch.nn.functional as F
     from vllm.model_executor.layers.linear import QKVParallelLinear
@@ -220,37 +228,64 @@ def probe_qkv_parallel_linear(device, device_group, world_size, rank):
     from spyre_inference.custom_ops.utils import convert
 
     hidden_size = 512
-    num_heads = 8
-    head_dim = 64
-    total_num_heads = num_heads  # total_num_heads = num_heads + 2 * num_kv_heads
+    head_size = 64
+    total_num_heads = 8
+    total_num_kv_heads = 2  # GQA: kv heads < query heads
 
     layer = QKVParallelLinear(
         hidden_size,
-        head_dim,
+        head_size,
         total_num_heads,
+        total_num_kv_heads=total_num_kv_heads,
         bias=False,
         params_dtype=torch.float16,
     )
     assert isinstance(layer, SpyreQKVParallelLinear), type(layer)
 
-    actual_output_size = layer.weight.shape[0] * world_size
+    # Mirror QKVParallelLinear.__init__ partitioning math.
+    num_heads = total_num_heads // world_size
+    if world_size >= total_num_kv_heads:
+        num_kv_heads = 1
+        num_kv_head_replicas = world_size // total_num_kv_heads
+    else:
+        num_kv_heads = total_num_kv_heads // world_size
+        num_kv_head_replicas = 1
+    assert layer.num_heads == num_heads
+    assert layer.num_kv_heads == num_kv_heads
+    assert layer.num_kv_head_replicas == num_kv_head_replicas
+
+    q_full_rows = total_num_heads * head_size
+    kv_full_rows = total_num_kv_heads * head_size
 
     torch.manual_seed(43)
-    full_weight = torch.randn(actual_output_size, hidden_size, dtype=torch.float16) * 0.02
+    q_full = torch.randn(q_full_rows, hidden_size, dtype=torch.float16) * 0.02
+    k_full = torch.randn(kv_full_rows, hidden_size, dtype=torch.float16) * 0.02
+    v_full = torch.randn(kv_full_rows, hidden_size, dtype=torch.float16) * 0.02
 
-    qkv_size_per_partition = actual_output_size // world_size
-    start = rank * qkv_size_per_partition
-    end = (rank + 1) * qkv_size_per_partition
-    layer.weight.data.copy_(full_weight[start:end])
+    q_start = rank * num_heads * head_size
+    q_end = q_start + num_heads * head_size
+    kv_shard_idx = rank // num_kv_head_replicas
+    kv_start = kv_shard_idx * num_kv_heads * head_size
+    kv_end = kv_start + num_kv_heads * head_size
+
+    q_shard = q_full[q_start:q_end]
+    k_shard = k_full[kv_start:kv_end]
+    v_shard = v_full[kv_start:kv_end]
+    layer.weight.data.copy_(torch.cat([q_shard, k_shard, v_shard], dim=0))
     layer.to(device)
 
     torch.manual_seed(8)
     x = torch.randn(16, hidden_size, dtype=torch.float16)
 
-    out, bias = layer(convert(x, device=device))
-    out = convert(out, device="cpu")
-    expected_full = F.linear(x, full_weight)
-    expected = expected_full[:, start:end]
+    out, _ = layer(convert(x, device=device))
+    expected = torch.cat(
+        [
+            F.linear(x, q_shard),
+            F.linear(x, k_shard),
+            F.linear(x, v_shard),
+        ],
+        dim=-1,
+    )
     torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
     dist.barrier(device_ids=[device.index])
 

--- a/tests/test_distributed_tp2.py
+++ b/tests/test_distributed_tp2.py
@@ -87,21 +87,26 @@ def test_tp2_vocab_parallel_embedding(run_tp_probe) -> None:
     _spyre_device_count() < 2,
     reason="needs >=2 Spyre cards; skipping TP=2 distributed test",
 )
-def test_tp_linear_layers(run_tp_probe) -> None:
-    """End-to-end TP=2 test of all Spyre linear layers on Spyre cards.
+@pytest.mark.parametrize(
+    "probe",
+    [
+        "merged_column_parallel_linear",
+        "qkv_parallel_linear",
+        "row_parallel_linear",
+    ],
+)
+def test_tp_linear_layers(run_tp_probe, probe: str) -> None:
+    """End-to-end TP=2 test of a Spyre linear layer on Spyre cards.
 
     Spawns one subprocess per rank, running through vllm's real
     `init_worker_distributed_environment` against a real `VllmConfig`,
-    then verifies all three linear layer types return numerically correct
-    results on TP=2 with Spyre communication:
-
-    1. SpyreMergedColumnParallelLinear - output sharding
-    2. SpyreQKVParallelLinear - Q/K/V sharding
-    3. SpyreRowParallelLinear - input sharding
+    then verifies the layer returns numerically correct results on
+    TP=2 with Spyre communication. Parametrized over the three layer
+    types: SpyreMergedColumnParallelLinear (output sharding),
+    SpyreQKVParallelLinear (Q/K/V sharding), and SpyreRowParallelLinear
+    (input sharding).
     """
-    run_tp_probe("merged_column_parallel_linear", world_size=2)
-    run_tp_probe("qkv_parallel_linear", world_size=2)
-    run_tp_probe("row_parallel_linear", world_size=2)
+    run_tp_probe(probe, world_size=2)
 
 
 @pytest.mark.spyre

--- a/tests/test_distributed_tp2.py
+++ b/tests/test_distributed_tp2.py
@@ -87,6 +87,29 @@ def test_tp2_vocab_parallel_embedding(run_tp_probe) -> None:
     _spyre_device_count() < 2,
     reason="needs >=2 Spyre cards; skipping TP=2 distributed test",
 )
+def test_tp_linear_layers(run_tp_probe) -> None:
+    """End-to-end TP=2 test of all Spyre linear layers on Spyre cards.
+
+    Spawns one subprocess per rank, running through vllm's real
+    `init_worker_distributed_environment` against a real `VllmConfig`,
+    then verifies all three linear layer types return numerically correct
+    results on TP=2 with Spyre communication:
+
+    1. SpyreMergedColumnParallelLinear - output sharding
+    2. SpyreQKVParallelLinear - Q/K/V sharding
+    3. SpyreRowParallelLinear - input sharding
+    """
+    run_tp_probe("merged_column_parallel_linear", world_size=2)
+    run_tp_probe("qkv_parallel_linear", world_size=2)
+    run_tp_probe("row_parallel_linear", world_size=2)
+
+
+@pytest.mark.spyre
+@pytest.mark.uses_subprocess
+@pytest.mark.skipif(
+    _spyre_device_count() < 2,
+    reason="needs >=2 Spyre cards; skipping TP=2 distributed test",
+)
 @pytest.mark.xfail(
     strict=True,
     reason=(

--- a/tests/test_mlp.py
+++ b/tests/test_mlp.py
@@ -159,6 +159,51 @@ def test_row_parallel_matches_reference(tp_group, num_tokens, input_size, output
 
 
 @pytest.mark.spyre
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Spyre cannot use a strided tensor as the source of an indexed scatter. "
+        "After qkv.split(), v is a strided view; Attention.forward() then calls "
+        "v.view(-1, num_kv_heads, head_size) which produces a non-contiguous 3D "
+        "tensor (strides [Q+2K, head_size, 1] instead of [K, head_size, 1]). "
+        "SpyreAttentionImpl._write_to_kv_cache then does "
+        "kv_cache[block_indices, 1, block_offsets] = value with that strided source. "
+        "SpyreQKVParallelLinear.forward() works around this with a D2H before "
+        "returning so the split and view run on CPU. "
+        "When this flips to passing, remove the D2H workaround from "
+        "SpyreQKVParallelLinear.forward()."
+    ),
+)
+def test_spyre_strided_scatter_source():
+    """Probe: Spyre accepts a non-contiguous tensor as a scatter-write source.
+
+    The failure path when D2H is removed from SpyreQKVParallelLinear:
+      1. qkv.split()        → strided 2D Spyre views
+      2. v.view(-1, H, D)   → non-contiguous 3D Spyre tensor (Attention.forward)
+      3. kv_cache[idx] = v  → scatter write with strided source (_write_to_kv_cache)
+    """
+    device = torch.device("spyre")
+    dtype = torch.float16
+    num_tokens = 16
+    num_heads, num_kv_heads, head_size = 8, 2, 64
+    q_size, kv_size = num_heads * head_size, num_kv_heads * head_size
+
+    qkv = torch.randn(num_tokens, q_size + 2 * kv_size, dtype=dtype, device=device)
+    _, _, v = qkv.split([q_size, kv_size, kv_size], dim=-1)
+    # Replicate what Attention.forward() does before calling impl.forward()
+    v = v.view(-1, num_kv_heads, head_size)
+
+    # Replicate _write_to_kv_cache's scatter write
+    num_blocks, block_size = 4, 8
+    kv_cache = torch.zeros(
+        num_blocks, 2, block_size, num_kv_heads, head_size, dtype=dtype, device=device
+    )
+    block_indices = torch.zeros(num_tokens, dtype=torch.long, device=device)
+    block_offsets = torch.arange(num_tokens, dtype=torch.long, device=device) % block_size
+    kv_cache[block_indices, 1, block_offsets] = v
+
+
+@pytest.mark.spyre
 @pytest.mark.mlp
 def test_linear_oot_registration(tp_group):
     """Verify OOT class swaps for all three linear layer types."""


### PR DESCRIPTION
## Description
This PR adds support for tensor Parallelism in linear layers. Note once `all_gather` is supported `SpyreMergedColumnParallelLinear` can be removed as its a mirror copy of upstream vllm just adding the runtime warning of all_gather not supported.

all_gather not being supported is not a blocker for most LLMs as gather_output param in model code in vllm have set it to false. This will only effect vision models and MTP models like gemma4 and some qwen 3.5 models
## Related Issues
resolves #134 
## Test Plan
Unit tests have been written and are passing
## Checklist

- [x] I have read the [contributing guidelines](https://torch-spyre.github.io/spyre-inference/contributing/)
- [x] My code follows the project's code style (run `bash format.sh`)
- [x] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
