### PR TITLE
Remove uninformative debug prints from custom_ops

### DIFF
--- a/spyre_inference/custom_ops/parallel_lm_head.py
+++ b/spyre_inference/custom_ops/parallel_lm_head.py
@@ -108,8 +108,6 @@ class SpyreParallelLMHead(ParallelLMHead):
                 f"(tp_size={self.tp_size}). Only tp_size=1 is supported."
             )
 
-        logger.debug("Building custom ParallelLMHead for Spyre")
-
         # Set the custom quantization method to route through spyre
         self.quant_method = SpyreUnquantizedLMHeadMethod()
 

--- a/spyre_inference/custom_ops/rms_norm.py
+++ b/spyre_inference/custom_ops/rms_norm.py
@@ -74,8 +74,6 @@ class SpyreRMSNorm(RMSNorm):
         """
         super().__init__(*args, **kwargs)
 
-        logger.debug("Building custom RMS norm")
-
         self._target_device = torch.device("spyre")
         self._target_dtype = torch.float16
         self.maybe_compiled_forward_spyre = self.maybe_compile(self.forward_spyre)

--- a/spyre_inference/custom_ops/silu_and_mul.py
+++ b/spyre_inference/custom_ops/silu_and_mul.py
@@ -59,8 +59,6 @@ class SpyreSiluAndMul(SiluAndMul):
         """Initialize SpyreSiluAndMul layer."""
         super().__init__(*args, **kwargs)
 
-        logger.debug("Building custom SiluAndMul")
-
     def forward_oot(self, x: torch.Tensor) -> torch.Tensor:
         """Spyre-optimized SiLU and multiply activation (SwiGLU).
 


### PR DESCRIPTION
## Description

Removed generic 'Building custom X' debug statements that didn't provide useful diagnostic info.

## Related Issues

Closes #172

## Checklist

- [x] I have read the [contributing guidelines](https://torch-spyre.github.io/spyre-inference/contributing/)
- [x] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
