### PR TITLE
cicd: enable distributed tests

### DIFF
--- a/.github/workflows/test_each_commit.yaml
+++ b/.github/workflows/test_each_commit.yaml
@@ -23,12 +23,37 @@ permissions:
 
 jobs:
   test:
-    name: 'build and run tests'
-    runs-on:
-      - x86_64
-      - spyre_pf_x1__pvc_1tb_x1
-      - linux
-      - image_spyre_inference
+    name: 'build and run tests (${{ matrix.cfg }})'
+    strategy:
+      matrix:
+        include:
+          - cfg: Non-distributed spyre tests
+            runs_on:
+              - x86_64
+              - spyre_pf_x1__pvc_1tb_x1
+              - linux
+              - image_spyre_inference
+            flags: >-
+              -m "not (upstream or uses_subprocess)"
+          - cfg: Distributed spyre tests
+            runs_on:
+              - x86_64
+              - spyre_pf_x2__pvc_1tb_x1
+              - linux
+              - image_spyre_inference
+            env:
+              AIU_WORLD_SIZE: 2
+            flags: >-
+              -m "uses_subprocess and not (spyre or upstream)"
+          - cfg: Upstream vLLM tests
+            runs_on:
+              - x86_64
+              - spyre_pf_x1__pvc_1tb_x1
+              - linux
+              - image_spyre_inference
+            flags: >-
+              -m upstream
+    runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 720
     env:
       # The CI env var is very important.
@@ -98,25 +123,26 @@ jobs:
           uv sync \
             --frozen \
             --verbose \
-            --all-extras \
             --group dev
           # Print the resolved torch install for log visibility.
           uv pip show torch
           uv pip freeze
 
       - name: Run tests
+        env:
+          AIU_WORLD_SIZE: ${{ matrix.env.AIU_WORLD_SIZE }}
         run: |
           source "$HOME/.bashrc"
           source /etc/profile.d/ibm-aiu-setup.sh
           cd "$CLONED_SPYRE_INFERENCE_DIR"
-          echo "Running tests..."
-          uv run pytest -s -vvv
+          echo "Running tests for config: ${{ matrix.cfg }}..."
+          uv run pytest -s -vvv ${{ matrix.flags }}
           echo "tests done"
 
   # ---------------------------------------------------------------------------
   # Required check gate -- this job name must match the existing branch
   # protection rule: "tests / Run Spyre unit tests".
-  # It fans in all parallel jobs so the single required check
+  # It fans in all matrix jobs so the single required check
   # passes only when every suite passes.
   # ---------------------------------------------------------------------------
   run-spyre-unit-tests:
@@ -127,7 +153,7 @@ jobs:
     steps:
       - name: Check all suites passed
         run: |-
-          if [[ "${{ needs.test.result }}" != "success" ]]; then
+          if ${{ contains(needs.test.result, 'failure') || contains(needs.test.result, 'cancelled') }}; then
             echo "One or more test suites failed."
             exit 1
           fi

--- a/.github/workflows/test_each_commit.yaml
+++ b/.github/workflows/test_each_commit.yaml
@@ -34,17 +34,15 @@ jobs:
               - linux
               - image_spyre_inference
             flags: >-
-              -m "not (upstream or uses_subprocess)"
+              -m "not (distributed or upstream)"
           - cfg: Distributed spyre tests
             runs_on:
               - x86_64
               - spyre_pf_x2__pvc_1tb_x1
               - linux
               - image_spyre_inference
-            env:
-              AIU_WORLD_SIZE: 2
             flags: >-
-              -m "uses_subprocess and not (spyre or upstream)"
+              -m distributed
           - cfg: Upstream vLLM tests
             runs_on:
               - x86_64
@@ -129,9 +127,9 @@ jobs:
           uv pip freeze
 
       - name: Run tests
-        env:
-          AIU_WORLD_SIZE: ${{ matrix.env.AIU_WORLD_SIZE }}
         run: |
+          unset _IBM_AIU_SETUP
+          rm /tmp/etc/ibm/spyre/topo.json
           source "$HOME/.bashrc"
           source /etc/profile.d/ibm-aiu-setup.sh
           cd "$CLONED_SPYRE_INFERENCE_DIR"

--- a/.github/workflows/test_each_commit.yaml
+++ b/.github/workflows/test_each_commit.yaml
@@ -64,7 +64,7 @@ jobs:
       CLONED_SPYRE_INFERENCE_DIR: /home/senuser/spyre-inference
       STORAGE_1_DIR: /storage-1/spyre-inference
       HF_HOME: /storage-1/spyre-inference/.cache/huggingface
-      UV_CACHE_DIR: /storage-1/spyre-inference/.cache/uv
+      # UV_CACHE_DIR: /storage-1/spyre-inference/.cache/uv
 
     steps:
       - name: Checkout PR branch/commit in pre-cloned spyre-inference
@@ -121,6 +121,7 @@ jobs:
           uv sync \
             --frozen \
             --verbose \
+            --refresh \
             --group dev
           # Print the resolved torch install for log visibility.
           uv pip show torch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,8 +45,11 @@ uv sync --frozen
 # Development install with test dependencies
 uv sync --group dev
 
-# Run Spyre device tests
-uv run pytest -m spyre
+# Run all tests (cached in ~/.cache/vllm-upstream-tests)
+uv run pytest
+
+# Run distributed tests (cached in ~/.cache/vllm-upstream-tests)
+uv run pytest -m distributed
 
 # Run upstream vLLM tests (cached in ~/.cache/vllm-upstream-tests)
 uv run pytest -m upstream

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -48,7 +48,7 @@ Some useful overrides:
 
 ```bash
 # Run only local tests
-pytest -m spyre
+pytest
 
 # Run all upstream tests
 pytest -m upstream

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ extra-build-variables = { vllm = { VLLM_TARGET_DEVICE = "cpu" } }
 # NB: torch-spyre can only be compiled where `sendnn` is available
 [tool.uv.sources]
 vllm = { git = "https://github.com/vllm-project/vllm", rev = "v0.20.1" }
-torch-spyre = { git = "https://github.com/torch-spyre/torch-spyre", rev = "ee37a9de5aaa33995fcbeac36ca1b1131677ce6f" }
+torch-spyre = { git = "https://github.com/torch-spyre/torch-spyre", rev = "4dcfee15c3a9344652f067149ec65c4bf2941890" }
 torch = [
   { index = "pytorch-cpu" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,7 +223,7 @@ filterwarnings = [
 
 # --8<-- [start:test-markers-definition]
 markers = [
-    "spyre: Tests that require a Spyre device",
+    "distributed: Tests requiring multiple spyre cards",
     "upstream: Tests coming from upstream vLLM",
 ]
 # --8<-- [end:test-markers-definition]

--- a/tests/test_distributed_tp2.py
+++ b/tests/test_distributed_tp2.py
@@ -42,8 +42,10 @@ def _spyre_device_count() -> int:
 # test_tp2_llm_construction / test_tp2_llm_generate_matches_tp1 pass,
 # this test is redundant — delete it along with the xfail markers on
 # the LLM tests.
-@pytest.mark.spyre
+
+
 @pytest.mark.uses_subprocess
+@pytest.mark.distributed
 @pytest.mark.skipif(
     _spyre_device_count() < 2,
     reason="needs >=2 Spyre cards; skipping TP=2 distributed test",
@@ -59,8 +61,8 @@ def test_tp2_tensor_model_parallel_all_reduce(run_tp_probe) -> None:
     run_tp_probe("tp_all_reduce", world_size=2)
 
 
-@pytest.mark.spyre
 @pytest.mark.uses_subprocess
+@pytest.mark.distributed
 @pytest.mark.skipif(
     _spyre_device_count() < 2,
     reason="needs >=2 Spyre cards; skipping TP=2 distributed test",
@@ -81,8 +83,8 @@ def test_tp2_vocab_parallel_embedding(run_tp_probe) -> None:
     run_tp_probe("vocab_parallel_embedding", world_size=2)
 
 
-@pytest.mark.spyre
 @pytest.mark.uses_subprocess
+@pytest.mark.distributed
 @pytest.mark.skipif(
     _spyre_device_count() < 2,
     reason="needs >=2 Spyre cards; skipping TP=2 distributed test",
@@ -144,8 +146,8 @@ def test_tp2_llm_construction() -> None:
     )
 
 
-@pytest.mark.spyre
 @pytest.mark.uses_subprocess
+@pytest.mark.distributed
 @pytest.mark.skipif(
     _spyre_device_count() < 2,
     reason="needs >=2 Spyre cards; skipping TP=2 distributed test",

--- a/tests/test_mlp.py
+++ b/tests/test_mlp.py
@@ -21,7 +21,6 @@ import torch
 import torch.nn.functional as F
 
 
-@pytest.mark.spyre
 @pytest.mark.mlp
 @pytest.mark.parametrize("num_tokens", [1, 7, 64, 256])
 @pytest.mark.parametrize("hidden_size,intermediate_size", [(64, 128), (128, 256), (512, 1024)])
@@ -61,7 +60,6 @@ def test_merged_column_matches_reference(
     torch.testing.assert_close(actual.float(), expected.float(), atol=1e-2, rtol=1e-2)
 
 
-@pytest.mark.spyre
 @pytest.mark.mlp
 @pytest.mark.parametrize("num_tokens", [1, 7, 64, 256])
 @pytest.mark.parametrize(
@@ -114,7 +112,6 @@ def test_qkv_matches_reference(tp_group, num_tokens, num_heads, num_kv_heads, he
     torch.testing.assert_close(actual.float(), expected.float(), atol=1e-2, rtol=1e-2)
 
 
-@pytest.mark.spyre
 @pytest.mark.mlp
 @pytest.mark.parametrize("num_tokens", [1, 7, 64, 256])
 @pytest.mark.parametrize("input_size,output_size", [(128, 64), (256, 128), (1024, 512)])
@@ -158,7 +155,6 @@ def test_row_parallel_matches_reference(tp_group, num_tokens, input_size, output
     torch.testing.assert_close(actual.float(), expected.float(), atol=1e-2, rtol=1e-2)
 
 
-@pytest.mark.spyre
 @pytest.mark.xfail(
     strict=True,
     reason=(
@@ -203,7 +199,6 @@ def test_spyre_strided_scatter_source():
     kv_cache[block_indices, 1, block_offsets] = v
 
 
-@pytest.mark.spyre
 @pytest.mark.mlp
 def test_linear_oot_registration(tp_group):
     """Verify OOT class swaps for all three linear layer types."""

--- a/tests/test_parallel_lm_head.py
+++ b/tests/test_parallel_lm_head.py
@@ -32,7 +32,6 @@ def reference_lm_head(
     return F.linear(x, weight, bias)
 
 
-@pytest.mark.spyre
 @pytest.mark.parallel_lm_head
 @pytest.mark.parametrize("num_tokens", [1, 7, 64])
 @pytest.mark.parametrize("vocab_size", [64, 128, 49216, 51200])
@@ -79,7 +78,6 @@ def test_spyre_parallel_lm_head_matches_reference(tp_group, num_tokens, vocab_si
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.spyre
 @pytest.mark.parallel_lm_head
 @pytest.mark.padding_workaround
 @pytest.mark.parametrize(
@@ -140,7 +138,6 @@ def test_padded_weight_reflects_loaded_weight(
         )
 
 
-@pytest.mark.spyre
 @pytest.mark.parallel_lm_head
 def test_lm_head_oot_dispatch(tp_group):
     """Verify ParallelLMHead OOT registration: class swap + quant_method swap."""
@@ -158,7 +155,6 @@ def test_lm_head_oot_dispatch(tp_group):
     assert isinstance(layer.quant_method, SpyreUnquantizedLMHeadMethod)
 
 
-@pytest.mark.spyre
 @pytest.mark.parallel_lm_head
 @pytest.mark.padding_workaround
 def test_invalid_weight_shape_raises(tp_group):

--- a/tests/test_rms_norm.py
+++ b/tests/test_rms_norm.py
@@ -40,7 +40,6 @@ def reference_rms_norm(
     return x_normed
 
 
-@pytest.mark.spyre
 @pytest.mark.rmsnorm
 @pytest.mark.parametrize("batch_size", [1])
 # Hidden sizes that aren't multiples of 64 currently fail on CI with size errors
@@ -94,7 +93,6 @@ def mock_forward_oot_with_residual(x, residual=None):
     return 2 * x, 2 * residual
 
 
-@pytest.mark.spyre
 @pytest.mark.rmsnorm
 @pytest.mark.parametrize("use_residual", [False, True])
 def test_rmsnorm_oot_dispatch(monkeypatch, dummy_tensor, use_residual):

--- a/tests/test_silu_and_mul.py
+++ b/tests/test_silu_and_mul.py
@@ -32,7 +32,6 @@ def reference_silu_and_mul(x: torch.Tensor) -> torch.Tensor:
     return F.silu(x1) * x2
 
 
-@pytest.mark.spyre
 @pytest.mark.siluandmul
 @pytest.mark.parametrize("num_tokens", [1, 7, 63, 64, 65, 1024])
 @pytest.mark.parametrize("d", [2, 63, 64, 65, 1024, 13824])
@@ -67,7 +66,6 @@ def test_spyre_siluandmul_matches_reference(num_tokens, d, dtype):
     torch.testing.assert_close(actual, expected, atol=1e-2, rtol=1e-2)
 
 
-@pytest.mark.spyre
 @pytest.mark.siluandmul
 def test_siluandmul_oot_dispatch():
     """Verify SiluAndMul OOT registration: class swap"""

--- a/tests/test_spyre_comms_native_probes.py
+++ b/tests/test_spyre_comms_native_probes.py
@@ -53,8 +53,8 @@ def _spyre_device_count() -> int:
         return 0
 
 
-@pytest.mark.spyre
 @pytest.mark.uses_subprocess
+@pytest.mark.distributed
 @pytest.mark.skipif(
     _spyre_device_count() < 2,
     reason="needs >=2 Spyre cards; skipping TP=2 native-probe test",
@@ -71,8 +71,8 @@ def test_native_all_reduce_works(run_tp_probe) -> None:
     run_tp_probe("native_all_reduce", world_size=2)
 
 
-@pytest.mark.spyre
 @pytest.mark.uses_subprocess
+@pytest.mark.distributed
 @pytest.mark.skipif(
     _spyre_device_count() < 2,
     reason="needs >=2 Spyre cards; skipping TP=2 native-probe test",
@@ -91,8 +91,8 @@ def test_native_all_gather_into_tensor_works(run_tp_probe) -> None:
     run_tp_probe("native_all_gather_into_tensor", world_size=2)
 
 
-@pytest.mark.spyre
 @pytest.mark.uses_subprocess
+@pytest.mark.distributed
 @pytest.mark.skipif(
     _spyre_device_count() < 2,
     reason="needs >=2 Spyre cards; skipping TP=2 native-probe test",
@@ -109,8 +109,8 @@ def test_native_all_gather_list_works(run_tp_probe) -> None:
     run_tp_probe("native_all_gather_list", world_size=2)
 
 
-@pytest.mark.spyre
 @pytest.mark.uses_subprocess
+@pytest.mark.distributed
 @pytest.mark.skipif(
     _spyre_device_count() < 2,
     reason="needs >=2 Spyre cards; skipping TP=2 native-probe test",

--- a/tests/test_vllm_spyre_next.py
+++ b/tests/test_vllm_spyre_next.py
@@ -19,7 +19,7 @@ from vllm.config import AttentionConfig
 import pytest
 
 
-@pytest.mark.spyre
+@pytest.mark.uses_subprocess
 def test_basic_model_load():
     model = LLM(
         "ibm-ai-platform/micro-g3.3-8b-instruct-1b",

--- a/tests/test_vllm_spyre_next.py
+++ b/tests/test_vllm_spyre_next.py
@@ -20,7 +20,6 @@ import pytest
 
 
 @pytest.mark.spyre
-@pytest.mark.uses_subprocess
 def test_basic_model_load():
     model = LLM(
         "ibm-ai-platform/micro-g3.3-8b-instruct-1b",

--- a/tests/test_vocab_parallel_embedding.py
+++ b/tests/test_vocab_parallel_embedding.py
@@ -36,7 +36,6 @@ import torch
 import torch.nn.functional as F
 
 
-@pytest.mark.spyre
 @pytest.mark.vocab_parallel_embedding
 def test_vocab_parallel_embedding_oot_dispatch(tp_group):
     """VocabParallelEmbedding(...) instantiates SpyreVocabParallelEmbedding."""
@@ -51,7 +50,6 @@ def test_vocab_parallel_embedding_oot_dispatch(tp_group):
     assert isinstance(layer, SpyreVocabParallelEmbedding)
 
 
-@pytest.mark.spyre
 @pytest.mark.vocab_parallel_embedding
 @pytest.mark.parametrize("num_tokens", [1, 7, 64])
 @pytest.mark.parametrize("vocab_size", [128, 1024, 32000])
@@ -76,7 +74,6 @@ def test_tp1_forward_matches_reference(tp_group, num_tokens, vocab_size, embeddi
     torch.testing.assert_close(actual.float(), expected.float(), atol=1e-3, rtol=1e-3)
 
 
-@pytest.mark.spyre
 @pytest.mark.vocab_parallel_embedding
 @pytest.mark.parametrize("num_tokens", [1, 8, 32])
 @pytest.mark.parametrize("vocab_size", [1024, 32000])
@@ -145,7 +142,6 @@ def test_fake_tp2_forward_matches_reference(
 # on TP > 1.
 
 
-@pytest.mark.spyre
 @pytest.mark.xfail(
     strict=True,
     reason=(

--- a/uv.lock
+++ b/uv.lock
@@ -7374,7 +7374,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "torch", index = "https://download.pytorch.org/whl/cpu" },
-    { name = "torch-spyre", git = "https://github.com/torch-spyre/torch-spyre?rev=ee37a9de5aaa33995fcbeac36ca1b1131677ce6f" },
+    { name = "torch-spyre", git = "https://github.com/torch-spyre/torch-spyre?rev=4dcfee15c3a9344652f067149ec65c4bf2941890" },
     { name = "vllm", git = "https://github.com/vllm-project/vllm?rev=v0.20.1" },
 ]
 
@@ -8132,7 +8132,7 @@ wheels = [
 [[package]]
 name = "torch-spyre"
 version = "0.0.1"
-source = { git = "https://github.com/torch-spyre/torch-spyre?rev=ee37a9de5aaa33995fcbeac36ca1b1131677ce6f#ee37a9de5aaa33995fcbeac36ca1b1131677ce6f" }
+source = { git = "https://github.com/torch-spyre/torch-spyre?rev=4dcfee15c3a9344652f067149ec65c4bf2941890#4dcfee15c3a9344652f067149ec65c4bf2941890" }
 dependencies = [
     { name = "numpy" },
     { name = "psutil" },


### PR DESCRIPTION
  This PR enables distributed (multi-card) tests in CI by splitting test execution into a
  matrix of three job types:

  - Non-distributed — single-card spyre tests (-m "not distributed")
  - Distributed — multi-card spyre tests (-m distributed)
  - Upstream — upstream vLLM tests (-m upstream)

  Key changes:

  1. Removed pytest.mark.spyre marker 
  2. Added pytest.mark.distributed — multi-card tests
  4. Updated the CI workflow with the above job matrix
  5. Updated docs
