### PR TITLE
ci-cd: reenable tests for hugging face models by using the new runner set with access to the cache in persistent storage

### DIFF
--- a/.github/workflows/test_each_commit.yaml
+++ b/.github/workflows/test_each_commit.yaml
@@ -26,7 +26,7 @@ jobs:
     name: 'build and run tests'
     runs-on:
       - x86_64
-      - spyre_pf_x1
+      - spyre_pf_x1__pvc_1tb_x1
       - linux
       - image_spyre_inference
     timeout-minutes: 720
@@ -39,6 +39,8 @@ jobs:
       CI: ''
       CLONED_TORCH_SPYRE_DIR: /home/senuser/torch-spyre
       CLONED_SPYRE_INFERENCE_DIR: /home/senuser/spyre-inference
+      STORAGE_1_DIR: /storage-1/spyre-inference
+      HF_HOME: /storage-1/spyre-inference/.cache/huggingface
 
     steps:
       - name: Checkout PR branch/commit in pre-cloned spyre-inference

--- a/tests/plugin/spyre_testing_plugin/upstream_tests.yaml
+++ b/tests/plugin/spyre_testing_plugin/upstream_tests.yaml
@@ -74,7 +74,7 @@ tests:
     - rel_path: tests/v1/attention/test_attention_backends.py
       allow_list:
         - test: "test_causal_backend_correctness"
-          mode: xfail
+          mode: mandatory_pass
           tags: [attention, upstream]
           params:
             allow:  # We only support TP=1, BS=1


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Use the PVC runner set so we can cache the HF models in persistent storage

## Related Issues

<!-- Link related issues, e.g., `Fixes #` or `Relates to #456` -->

## Test Plan

<!-- Describe how you tested your changes. Include commands or steps to reproduce. -->

## Checklist

- [ ] I have read the [contributing guidelines](https://torch-spyre.github.io/spyre-inference/contributing/)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
