### PR TITLE
tests: mark test_spyre_attn with @pytest.mark.spyre

### DIFF
--- a/tests/test_spyre_attn.py
+++ b/tests/test_spyre_attn.py
@@ -195,6 +195,7 @@ def ref_attn(
         pytest.param(32768, id="num_blocks(32768)"),
     ],
 )
+@pytest.mark.spyre
 @torch.inference_mode()
 def test_spyre_attn(
     default_vllm_config,


### PR DESCRIPTION
## Summary
- `test_spyre_attn.py` was missing `@pytest.mark.spyre`, so `uv run pytest -m spyre` deselected every test in the file — attention-backend coverage was silently skipped on every CI run.
- Apply the marker to `test_spyre_attn` to match the per-test style used in `test_mlp.py`, `test_rms_norm.py`, etc.

## Test plan
- [x] `uv run pytest tests/test_spyre_attn.py -m spyre --collect-only -q` lists the parametrized cases (previously: 0 collected)
- [x] `uv run pytest -m spyre` includes `tests/test_spyre_attn.py` in the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)