### PR TITLE
Set attention backend to custom by default in platforms.py

### DIFF
--- a/spyre_inference/platform.py
+++ b/spyre_inference/platform.py
@@ -162,10 +162,7 @@ class TorchSpyrePlatform(CpuPlatform):
 
     @classmethod
     def get_attn_backend_cls(cls, selected_backend, *args, **kwargs) -> str:
-        if selected_backend == AttentionBackendEnum.CUSTOM:
-            return AttentionBackendEnum.CUSTOM.get_path()
-        else:
-            return super().get_attn_backend_cls(selected_backend, *args, **kwargs)
+        return AttentionBackendEnum.CUSTOM.get_path()
 
     @classmethod
     def check_and_update_config(cls, vllm_config: VllmConfig) -> None:


### PR DESCRIPTION
## Description
`platform.py` now sets custom attention backend by default. Previously attention backend needed to be set explicitly and if not set after merging of PR #213 it causes server to crash 

## Related Issues

Fixes #230 

## Test Plan

Run server

## Test Result
```
INFO 06-04 09:46:20 [__init__.py:44] Available plugins for group vllm.platform_plugins:
INFO 06-04 09:46:20 [__init__.py:46] - spyre_inference -> spyre_inference:register
INFO 06-04 09:46:20 [__init__.py:49] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 06-04 09:46:20 [__init__.py:238] Platform plugin spyre_inference is activated
INFO 06-04 09:46:42 [importing.py:44] Triton is installed but 0 active driver(s) found (expected 1). Disabling Triton to prevent runtime errors.
INFO 06-04 09:46:42 [importing.py:68] Triton not installed or not compatible; certain GPU-related functions will not be available.
INFO 06-04 09:46:42 [__init__.py:32] Registering custom ops for spyre_inference
INFO 06-04 09:46:42 [rms_norm.py:243] Registered custom op: SpyreRMSNorm
INFO 06-04 09:46:42 [utils.py:233] non-default args: {'dtype': 'float16', 'max_model_len': 8192, 'enable_prefix_caching': True, 'gpu_memory_utilization': 0.8, 'model': 'ibm-granite/granite-3.3-8b-instruct'}
INFO 06-04 09:46:43 [model.py:555] Resolved architecture: GraniteForCausalLM
WARNING 06-04 09:46:43 [model.py:2018] Casting torch.bfloat16 to torch.float16.
INFO 06-04 09:46:43 [model.py:1680] Using max model len 8192
INFO 06-04 09:46:43 [scheduler.py:239] Chunked prefill is enabled with max_num_batched_tokens=16384.
INFO 06-04 09:46:43 [vllm.py:840] Asynchronous scheduling is enabled.
INFO 06-04 09:46:43 [kernel.py:205] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'])
INFO 06-04 09:46:43 [vllm.py:978] Cudagraph mode FULL_AND_PIECEWISE is not compatible with compilation mode 0.Overriding to NONE.

    ▄█▀▀█▄  █▀▀▀█▄  █   █  █▀▀▀█▄  █▀▀▀▀    █  █▄   █  █▀▀▀▀ █▀▀▀▀  █▀▀▀█▄ █▀▀▀▀  █▄   █  ▄█▀▀█▄ █▀▀▀▀
    ▀▀▄▄▄   █▄▄▄█▀  ▀▄ ▄▀  █▄▄▄█▀  █▄▄▄     █  █ █  █  █▄▄▄  █▄▄▄   █▄▄▄█▀ █▄▄▄   █ █  █  █      █▄▄▄
         █  █        ▀█▀   █ ▀█▄   █        █  █  █ █  █     █      █ ▀█▄  █      █  █ █  █      █
    ▀▄▄▄█▀  █         █    █   ▀█  █▄▄▄▄    █  █   ▀█  █     █▄▄▄▄  █   ▀█ █▄▄▄▄  █   ▀█  ▀█▄▄█▀ █▄▄▄▄

    version 0.1.dev72    model ibm-granite/granite-3.3-8b-instruct

INFO 06-04 09:46:43 [platform.py:198] Loading worker from: spyre_inference.v1.worker.spyre_worker.TorchSpyreWorker
INFO 06-04 09:46:43 [platform.py:207] Loading scheduler from: vllm.v1.core.sched.scheduler.Scheduler
INFO 06-04 09:46:43 [compilation.py:303] Enabled custom fusions: norm_quant, act_quant
INFO 06-04 09:46:49 [__init__.py:44] Available plugins for group vllm.platform_plugins:
INFO 06-04 09:46:49 [__init__.py:46] - spyre_inference -> spyre_inference:register
INFO 06-04 09:46:49 [__init__.py:49] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 06-04 09:46:49 [__init__.py:238] Platform plugin spyre_inference is activated
(EngineCore pid=20573) INFO 06-04 09:46:59 [importing.py:44] Triton is installed but 0 active driver(s) found (expected 1). Disabling Triton to prevent runtime errors.
(EngineCore pid=20573) INFO 06-04 09:46:59 [importing.py:68] Triton not installed or not compatible; certain GPU-related functions will not be available.
(EngineCore pid=20573) INFO 06-04 09:47:01 [__init__.py:32] Registering custom ops for spyre_inference
(EngineCore pid=20573) INFO 06-04 09:47:01 [rms_norm.py:243] Registered custom op: SpyreRMSNorm
(EngineCore pid=20573) INFO 06-04 09:47:01 [core.py:109] Initializing a V1 LLM engine (v0.20.2.dev0+g132765e35.d20260604) with config: model='ibm-granite/granite-3.3-8b-instruct', speculative_config=None, tokenizer='ibm-granite/granite-3.3-8b-instruct', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.float16, max_seq_len=8192, download_dir=None, load_format=auto, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=True, quantization=None, quantization_config=None, enforce_eager=True, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cpu, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=ibm-granite/granite-3.3-8b-instruct, enable_prefix_caching=True, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.NONE: 0>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['all'], 'ir_enable_torch_wrap': False, 'splitting_ops': [], 'compile_mm_encoder': False, 'cudagraph_mm_encoder': False, 'encoder_cudagraph_token_budgets': [], 'encoder_cudagraph_max_vision_items_per_batch': 0, 'encoder_cudagraph_max_frames_per_batch': None, 'compile_sizes': None, 'compile_ranges_endpoints': [16384], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'size_asserts': False, 'alignment_asserts': False, 'scalar_asserts': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.NONE: 0>, 'cudagraph_num_of_warmups': 0, 'cudagraph_capture_sizes': [], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': True, 'fuse_act_quant': True, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False}, 'max_cudagraph_capture_size': None, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': False, 'static_all_moe_layers': []}, kernel_config=KernelConfig(ir_op_priority=IrOpPriorityConfig(rms_norm=['native']), enable_flashinfer_autotune=True, moe_backend='auto')
(EngineCore pid=20573) INFO 06-04 09:47:01 [multiproc_executor.py:139] DP group leader: node_rank=0, node_rank_within_dp=0, master_addr=127.0.0.1, mq_connect_ip=10.128.18.188 (local), world_size=1, local_world_size=1
INFO 06-04 09:47:06 [__init__.py:44] Available plugins for group vllm.platform_plugins:
INFO 06-04 09:47:06 [__init__.py:46] - spyre_inference -> spyre_inference:register
INFO 06-04 09:47:06 [__init__.py:49] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 06-04 09:47:06 [__init__.py:238] Platform plugin spyre_inference is activated
INFO 06-04 09:47:13 [importing.py:44] Triton is installed but 0 active driver(s) found (expected 1). Disabling Triton to prevent runtime errors.
INFO 06-04 09:47:13 [importing.py:68] Triton not installed or not compatible; certain GPU-related functions will not be available.
INFO 06-04 09:47:15 [__init__.py:32] Registering custom ops for spyre_inference
INFO 06-04 09:47:15 [rms_norm.py:243] Registered custom op: SpyreRMSNorm
INFO 06-04 09:47:16 [nixl_utils.py:20] Setting UCX_RCACHE_MAX_UNRELEASED to '1024' to avoid a rare memory leak in UCX when using NIXL.
WARNING 06-04 09:47:16 [nixl_utils.py:34] NIXL is not available
WARNING 06-04 09:47:16 [nixl_utils.py:44] NIXL agent config is not available
[W604 09:47:17.895270504 utils.cpp:41] Warning: numa_migrate_pages failed. errno: 1 (function init_cpu_memory_env)
[W604 09:47:17.895294536 utils.cpp:68] Warning: NUMA binding: Using MEMBIND policy for memory allocation on the NUMA nodes (0). Memory allocations will be strictly bound to these NUMA nodes. (function init_cpu_memory_env)
(Worker pid=20771) WARNING 06-04 09:47:18 [cpu_worker.py:105] libtcmalloc is not found in LD_PRELOAD. For best performance, please follow the section `set LD_PRELOAD` in https://docs.vllm.ai/en/latest/getting_started/installation/cpu/ to setup required pre-loaded libraries.
(Worker pid=20771) WARNING 06-04 09:47:18 [cpu_worker.py:105] libiomp is not found in LD_PRELOAD. For best performance, please follow the section `set LD_PRELOAD` in https://docs.vllm.ai/en/latest/getting_started/installation/cpu/ to setup required pre-loaded libraries.
(Worker pid=20771) INFO 06-04 09:47:18 [parallel_state.py:1402] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://127.0.0.1:52067 backend=cpu:gloo,spyre:spyreccl
(Worker pid=20771) INFO 06-04 09:47:23 [parallel_state.py:1715] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A, EPLB rank N/A
(Worker pid=20771) INFO 06-04 09:47:24 [spyre_model_runner.py:214] Loading model ibm-granite/granite-3.3-8b-instruct...
(Worker pid=20771) WARNING 06-04 09:47:24 [rms_norm.py:83] SpyreRMSNorm: no dtype promotion is performed, expect numerical differences to upstream vLLM.
(Worker pid=20771) INFO 06-04 09:47:24 [weight_utils.py:904] Filesystem type for checkpoints: NFS4. Checkpoint size: 15.22 GiB. Available RAM: 979.63 GiB.
(Worker pid=20771) INFO 06-04 09:47:24 [weight_utils.py:874] Prefetching checkpoint files into page cache started (in background)
Loading safetensors checkpoint shards:   0% Completed | 0/4 [00:00<?, ?it/s]
Loading safetensors checkpoint shards:  25% Completed | 1/4 [00:00<00:00,  3.18it/s]
(Worker pid=20771) INFO 06-04 09:47:25 [weight_utils.py:851] Prefetching checkpoint files: 10% (1/4)
Loading safetensors checkpoint shards:  50% Completed | 2/4 [00:00<00:00,  2.70it/s]
Loading safetensors checkpoint shards:  75% Completed | 3/4 [00:01<00:00,  2.65it/s]
Loading safetensors checkpoint shards: 100% Completed | 4/4 [00:01<00:00,  3.26it/s]
Loading safetensors checkpoint shards: 100% Completed | 4/4 [00:01<00:00,  3.06it/s]
(Worker pid=20771) 
(Worker pid=20771) INFO 06-04 09:47:25 [default_loader.py:384] Loading weights took 1.37 seconds
(Worker pid=20771) WARNING 06-04 09:47:25 [parallel_lm_head.py:74] SpyreParallelLMHead: weights padded from 49216 to 51200 (torch-spyre limitation) expect numerical differences to upstream vLLM.
(Worker pid=20771) INFO 06-04 09:47:49 [spyre_model_runner.py:251] Spyre-native layer weights moved to spyre
(Worker pid=20771) INFO 06-04 09:47:49 [spyre_model_runner.py:289] Compilation disabled (enforce_eager=True)
(Worker pid=20771) INFO 06-04 09:47:49 [spyre_model_runner.py:263] Model loaded and compiled for Spyre.
(Worker pid=20771) INFO 06-04 09:47:49 [spyre_model_runner.py:313] Warming up model...
(Worker pid=20771) /home/rehankhan/dt-inductor/torch-spyre/torch_spyre/_monkey_patch.py:107: UserWarning: Backend Spyre does not support int64; downcasting to int32 may change values outside the 32-bit range. You can silence this via warnings.filterwarnings(...) or spyre.set_downcast_warning(False) or TORCH_SPYRE_DOWNCAST_WARN env. variable. (Triggered internally at /home/rehankhan/dt-inductor/torch-spyre/torch_spyre/csrc/types_mapping.h:101.)
(Worker pid=20771)   return orig_to(self, *args, **kwargs)
(Worker pid=20771) /home/rehankhan/vllm-spyre-next/vllm/vllm/model_executor/layers/vocab_parallel_embedding.py:78: FallbackWarning: aten.embedding.default is falling back to cpu
(Worker pid=20771)   return F.embedding(input_, layer.weight)
(Worker pid=20771) INFO 06-04 09:47:50 [weight_utils.py:851] Prefetching checkpoint files: 20% (2/4)
(Worker pid=20771) INFO 06-04 09:47:50 [weight_utils.py:851] Prefetching checkpoint files: 30% (3/4)
(Worker pid=20771) INFO 06-04 09:47:50 [weight_utils.py:851] Prefetching checkpoint files: 40% (4/4)
(Worker pid=20771) INFO 06-04 09:47:50 [weight_utils.py:869] Prefetching checkpoint files into page cache finished in 25.94s
(Worker pid=20771) INFO 06-04 09:48:17 [spyre_model_runner.py:320] Warmup done.
(Worker pid=20771) INFO 06-04 09:48:17 [cpu_worker.py:208] Explicitly set (4.0/503.63) GiB for KV cache on node 0.
(EngineCore pid=20573) INFO 06-04 09:48:17 [kv_cache_utils.py:1708] GPU KV cache size: 26,112 tokens
(EngineCore pid=20573) INFO 06-04 09:48:17 [kv_cache_utils.py:1709] Maximum concurrency for 8,192 tokens per request: 3.19x
(Worker pid=20771) WARNING 06-04 09:48:17 [spyre_worker.py:103] FIXME: Adding aten::addmm decomposition to work-around torch-spyre crash
(Worker pid=20771) WARNING 06-04 09:48:17 [spyre_worker.py:103] FIXME: Adding aten::addmm.out decomposition to work-around torch-spyre crash
(Worker pid=20771) INFO 06-04 09:48:17 [spyre_model_runner.py:313] Warming up model...
(Worker pid=20771) /home/rehankhan/vllm-spyre-next/vllm/vllm/model_executor/layers/vocab_parallel_embedding.py:78: FallbackWarning: aten.embedding.default is falling back to cpu
(Worker pid=20771)   return F.embedding(input_, layer.weight)
(Worker pid=20771) INFO 06-04 09:48:29 [spyre_model_runner.py:320] Warmup done.
(EngineCore pid=20573) INFO 06-04 09:48:29 [core.py:299] init engine (profile, create kv cache, warmup model) took 40.05 s (compilation: 11.75 s)
(EngineCore pid=20573) WARNING 06-04 09:48:32 [scheduler.py:181] Using custom scheduler class vllm.v1.core.sched.scheduler.Scheduler. This scheduler interface is not public and compatibility may not be maintained.
(EngineCore pid=20573) INFO 06-04 09:48:33 [nixl_utils.py:20] Setting UCX_RCACHE_MAX_UNRELEASED to '1024' to avoid a rare memory leak in UCX when using NIXL.
(EngineCore pid=20573) WARNING 06-04 09:48:33 [nixl_utils.py:34] NIXL is not available
(EngineCore pid=20573) WARNING 06-04 09:48:33 [nixl_utils.py:44] NIXL agent config is not available
(EngineCore pid=20573) INFO 06-04 09:48:33 [vllm.py:840] Asynchronous scheduling is disabled.
(EngineCore pid=20573) WARNING 06-04 09:48:33 [vllm.py:896] Enforce eager set, disabling torch.compile and CUDAGraphs. This is equivalent to setting -cc.mode=none -cc.cudagraph_mode=none
(EngineCore pid=20573) WARNING 06-04 09:48:33 [vllm.py:914] Inductor compilation was disabled by user settings, optimizations settings that are only active during inductor compilation will be ignored.
(EngineCore pid=20573) INFO 06-04 09:48:33 [kernel.py:205] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'])
(EngineCore pid=20573) INFO 06-04 09:48:33 [platform.py:207] Loading scheduler from: vllm.v1.core.sched.scheduler.Scheduler
(EngineCore pid=20573) INFO 06-04 09:48:33 [compilation.py:303] Enabled custom fusions: norm_quant, act_quant
Rendering prompts: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  3.45it/s]
Processed prompts:   0%|                                                                        | 0/1 [00:00<?, ?it/s, est. speed input: 0.00 toks/s, output: 0.00 toks/s](Worker pid=20771) INFO 06-04 09:48:46 [logits_processor.py:81] [DEBUG _gather_logits] logits device: cpu, dtype: torch.float16, shape: torch.Size([1, 49216])
(Worker pid=20771) INFO 06-04 09:48:46 [logits_processor.py:85] [DEBUG _gather_logits] use_all_gather: True
(Worker pid=20771) INFO 06-04 09:48:46 [logits_processor.py:93] [DEBUG _gather_logits] Calling tensor_model_parallel_all_gather()
(Worker pid=20771) INFO 06-04 09:48:46 [logits_processor.py:101] [DEBUG _gather_logits] Result device: cpu, shape: torch.Size([1, 49216])
(Worker pid=20771) /home/rehankhan/vllm-spyre-next/vllm/vllm/model_executor/layers/vocab_parallel_embedding.py:78: FallbackWarning: aten.embedding.default is falling back to cpu
(Worker pid=20771)   return F.embedding(input_, layer.weight)
(Worker pid=20771) /home/rehankhan/vllm-spyre-next/vllm/vllm/model_executor/layers/vocab_parallel_embedding.py:78: FallbackWarning: aten.embedding.default is falling back to cpu
(Worker pid=20771)   return F.embedding(input_, layer.weight)
INFO 06-04 09:48:57 [loggers.py:271] Engine 000: Avg prompt throughput: 0.3 tokens/s, Avg generation throughput: 0.2 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.5%, Prefix cache hit rate: 0.0%
INFO 06-04 09:49:08 [loggers.py:271] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.8 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.5%, Prefix cache hit rate: 0.0%
INFO 06-04 09:49:18 [loggers.py:271] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.7 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.5%, Prefix cache hit rate: 0.0%
INFO 06-04 09:49:30 [loggers.py:271] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.8 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.5%, Prefix cache hit rate: 0.0%
INFO 06-04 09:49:41 [loggers.py:271] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.7 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.5%, Prefix cache hit rate: 0.0%
INFO 06-04 09:49:52 [loggers.py:271] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.7 tokens/s, Running: 1 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.5%, Prefix cache hit rate: 0.0%
Processed prompts: 100%|████████████████████████████████████████████████████████████████| 1/1 [01:24<00:00, 84.20s/it, est. speed input: 0.10 toks/s, output: 0.59 toks/s]
--------------------------------------------------
Generated text: '\n\nIBM operates in more than 175 countries and has approximately 350,000 employees, including 100,000 consultants. Its main businesses include Global Technology Services, Global Business Services'
--------------------------------------------------
```

## Checklist

- [x] I have read the [contributing guidelines](https://torch-spyre.github.io/spyre-inference/contributing/)
- [x] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
