### PR TITLE
:zap: setup uv cache for builds

### DIFF
--- a/.github/workflows/test_each_commit.yaml
+++ b/.github/workflows/test_each_commit.yaml
@@ -41,6 +41,7 @@ jobs:
       CLONED_SPYRE_INFERENCE_DIR: /home/senuser/spyre-inference
       STORAGE_1_DIR: /storage-1/spyre-inference
       HF_HOME: /storage-1/spyre-inference/.cache/huggingface
+      UV_CACHE_DIR: /storage-1/spyre-inference/.cache/uv
 
     steps:
       - name: Checkout PR branch/commit in pre-cloned spyre-inference


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Sets up the uv cache to use shared storage for builds

## Related Issues

## Test Plan

Builds should be ~1m instead of ~10m

## Checklist

- [ ] I have read the [contributing guidelines](https://torch-spyre.github.io/spyre-inference/contributing/)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
