### PR TITLE
👷 Set up type checking in CI

### DIFF
--- a/.github/actions/spyre-uv-cache/action.yml
+++ b/.github/actions/spyre-uv-cache/action.yml
@@ -1,0 +1,56 @@
+name: 'Spyre image-versioned UV cache'
+description: |
+  Exports UV_CACHE_DIR pointed at a path keyed by the Spyre image's
+  component manifest hash. torch-spyre links against runtime binaries
+  carried by the image. Those binaries are upgraded in place when the 
+  image is rolled, but uv keys its built-wheel cache only by source URL
+  + commit — so without this action a wheel built on image v_N can be 
+  reused against image v_{N+1} and crash at import.
+
+  Each image version gets its own UV_CACHE_DIR subdirectory under the
+  PVC, which means:
+    * No cross-image contamination — image bumps see an empty cache
+      and rebuild once, then warm-cache for every subsequent run.
+    * No mid-run mutation, no race conditions: jobs on the same image
+      hit the same dir, jobs on different images never touch the same
+      files.
+
+  Pair with `astral-sh/setup-uv@v5` set to `enable-cache: false` —
+  setup-uv@v5 honors a pre-set UV_CACHE_DIR and will not override it.
+
+inputs:
+  cache-root:
+    description: 'Persistent root for uv caches (one subdir per image hash).'
+    required: false
+    default: '/storage-1/spyre-inference/.cache'
+  manifest-path:
+    description: 'Spyre image component manifest used as the cache key.'
+    required: false
+    default: '/opt/ibm/spyre/components.txt'
+
+outputs:
+  uv-cache-dir:
+    description: 'The image-versioned UV_CACHE_DIR that was exported.'
+    value: ${{ steps.compute.outputs.uv-cache-dir }}
+  image-hash:
+    description: 'Short hash of the Spyre image component manifest.'
+    value: ${{ steps.compute.outputs.image-hash }}
+
+runs:
+  using: 'composite'
+  steps:
+    - id: compute
+      shell: bash
+      run: |
+        set -euo pipefail
+        manifest="${{ inputs.manifest-path }}"
+        if [[ ! -f "$manifest" ]]; then
+          echo "::error::Spyre component manifest not found at $manifest"
+          exit 1
+        fi
+        image_hash=$(sha256sum "$manifest" | cut -c1-12)
+        cache_dir="${{ inputs.cache-root }}/uv-${image_hash}"
+        echo "UV_CACHE_DIR=${cache_dir}" >> "$GITHUB_ENV"
+        echo "uv-cache-dir=${cache_dir}" >> "$GITHUB_OUTPUT"
+        echo "image-hash=${image_hash}" >> "$GITHUB_OUTPUT"
+        echo "::notice::Using UV cache ${cache_dir} (image hash ${image_hash})"

--- a/.github/actions/spyre-uv-cache/action.yml
+++ b/.github/actions/spyre-uv-cache/action.yml
@@ -15,8 +15,7 @@ description: |
       hit the same dir, jobs on different images never touch the same
       files.
 
-  Pair with `astral-sh/setup-uv@v5` set to `enable-cache: false` —
-  setup-uv@v5 honors a pre-set UV_CACHE_DIR and will not override it.
+  Pair with `astral-sh/setup-uv@v5` set to `enable-cache: false`
 
 inputs:
   cache-root:
@@ -51,6 +50,10 @@ runs:
         image_hash=$(sha256sum "$manifest" | cut -c1-12)
         cache_dir="${{ inputs.cache-root }}/uv-${image_hash}"
         echo "UV_CACHE_DIR=${cache_dir}" >> "$GITHUB_ENV"
+        # The PVC backing the cache does not support hardlinks across to the
+        # venv filesystem, so force uv to copy. Without this, uv emits a
+        # warning per package on every sync and falls back to copy anyway.
+        echo "UV_LINK_MODE=copy" >> "$GITHUB_ENV"
         echo "uv-cache-dir=${cache_dir}" >> "$GITHUB_OUTPUT"
         echo "image-hash=${image_hash}" >> "$GITHUB_OUTPUT"
         echo "::notice::Using UV cache ${cache_dir} (image hash ${image_hash})"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -48,9 +48,6 @@ jobs:
       - linux
       - image_spyre_inference
     timeout-minutes: 30
-    env:
-      STORAGE_1_DIR: /storage-1/spyre-inference
-      UV_CACHE_DIR: /storage-1/spyre-inference/.cache/uv
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
@@ -58,6 +55,8 @@ jobs:
       uses: astral-sh/setup-uv@v5
       with:
         python-version: "3.12"
+        enable-cache: true
+        cache-local-path: /storage-1/spyre-inference/.cache/uv
     - name: "Install dependencies"
       run: |
         source /etc/profile.d/ibm-aiu-setup.sh

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -48,20 +48,31 @@ jobs:
       - linux
       - image_spyre_inference
     timeout-minutes: 30
+    env:
+      # uv serializes builds of the same package via a per-distribution lock.
+      # On a fresh image-versioned cache dir, several concurrent jobs all try
+      # to build torch-spyre (~50s) and the late arrivals time out at the
+      # default 300s. Bump generously — late jobs just wait, no work is lost.
+      UV_LOCK_TIMEOUT: '1800'
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - name: "Configure image-versioned UV cache"
+    - id: uv-cache
+      name: "Configure image-versioned UV cache"
       uses: ./.github/actions/spyre-uv-cache
 
     - name: "Set up Python 3.12"
       uses: astral-sh/setup-uv@v5
       with:
         python-version: "3.12"
-        # GHA caching disabled on self-hosted runners — UV_CACHE_DIR (set by
-        # the spyre-uv-cache action above) points at the PVC and survives
-        # across runs. setup-uv@v5 honors a pre-set UV_CACHE_DIR.
+        # GHA caching disabled on self-hosted runners — we point uv at the
+        # PVC instead. Despite what the docs imply, setup-uv@v5 *will*
+        # overwrite a pre-set UV_CACHE_DIR with its own temp path during
+        # this step (observed: "Set UV_CACHE_DIR to /…/_temp/setup-uv-cache").
+        # `cache-local-path` is the only input it reliably honors, so we
+        # pass the same value our spyre-uv-cache action exported.
         enable-cache: false
+        cache-local-path: ${{ steps.uv-cache.outputs.uv-cache-dir }}
     - name: "Install dependencies"
       run: |
         source /etc/profile.d/ibm-aiu-setup.sh

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -22,9 +22,12 @@ jobs:
     # the test job in test_each_commit.yaml.
     runs-on:
       - x86_64
-      - spyre_pf_x0
+      - spyre_pf_x0__pvc_1tb_x1
       - linux
       - image_spyre_inference
+    env:
+      STORAGE_1_DIR: /storage-1/spyre-inference
+      UV_CACHE_DIR: /storage-1/spyre-inference/.cache/uv
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -55,7 +55,13 @@ jobs:
       uses: astral-sh/setup-uv@v5
       with:
         python-version: "3.12"
-        enable-cache: true
+        # `enable-cache: true` would prune the local cache and upload it to
+        # the GitHub Actions cache at end-of-job — which destroys the
+        # pre-built wheels on our PVC. `setup-uv` docs recommend against
+        # GHA cache on self-hosted runners with persistent storage; we just
+        # point uv at the PVC via `cache-local-path` (which sets
+        # `UV_CACHE_DIR` for the rest of the job).
+        enable-cache: false
         cache-local-path: /storage-1/spyre-inference/.cache/uv
     - name: "Install dependencies"
       run: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -51,18 +51,17 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+    - name: "Configure image-versioned UV cache"
+      uses: ./.github/actions/spyre-uv-cache
+
     - name: "Set up Python 3.12"
       uses: astral-sh/setup-uv@v5
       with:
         python-version: "3.12"
-        # `enable-cache: true` would prune the local cache and upload it to
-        # the GitHub Actions cache at end-of-job — which destroys the
-        # pre-built wheels on our PVC. `setup-uv` docs recommend against
-        # GHA cache on self-hosted runners with persistent storage; we just
-        # point uv at the PVC via `cache-local-path` (which sets
-        # `UV_CACHE_DIR` for the rest of the job).
+        # GHA caching disabled on self-hosted runners — UV_CACHE_DIR (set by
+        # the spyre-uv-cache action above) points at the PVC and survives
+        # across runs. setup-uv@v5 honors a pre-set UV_CACHE_DIR.
         enable-cache: false
-        cache-local-path: /storage-1/spyre-inference/.cache/uv
     - name: "Install dependencies"
       run: |
         source /etc/profile.d/ibm-aiu-setup.sh

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    
+
     # Need to pull real deps from cache so that `ty` can type check against vllm
     - name: "Set up Python 3.12"
       uses: astral-sh/setup-uv@v5
@@ -35,3 +35,59 @@ jobs:
     - uses: j178/prek-action@v1
       with:
         extra_args: --all-files --hook-stage manual
+
+  type-check:
+    name: 'ty type check'
+    # ty needs the real torch/vllm/torch-spyre deps to type check imports, and
+    # those need the spyre runtime libs (carried by `image_spyre_inference`)
+    # to install. The check itself does not exercise the Spyre device, so it
+    # runs on `spyre_pf_x0` (no cards) to avoid contesting a card slot with
+    # the test job in test_each_commit.yaml.
+    runs-on:
+      - x86_64
+      - spyre_pf_x0
+      - linux
+      - image_spyre_inference
+    timeout-minutes: 30
+    env:
+      CI: ''
+      CLONED_SPYRE_INFERENCE_DIR: /home/senuser/spyre-inference
+
+    steps:
+      - name: Checkout PR branch/commit in pre-cloned spyre-inference
+        env:
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          GITHUB_SHA: ${{ github.sha }}
+          GITHUB_REF: ${{ github.ref }}
+        run: |
+          source "$HOME/.bashrc"
+          source /etc/profile.d/ibm-aiu-setup.sh
+          git config --global --add safe.directory '*'
+          cd "$CLONED_SPYRE_INFERENCE_DIR"
+          TARGET_SHA="${PR_HEAD_SHA:-$GITHUB_SHA}"
+          TARGET_REF="${PR_HEAD_REF:-$GITHUB_REF}"
+          echo "TARGET_REF=${TARGET_REF}"
+          echo "TARGET_SHA=${TARGET_SHA}"
+          git fetch --tags --force origin "+${TARGET_SHA}" || \
+            git fetch --tags --force origin
+          git checkout --force "${TARGET_SHA}"
+          git log -1 --oneline
+
+      - name: Build spyre-inference
+        run: |
+          source "$HOME/.bashrc"
+          source /etc/profile.d/ibm-aiu-setup.sh
+          cd "$CLONED_SPYRE_INFERENCE_DIR"
+          uv sync \
+            --frozen \
+            --verbose \
+            --all-extras \
+            --group dev
+
+      - name: Run ty type check
+        run: |
+          source "$HOME/.bashrc"
+          source /etc/profile.d/ibm-aiu-setup.sh
+          cd "$CLONED_SPYRE_INFERENCE_DIR"
+          uvx ty@0.0.16 check spyre_inference

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,40 +14,55 @@ permissions:
 
 jobs:
   pre-commit:
-    # `ty` (run as part of the prek hooks below) needs the real
-    # torch/vllm/torch-spyre deps installed to type-check imports, and
-    # those need the spyre runtime libs (carried by `image_spyre_inference`)
-    # to install. The check itself does not exercise the Spyre device, so it
-    # runs on `spyre_pf_x0` (no cards) to avoid contesting a card slot with
-    # the test job in test_each_commit.yaml.
-    runs-on:
-      - x86_64
-      - spyre_pf_x0__pvc_1tb_x1
-      - linux
-      - image_spyre_inference
-    env:
-      STORAGE_1_DIR: /storage-1/spyre-inference
-      UV_CACHE_DIR: /storage-1/spyre-inference/.cache/uv
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-    # The `markdownlint` hook installs node via npm, which links against
-    # libatomic — not present in the `image_spyre_inference` image by default.
-    - name: "Install libatomic for node"
-      run: sudo dnf install -y libatomic
 
     - name: "Set up Python 3.12"
       uses: astral-sh/setup-uv@v5
       with:
         python-version: "3.12"
         enable-cache: true
-    # Full sync (including torch-spyre + vllm) so `ty` can resolve every
-    # import in the project. `--no-dev` skips the test deps we don't need here.
+    # Required to build vllm's CPU backend
+    - name: "Install system dependencies for vllm CPU build"
+      run: sudo apt-get update && sudo apt-get install -y libnuma-dev
+    # torch-spyre cannot install without the spyre runtime libs installed
+    # we're not running any tests so we can skip the dev group with `--no-dev`
     - name: "Install dependencies"
-      run: |
-        source /etc/profile.d/ibm-aiu-setup.sh
-        uv sync --frozen --no-dev -v
+      run: uv sync --frozen --no-install-package torch-spyre --no-install-package vllm --no-dev -v
     - run: echo "::add-matcher::.github/workflows/matchers/ruff.json"
     - uses: j178/prek-action@v1
       with:
         extra_args: --all-files --hook-stage manual
+
+  type-check:
+    name: 'ty type check'
+    # `ty` needs the real torch/vllm/torch-spyre deps to type check imports,
+    # which need the spyre runtime libs (carried by `image_spyre_inference`)
+    # to install. The check itself does not exercise the Spyre device, so it
+    # runs on `spyre_pf_x0` (no cards). The `__pvc_1tb_x1` suffix gives us a
+    # persistent volume so we can cache `uv` artifacts across runs.
+    runs-on:
+      - x86_64
+      - spyre_pf_x0__pvc_1tb_x1
+      - linux
+      - image_spyre_inference
+    timeout-minutes: 30
+    env:
+      STORAGE_1_DIR: /storage-1/spyre-inference
+      UV_CACHE_DIR: /storage-1/spyre-inference/.cache/uv
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+    - name: "Set up Python 3.12"
+      uses: astral-sh/setup-uv@v5
+      with:
+        python-version: "3.12"
+    - name: "Install dependencies"
+      run: |
+        source /etc/profile.d/ibm-aiu-setup.sh
+        uv sync --frozen --no-dev -v
+    - name: "Run ty via prek"
+      run: |
+        source /etc/profile.d/ibm-aiu-setup.sh
+        uvx prek@v0.4.4 run ty --all-files --stage pre-commit

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -31,6 +31,11 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+    # The `markdownlint` hook installs node via npm, which links against
+    # libatomic — not present in the `image_spyre_inference` image by default.
+    - name: "Install libatomic for node"
+      run: sudo dnf install -y libatomic
+
     - name: "Set up Python 3.12"
       uses: astral-sh/setup-uv@v5
       with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,31 +14,8 @@ permissions:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-    # Need to pull real deps from cache so that `ty` can type check against vllm
-    - name: "Set up Python 3.12"
-      uses: astral-sh/setup-uv@v5
-      with:
-        python-version: "3.12"
-        enable-cache: true
-    # Required to build vllm's CPU backend
-    - name: "Install system dependencies for vllm CPU build"
-      run: sudo apt-get update && sudo apt-get install -y libnuma-dev
-    # torch-spyre cannot install without the spyre runtime libs installed
-    # we're not running any tests so we can skip the dev group with `--no-dev`
-    - name: "Install dependencies"
-      run: uv sync --frozen --no-install-package torch-spyre --no-install-package vllm --no-dev -v
-    - run: echo "::add-matcher::.github/workflows/matchers/ruff.json"
-    - uses: j178/prek-action@v1
-      with:
-        extra_args: --all-files --hook-stage manual
-
-  type-check:
-    name: 'ty type check'
-    # ty needs the real torch/vllm/torch-spyre deps to type check imports, and
+    # `ty` (run as part of the prek hooks below) needs the real
+    # torch/vllm/torch-spyre deps installed to type-check imports, and
     # those need the spyre runtime libs (carried by `image_spyre_inference`)
     # to install. The check itself does not exercise the Spyre device, so it
     # runs on `spyre_pf_x0` (no cards) to avoid contesting a card slot with
@@ -48,46 +25,21 @@ jobs:
       - spyre_pf_x0
       - linux
       - image_spyre_inference
-    timeout-minutes: 30
-    env:
-      CI: ''
-      CLONED_SPYRE_INFERENCE_DIR: /home/senuser/spyre-inference
-
     steps:
-      - name: Checkout PR branch/commit in pre-cloned spyre-inference
-        env:
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          GITHUB_SHA: ${{ github.sha }}
-          GITHUB_REF: ${{ github.ref }}
-        run: |
-          source "$HOME/.bashrc"
-          source /etc/profile.d/ibm-aiu-setup.sh
-          git config --global --add safe.directory '*'
-          cd "$CLONED_SPYRE_INFERENCE_DIR"
-          TARGET_SHA="${PR_HEAD_SHA:-$GITHUB_SHA}"
-          TARGET_REF="${PR_HEAD_REF:-$GITHUB_REF}"
-          echo "TARGET_REF=${TARGET_REF}"
-          echo "TARGET_SHA=${TARGET_SHA}"
-          git fetch --tags --force origin "+${TARGET_SHA}" || \
-            git fetch --tags --force origin
-          git checkout --force "${TARGET_SHA}"
-          git log -1 --oneline
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Build spyre-inference
-        run: |
-          source "$HOME/.bashrc"
-          source /etc/profile.d/ibm-aiu-setup.sh
-          cd "$CLONED_SPYRE_INFERENCE_DIR"
-          uv sync \
-            --frozen \
-            --verbose \
-            --all-extras \
-            --group dev
-
-      - name: Run ty type check
-        run: |
-          source "$HOME/.bashrc"
-          source /etc/profile.d/ibm-aiu-setup.sh
-          cd "$CLONED_SPYRE_INFERENCE_DIR"
-          uvx ty@0.0.16 check spyre_inference
+    - name: "Set up Python 3.12"
+      uses: astral-sh/setup-uv@v5
+      with:
+        python-version: "3.12"
+        enable-cache: true
+    # Full sync (including torch-spyre + vllm) so `ty` can resolve every
+    # import in the project. `--no-dev` skips the test deps we don't need here.
+    - name: "Install dependencies"
+      run: |
+        source /etc/profile.d/ibm-aiu-setup.sh
+        uv sync --frozen --no-dev -v
+    - run: echo "::add-matcher::.github/workflows/matchers/ruff.json"
+    - uses: j178/prek-action@v1
+      with:
+        extra_args: --all-files --hook-stage manual

--- a/.github/workflows/test_each_commit.yaml
+++ b/.github/workflows/test_each_commit.yaml
@@ -37,37 +37,17 @@ jobs:
       # due to a mix of fallbacks and decompositions.
       # Here we set it to an empty string (or we could also unset it).
       CI: ''
-      CLONED_TORCH_SPYRE_DIR: /home/senuser/torch-spyre
-      CLONED_SPYRE_INFERENCE_DIR: /home/senuser/spyre-inference
       STORAGE_1_DIR: /storage-1/spyre-inference
       HF_HOME: /storage-1/spyre-inference/.cache/huggingface
-      UV_CACHE_DIR: /storage-1/spyre-inference/.cache/uv
+      # UV_CACHE_DIR is exported by the spyre-uv-cache action below, keyed by
+      # the Spyre image's component manifest hash so torch-spyre wheels built
+      # against one runtime cannot be reused after an image bump.
 
     steps:
-      - name: Checkout PR branch/commit in pre-cloned spyre-inference
-        env:
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          GITHUB_SHA: ${{ github.sha }}
-          GITHUB_REF: ${{ github.ref }}
-        run: |
-          source "$HOME/.bashrc"
-          source /etc/profile.d/ibm-aiu-setup.sh
-          # The pre-cloned repo may be owned by a different user than the
-          # runner process; mark all directories as safe to avoid git's
-          # "dubious ownership" error.
-          git config --global --add safe.directory '*'
-          cd "$CLONED_SPYRE_INFERENCE_DIR"
-          # Prefer the PR head SHA when triggered by pull_request, otherwise
-          # fall back to the SHA of the push/tag that triggered the workflow.
-          TARGET_SHA="${PR_HEAD_SHA:-$GITHUB_SHA}"
-          TARGET_REF="${PR_HEAD_REF:-$GITHUB_REF}"
-          echo "TARGET_REF=${TARGET_REF}"
-          echo "TARGET_SHA=${TARGET_SHA}"
-          git fetch --tags --force origin "+${TARGET_SHA}" || \
-            git fetch --tags --force origin
-          git checkout --force "${TARGET_SHA}"
-          git log -1 --oneline
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Configure image-versioned UV cache
+        uses: ./.github/actions/spyre-uv-cache
 
       - name: Gather runner info
         run: |
@@ -87,14 +67,13 @@ jobs:
           echo "--- AIU env ---"
           env | sort | grep AIU || true
           echo "--- repo listing ---"
-          ls -lart "$CLONED_SPYRE_INFERENCE_DIR"
+          ls -lart
           echo "---"
 
       - name: Build spyre-inference
         run: |
           source "$HOME/.bashrc"
           source /etc/profile.d/ibm-aiu-setup.sh
-          cd "$CLONED_SPYRE_INFERENCE_DIR"
           uv sync \
             --frozen \
             --verbose \
@@ -108,7 +87,6 @@ jobs:
         run: |
           source "$HOME/.bashrc"
           source /etc/profile.d/ibm-aiu-setup.sh
-          cd "$CLONED_SPYRE_INFERENCE_DIR"
           echo "Running tests..."
           uv run pytest -s -vvv
           echo "tests done"

--- a/.github/workflows/test_each_commit.yaml
+++ b/.github/workflows/test_each_commit.yaml
@@ -65,6 +65,11 @@ jobs:
       # UV_CACHE_DIR is exported by the spyre-uv-cache action below, keyed by
       # the Spyre image's component manifest hash so torch-spyre wheels built
       # against one runtime cannot be reused after an image bump.
+      # uv serializes builds of the same package via a per-distribution lock.
+      # On a fresh image-versioned cache dir, several concurrent jobs all try
+      # to build torch-spyre (~50s) and the late arrivals time out at the
+      # default 300s. Bump generously — late jobs just wait, no work is lost.
+      UV_LOCK_TIMEOUT: '1800'
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,5 +45,3 @@ repos:
       # check all files because the staged changes may cause errors in unmodified files. Think
       # deleting a method but forgetting to remove all of the call sites in other files.
       pass_filenames: false
-      # Local commits only — CI installs without vllm/torch-spyre, so ty would fail on every import
-      stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,3 +45,7 @@ repos:
       # check all files because the staged changes may cause errors in unmodified files. Think
       # deleting a method but forgetting to remove all of the call sites in other files.
       pass_filenames: false
+      # Pinned to the pre-commit stage so the manual-stage CI run on
+      # ubuntu-latest (which does not install vllm/torch-spyre) skips it; a
+      # dedicated CI job on a Spyre runner runs `prek run ty --stage pre-commit`.
+      stages: [pre-commit]

--- a/spyre_inference/custom_ops/parallel_lm_head.py
+++ b/spyre_inference/custom_ops/parallel_lm_head.py
@@ -92,6 +92,9 @@ class SpyreParallelLMHead(ParallelLMHead):
     and runs F.linear on Spyre.
     """
 
+    padding: int
+    padded_weight: torch.Tensor
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/spyre_inference/custom_ops/rms_norm.py
+++ b/spyre_inference/custom_ops/rms_norm.py
@@ -115,13 +115,15 @@ class SpyreRMSNorm(RMSNorm):
             return self._forward_spyre_impl(x, residual)
 
         output = torch.empty_like(x)
-        residual_out = torch.empty_like(residual) if residual is not None else None
 
-        # Custom op call - executes outside torch.compile graph
-        torch.ops.vllm.spyre_rmsnorm(x, output, self._layer_name, residual, residual_out)
-
+        # `torch.ops.vllm.spyre_rmsnorm` is dynamically registered, so its
+        # signature is opaque to the type checker (ParamSpec resolves to `...`).
         if residual is not None:
+            residual_out = torch.empty_like(residual)
+            torch.ops.vllm.spyre_rmsnorm(x, output, self._layer_name, residual, residual_out)  # ty: ignore[invalid-argument-type]
             return output, residual_out
+
+        torch.ops.vllm.spyre_rmsnorm(x, output, self._layer_name, None, None)  # ty: ignore[invalid-argument-type]
         return output
 
     @staticmethod
@@ -148,13 +150,13 @@ class SpyreRMSNorm(RMSNorm):
         if x.shape[-1] != hidden_size:
             raise ValueError(f"Expected hidden_size to be {hidden_size}, but found: {x.shape[-1]}")
 
-        variance_epsilon = torch.full(
+        variance_epsilon_t = torch.full(
             x.shape, variance_epsilon, dtype=torch.float16, device=x.device
         )
 
         variance = x.pow(2).mean(dim=-1, keepdim=True)
 
-        x = x * torch.rsqrt(variance + variance_epsilon)
+        x = x * torch.rsqrt(variance + variance_epsilon_t)
 
         if weight is not None:
             x = x * weight

--- a/spyre_inference/custom_ops/rms_norm.py
+++ b/spyre_inference/custom_ops/rms_norm.py
@@ -115,15 +115,14 @@ class SpyreRMSNorm(RMSNorm):
             return self._forward_spyre_impl(x, residual)
 
         output = torch.empty_like(x)
+        residual_out = torch.empty_like(residual) if residual is not None else None
 
         # `torch.ops.vllm.spyre_rmsnorm` is dynamically registered, so its
         # signature is opaque to the type checker (ParamSpec resolves to `...`).
-        if residual is not None:
-            residual_out = torch.empty_like(residual)
-            torch.ops.vllm.spyre_rmsnorm(x, output, self._layer_name, residual, residual_out)  # ty: ignore[invalid-argument-type]
-            return output, residual_out
+        torch.ops.vllm.spyre_rmsnorm(x, output, self._layer_name, residual, residual_out)  # ty: ignore[invalid-argument-type]
 
-        torch.ops.vllm.spyre_rmsnorm(x, output, self._layer_name, None, None)  # ty: ignore[invalid-argument-type]
+        if residual_out is not None:
+            return output, residual_out
         return output
 
     @staticmethod

--- a/spyre_inference/v1/attention/backends/spyre_attn.py
+++ b/spyre_inference/v1/attention/backends/spyre_attn.py
@@ -62,7 +62,9 @@ def _overwrite(
 ) -> None:
     """Write input into output at the specified position (in-place)."""
     if output.device.type == "spyre":
-        torch.ops.spyre.overwrite(input, output, dims, offsets)
+        # `torch.ops.spyre.overwrite` is dynamically registered, so its
+        # signature is opaque to the type checker (ParamSpec resolves to `...`).
+        torch.ops.spyre.overwrite(input, output, dims, offsets)  # ty: ignore[invalid-argument-type]
     else:
         # intended behaviour on cpu
         sliced_t = output
@@ -117,16 +119,22 @@ def _indirect_matmul_mock(
     if isinstance(a, list) or (isinstance(a, torch.Tensor) and address_or_index_of_a is not None):
         if isinstance(address_or_index_of_a, torch.Tensor):
             assert len(address_or_index_of_a) == 1, "for now, we support only one page at a time"
-            address_or_index_of_a = address_or_index_of_a.item()
+            idx_a = int(address_or_index_of_a.item())
+        else:
+            assert address_or_index_of_a is not None
+            idx_a = address_or_index_of_a
         # pytorch syntax is the same like for python lists here
-        a = a[address_or_index_of_a]
+        a = a[idx_a]
         if transform_a:
             a = transform_a(a)
     if isinstance(b, list) or (isinstance(b, torch.Tensor) and address_or_index_of_b is not None):
         if isinstance(address_or_index_of_b, torch.Tensor):
             assert len(address_or_index_of_b) == 1, "for now, we support only one page at a time"
-            address_or_index_of_b = address_or_index_of_b.item()
-        b = b[address_or_index_of_b]
+            idx_b = int(address_or_index_of_b.item())
+        else:
+            assert address_or_index_of_b is not None
+            idx_b = address_or_index_of_b
+        b = b[idx_b]
         if transform_b:
             b = transform_b(b)
 
@@ -232,6 +240,10 @@ def _create_compilable_page_attn(num_blocks: int, padded_query_len: int):
                 )
                 tile_sum = tile_probs.sum(dim=-1, keepdim=True)
             else:
+                # i > 0 only reachable after the i == 0 branch initialized these.
+                assert tile_max is not None
+                assert tile_sum is not None
+                assert tile_output is not None
                 new_max = torch.maximum(tile_max, scores_max)
                 rescale = torch.exp(tile_max - new_max)
                 tile_output = tile_output * rescale
@@ -346,7 +358,11 @@ class SpyreAttentionMetadataBuilder(AttentionMetadataBuilder[SpyreAttentionMetad
         model_config = vllm_config.model_config
         self.num_heads = model_config.get_num_attention_heads(vllm_config.parallel_config)
         self.num_kv_heads = model_config.get_num_kv_heads(vllm_config.parallel_config)
-        self.model_dtype = model_config.dtype
+        # `model_config.dtype` is typed `ModelDType | torch.dtype`, but
+        # `TorchSpyrePlatform.check_and_update_config` rejects anything but
+        # `torch.float16` upstream so it's always a real torch.dtype here.
+        assert isinstance(model_config.dtype, torch.dtype)
+        self.model_dtype: torch.dtype = model_config.dtype
 
     def _build_attention_mask(
         self,
@@ -573,9 +589,10 @@ class SpyreAttentionImpl(AttentionImpl[SpyreAttentionMetadata]):
         self.kv_cache_dtype = kv_cache_dtype
         self.attn_type = attn_type
 
-        # Compiled function caches (keyed by iteration count)
+        # Compiled function caches (keyed by iteration count for reshape, and
+        # by (num_blocks, padded_query_len) for the per-page attention loop)
         self._reshape_fns: dict[int, object] = {}
-        self._attn_fns: dict[int, object] = {}
+        self._attn_fns: dict[tuple[int, int], object] = {}
 
         logger.debug_once("Using SpyreAttentionBackend with LIST-BASED online softmax")
 
@@ -601,7 +618,12 @@ class SpyreAttentionImpl(AttentionImpl[SpyreAttentionMetadata]):
             )
         return self._attn_fns[key]
 
-    def forward(
+    # `kv_cache` widens the base's `torch.Tensor` to a `(k_pages, v_pages)`
+    # tuple — `TorchSpyreModelRunner.initialize_kv_cache_tensors` allocates
+    # this shape and `bind_kv_cache` smuggles it through a dict typed as
+    # `dict[str, torch.Tensor]`. The matching pair of overrides preserves
+    # the runtime contract; ty cannot see the co-evolution.
+    def forward(  # ty: ignore[invalid-method-override]
         self,
         layer: AttentionLayer,
         query: torch.Tensor,  # [num_tokens, num_heads, head_size]
@@ -613,8 +635,6 @@ class SpyreAttentionImpl(AttentionImpl[SpyreAttentionMetadata]):
         output_scale: torch.Tensor | None = None,
         output_block_scale: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        assert output is not None, "Output tensor must be provided"
-
         if attn_metadata is None:
             return output
 

--- a/spyre_inference/v1/attention/backends/spyre_attn.py
+++ b/spyre_inference/v1/attention/backends/spyre_attn.py
@@ -19,7 +19,7 @@ such as matmul, softmax, etc. It supports vLLM's KV cache.
 """
 
 from dataclasses import dataclass
-from typing import ClassVar
+from typing import Callable, ClassVar
 
 import torch
 
@@ -31,6 +31,7 @@ from vllm.v1.attention.backend import (
     AttentionBackend,
     AttentionCGSupport,
     AttentionImpl,
+    AttentionLayer,
     AttentionMetadata,
     AttentionMetadataBuilder,
     AttentionType,
@@ -63,7 +64,9 @@ def copy_attn_output(attn_output, num_actual_tokens, output):
     """Place `attn_output[:num_actual_tokens]` into the caller-provided `output` buffer."""
     if output.device.type == "spyre":
         attn_output_spyre = convert(attn_output, "spyre", output.dtype)
-        torch.ops.spyre.overwrite(attn_output_spyre, output, [0], [0])
+        # `torch.ops.spyre.overwrite` is dynamically registered, so its signature
+        # is opaque to the type checker (ParamSpec resolves to `...`).
+        torch.ops.spyre.overwrite(attn_output_spyre, output, [0], [0])  # ty: ignore[invalid-argument-type]
     else:
         output[:num_actual_tokens].copy_(attn_output)
     return output
@@ -232,13 +235,11 @@ class SpyreAttentionImpl(AttentionImpl[SpyreAttentionMetadata]):
         # Otherwise, use the 4D matmul kernel (_attn_4d).
         self.use_sdpa = use_sdpa
 
-        if self.use_sdpa:
-            self.attn_op = torch.nn.functional.scaled_dot_product_attention
-        else:
-            self.attn_op = _attn_4d
-
-        # Compile the attention function once for reuse.
-        self.attn_op = torch.compile(self.attn_op)
+        # Annotated as a permissive Callable so ty doesn't try to resolve
+        # the union of SDPA's kwarg signature with `_attn_4d`'s positional one.
+        # The dispatch in `_compute_attention` selects the right call shape.
+        fn = torch.nn.functional.scaled_dot_product_attention if self.use_sdpa else _attn_4d
+        self.attn_op: Callable[..., torch.Tensor] = torch.compile(fn)
 
         # Simplified implementation: don't support these features initially
         if alibi_slopes is not None:
@@ -250,20 +251,17 @@ class SpyreAttentionImpl(AttentionImpl[SpyreAttentionMetadata]):
 
     def forward(
         self,
-        layer: torch.nn.Module,
+        layer: AttentionLayer,
         query: torch.Tensor,  # [num_tokens, num_heads, head_size]
         key: torch.Tensor,  # [num_tokens, num_kv_heads, head_size]
         value: torch.Tensor,  # [num_tokens, num_kv_heads, head_size]
         kv_cache: torch.Tensor,  # [num_blocks, 2, block_size, num_kv_heads, head_size]
         attn_metadata: SpyreAttentionMetadata,
-        output: torch.Tensor | None = None,
+        output: torch.Tensor,
         output_scale: torch.Tensor | None = None,
         output_block_scale: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Compute attention output using PyTorch native operations."""
-
-        assert output is not None, "Output tensor must be provided"
-
         if attn_metadata is None:
             return output
 

--- a/spyre_inference/v1/attention/backends/spyre_attn.py
+++ b/spyre_inference/v1/attention/backends/spyre_attn.py
@@ -15,7 +15,7 @@
 """Paged KV-cache attention backend for Spyre using list-of-pages and online softmax."""
 
 from dataclasses import dataclass
-from typing import Callable, ClassVar
+from typing import Callable, ClassVar, NamedTuple
 
 import torch
 
@@ -52,6 +52,26 @@ KV_LENGTH_ALIGNMENT = 256
 # Explore a separate decode kernel path that doesn't need query padding, or use
 # a smaller alignment (e.g. QUERY_CHUNK_SIZE=1) for single-token decode steps.
 QUERY_CHUNK_SIZE = 32
+
+
+class SpyrePagedKVCache(NamedTuple):
+    """Per-layer paged KV cache for the Spyre backend.
+
+    NamedTuple (not dataclass) because it is a tuple at runtime — Dynamo
+    specializes tuple subscripts at trace time, which is what makes the
+    compile-unrolled per-page loop in `_create_compilable_page_attn` work.
+    A regular dataclass would cross an unverified line with Dynamo's tracing
+    of attribute access on custom objects. Index-by-int and unpacking
+    (`k_pages, v_pages = cache`) keep working unchanged.
+
+    Allocated by `TorchSpyreModelRunner.initialize_kv_cache_tensors` and
+    consumed by `SpyreAttentionImpl.forward`. vLLM's `bind_kv_cache` types
+    the relay path as `dict[str, torch.Tensor]`; see the suppression at the
+    `bind_kv_cache(...)` call site for why that type-hole is benign.
+    """
+
+    k_pages: list[torch.Tensor]
+    v_pages: list[torch.Tensor]
 
 
 def _overwrite(
@@ -618,18 +638,18 @@ class SpyreAttentionImpl(AttentionImpl[SpyreAttentionMetadata]):
             )
         return self._attn_fns[key]
 
-    # `kv_cache` widens the base's `torch.Tensor` to a `(k_pages, v_pages)`
-    # tuple — `TorchSpyreModelRunner.initialize_kv_cache_tensors` allocates
-    # this shape and `bind_kv_cache` smuggles it through a dict typed as
-    # `dict[str, torch.Tensor]`. The matching pair of overrides preserves
-    # the runtime contract; ty cannot see the co-evolution.
+    # `kv_cache` widens the base's `torch.Tensor` to `SpyrePagedKVCache`,
+    # which `TorchSpyreModelRunner.initialize_kv_cache_tensors` allocates
+    # and `bind_kv_cache` smuggles through a dict typed `dict[str, Tensor]`.
+    # The matching pair of overrides preserves the runtime contract; ty
+    # cannot see the co-evolution.
     def forward(  # ty: ignore[invalid-method-override]
         self,
         layer: AttentionLayer,
         query: torch.Tensor,  # [num_tokens, num_heads, head_size]
         key: torch.Tensor,  # [num_tokens, num_kv_heads, head_size]
         value: torch.Tensor,  # [num_tokens, num_kv_heads, head_size]
-        kv_cache: tuple[list[torch.Tensor], list[torch.Tensor]],
+        kv_cache: SpyrePagedKVCache,
         attn_metadata: SpyreAttentionMetadata,
         output: torch.Tensor,
         output_scale: torch.Tensor | None = None,

--- a/spyre_inference/v1/attention/backends/spyre_attn_exp.py
+++ b/spyre_inference/v1/attention/backends/spyre_attn_exp.py
@@ -117,7 +117,7 @@ def copy_attn_output(attn_output, num_actual_tokens, output):
     return output
 
 
-@dataclass
+@dataclass(kw_only=True)
 class SpyreAttentionMetadata(AttentionMetadata):
     """Metadata for PyTorch native attention computation on Spyre."""
 
@@ -146,29 +146,31 @@ class SpyreAttentionMetadata(AttentionMetadata):
     num_heads: int = 0
 
     # --- Precomputed by builder (shared across all layers) ---
+    # Always populated by SpyreAttentionMetadataBuilder.build(); declared
+    # required (kw_only dataclass) so consumers don't need to narrow `| None`.
 
     # Additive attention mask on Spyre, ready for the compiled attention op.
     # Shape: [num_seqs * num_kv_heads, 1, padded_query_len, aligned_max_seq_len]
     # fp16, masked positions = -65504, unmasked = 0.
-    attention_mask: torch.Tensor | None = None
+    attention_mask: torch.Tensor
 
     # Gather selection mask on Spyre:
     # [num_kv_heads, aligned_num_logical_blocks, aligned_num_physical_blocks]
-    gather_sel_mask_dev: torch.Tensor | None = None
+    gather_sel_mask_dev: torch.Tensor
 
     # Aligned max seq len used by gather (needed for reshape)
-    aligned_max_seq_len: int = 0
+    aligned_max_seq_len: int
 
     # Scatter position mask on Spyre: [num_kv_heads, aligned_num_physical_blocks, block_width]
-    scatter_mask_dev: torch.Tensor | None = None
+    scatter_mask_dev: torch.Tensor
 
     # Scatter row selector on Spyre: [num_kv_heads, aligned_num_physical_blocks, num_tokens]
     # one-hot: row_sel[h, r, t] = 1 iff block_indices[t] == r (broadcast-identical across heads)
-    scatter_row_sel_dev: torch.Tensor | None = None
+    scatter_row_sel_dev: torch.Tensor
 
     # Scatter column placement selector on Spyre: [num_tokens, head_size, block_width]
     # one-hot: col_sel[t, d, c] = 1 iff c == block_offsets[t]*head_size + d
-    scatter_col_sel_dev: torch.Tensor | None = None
+    scatter_col_sel_dev: torch.Tensor
 
     @property
     def query_lens(self) -> torch.Tensor:
@@ -468,6 +470,13 @@ class SpyreAttentionImpl(AttentionImpl[SpyreAttentionMetadata]):
     per-layer work: fill K/V values, scatter, bmm gather, attention.
     """
 
+    # Set in `forward()` from `kv_cache` and `attn_metadata` before any helper
+    # reads them. Declared without `| None` so ty doesn't require narrowing
+    # asserts in every helper method.
+    _block_size: int
+    _k_cache_dev: torch.Tensor
+    _v_cache_dev: torch.Tensor
+
     def __init__(
         self,
         num_heads: int,
@@ -494,12 +503,9 @@ class SpyreAttentionImpl(AttentionImpl[SpyreAttentionMetadata]):
 
         self._attn_4d = _maybe_compile(_attn_4d)
 
-        self._block_size: int | None = None
         self._num_blocks: int | None = None
         self._aligned_num_physical_blocks: int | None = None
         self._block_width: int | None = None
-        self._k_cache_dev: torch.Tensor | None = None
-        self._v_cache_dev: torch.Tensor | None = None
 
         if alibi_slopes is not None:
             raise NotImplementedError("ALiBi slopes not supported yet")
@@ -527,21 +533,6 @@ class SpyreAttentionImpl(AttentionImpl[SpyreAttentionMetadata]):
             f"Spyre attention requires num_seqs=1, got {attn_metadata.num_seqs}"
         )
 
-        # The metadata builder always populates these on Spyre; narrow the
-        # `Tensor | None` declared on SpyreAttentionMetadata for the type checker.
-        scatter_mask_dev = attn_metadata.scatter_mask_dev
-        scatter_row_sel_dev = attn_metadata.scatter_row_sel_dev
-        scatter_col_sel_dev = attn_metadata.scatter_col_sel_dev
-        gather_sel_mask_dev = attn_metadata.gather_sel_mask_dev
-        attention_mask = attn_metadata.attention_mask
-        assert (
-            scatter_mask_dev is not None
-            and scatter_row_sel_dev is not None
-            and scatter_col_sel_dev is not None
-            and gather_sel_mask_dev is not None
-            and attention_mask is not None
-        ), "SpyreAttentionMetadataBuilder must populate all device-side selectors"
-
         # The value still resides on CPU, as it is
         # created in the GraniteAttention through a split
         # operation, which has to be carried out on CPU
@@ -563,24 +554,29 @@ class SpyreAttentionImpl(AttentionImpl[SpyreAttentionMetadata]):
         self._scatter_to_device_cache(
             key[:num_actual_tokens],
             value[:num_actual_tokens],
-            scatter_mask_dev,
-            scatter_row_sel_dev,
-            scatter_col_sel_dev,
+            attn_metadata.scatter_mask_dev,
+            attn_metadata.scatter_row_sel_dev,
+            attn_metadata.scatter_col_sel_dev,
             attn_metadata.slot_mapping[:num_actual_tokens],
         )
 
         # Step 2: Gather — sel_mask is precomputed by builder and lives on Spyre
         compact_k, compact_v = self._gather_from_device_cache(
-            gather_sel_mask_dev,
+            attn_metadata.gather_sel_mask_dev,
             attn_metadata.aligned_max_seq_len,
         )
 
         # Step 3: Add batch dim (num_seqs=1)
         query_per_seq = query[:num_actual_tokens].unsqueeze(0)
 
-        # Step 5: Compute attention (mask precomputed by builder)
+        # Step 4: Compute attention (mask precomputed by builder)
         attn_output = self._compute_attention(
-            query_per_seq, compact_k, compact_v, attention_mask, query.device, query.dtype
+            query_per_seq,
+            compact_k,
+            compact_v,
+            attn_metadata.attention_mask,
+            query.device,
+            query.dtype,
         )
 
         # Step 6: Extract actual tokens (num_seqs=1 → simple slice)
@@ -624,14 +620,9 @@ class SpyreAttentionImpl(AttentionImpl[SpyreAttentionMetadata]):
             # Input must be [num_kv_heads, 1, head_size] to match the
             # output's rank (3D) with the listed dims being singleton.
             head_size = self.head_size
-            block_size = self._block_size
-            k_cache_dev = self._k_cache_dev
-            v_cache_dev = self._v_cache_dev
-            assert block_size is not None
-            assert k_cache_dev is not None and v_cache_dev is not None
             sm = convert(slot_mapping, device="cpu")
-            block_indices = (sm // block_size).tolist()
-            block_offsets = (sm % block_size).tolist()
+            block_indices = (sm // self._block_size).tolist()
+            block_offsets = (sm % self._block_size).tolist()
             num_tokens = k_new_dev.shape[0]
 
             # Use spyre.overwrite (mutates_args=("output",)) so the underlying
@@ -646,8 +637,8 @@ class SpyreAttentionImpl(AttentionImpl[SpyreAttentionMetadata]):
                 cs = int(block_offsets[t]) * head_size
                 k_tok = convert(key[t].unsqueeze(1).contiguous(), device=self._target_device)
                 v_tok = convert(value[t].unsqueeze(1).contiguous(), device=self._target_device)
-                torch.ops.spyre.overwrite(k_tok, k_cache_dev, [1, 2], [br, cs])  # ty: ignore[invalid-argument-type]
-                torch.ops.spyre.overwrite(v_tok, v_cache_dev, [1, 2], [br, cs])  # ty: ignore[invalid-argument-type]
+                torch.ops.spyre.overwrite(k_tok, self._k_cache_dev, [1, 2], [br, cs])  # ty: ignore[invalid-argument-type]
+                torch.ops.spyre.overwrite(v_tok, self._v_cache_dev, [1, 2], [br, cs])  # ty: ignore[invalid-argument-type]
             return
 
         # bmm 1: place each token's head_size-vector into its block-width slot.
@@ -668,11 +659,8 @@ class SpyreAttentionImpl(AttentionImpl[SpyreAttentionMetadata]):
         v_vals = torch.bmm(row_sel_dev, v_spread)
 
         # Mutate the persistent KV cache in place.
-        k_cache_dev = self._k_cache_dev
-        v_cache_dev = self._v_cache_dev
-        assert k_cache_dev is not None and v_cache_dev is not None
-        k_cache_dev.copy_(self._scatter_cache(k_cache_dev, scatter_mask_dev, k_vals))
-        v_cache_dev.copy_(self._scatter_cache(v_cache_dev, scatter_mask_dev, v_vals))
+        self._k_cache_dev.copy_(self._scatter_cache(self._k_cache_dev, scatter_mask_dev, k_vals))
+        self._v_cache_dev.copy_(self._scatter_cache(self._v_cache_dev, scatter_mask_dev, v_vals))
 
     def _gather_from_device_cache(
         self,
@@ -683,11 +671,8 @@ class SpyreAttentionImpl(AttentionImpl[SpyreAttentionMetadata]):
         num_kv_heads = self.num_kv_heads
         head_size = self.head_size
 
-        k_cache_dev = self._k_cache_dev
-        v_cache_dev = self._v_cache_dev
-        assert k_cache_dev is not None and v_cache_dev is not None
-        gathered_k = torch.bmm(sel_mask_dev, k_cache_dev)
-        gathered_v = torch.bmm(sel_mask_dev, v_cache_dev)
+        gathered_k = torch.bmm(sel_mask_dev, self._k_cache_dev)
+        gathered_v = torch.bmm(sel_mask_dev, self._v_cache_dev)
 
         gathered_k = gathered_k.reshape(num_kv_heads, aligned_max_seq_len, head_size)
         gathered_v = gathered_v.reshape(num_kv_heads, aligned_max_seq_len, head_size)

--- a/spyre_inference/v1/attention/backends/spyre_attn_exp.py
+++ b/spyre_inference/v1/attention/backends/spyre_attn_exp.py
@@ -60,6 +60,7 @@ from vllm.v1.attention.backend import (
     AttentionBackend,
     AttentionCGSupport,
     AttentionImpl,
+    AttentionLayer,
     AttentionMetadata,
     AttentionMetadataBuilder,
     AttentionType,
@@ -110,7 +111,9 @@ def copy_attn_output(attn_output, num_actual_tokens, output):
     """Place `attn_output[:num_actual_tokens]` into the caller-provided `output` buffer."""
     if output.device.type == "spyre":
         attn_output_spyre = convert(attn_output, "spyre", output.dtype)
-        torch.ops.spyre.overwrite(attn_output_spyre, output, [0], [0])
+        # `torch.ops.spyre.overwrite` is dynamically registered, so its signature
+        # is opaque to the type checker (ParamSpec resolves to `...`).
+        torch.ops.spyre.overwrite(attn_output_spyre, output, [0], [0])  # ty: ignore[invalid-argument-type]
     else:
         output[:num_actual_tokens].copy_(attn_output)
     return output
@@ -509,24 +512,37 @@ class SpyreAttentionImpl(AttentionImpl[SpyreAttentionMetadata]):
 
     def forward(
         self,
-        layer: torch.nn.Module,
+        layer: AttentionLayer,
         query: torch.Tensor,
         key: torch.Tensor,
         value: torch.Tensor,
         kv_cache: torch.Tensor,
         attn_metadata: SpyreAttentionMetadata,
-        output: torch.Tensor | None = None,
+        output: torch.Tensor,
         output_scale: torch.Tensor | None = None,
         output_block_scale: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        assert output is not None, "Output tensor must be provided"
-
         if attn_metadata is None:
             return output
 
         assert attn_metadata.num_seqs == 1, (
             f"Spyre attention requires num_seqs=1, got {attn_metadata.num_seqs}"
         )
+
+        # The metadata builder always populates these on Spyre; narrow the
+        # `Tensor | None` declared on SpyreAttentionMetadata for the type checker.
+        scatter_mask_dev = attn_metadata.scatter_mask_dev
+        scatter_row_sel_dev = attn_metadata.scatter_row_sel_dev
+        scatter_col_sel_dev = attn_metadata.scatter_col_sel_dev
+        gather_sel_mask_dev = attn_metadata.gather_sel_mask_dev
+        attention_mask = attn_metadata.attention_mask
+        assert (
+            scatter_mask_dev is not None
+            and scatter_row_sel_dev is not None
+            and scatter_col_sel_dev is not None
+            and gather_sel_mask_dev is not None
+            and attention_mask is not None
+        ), "SpyreAttentionMetadataBuilder must populate all device-side selectors"
 
         # The value still resides on CPU, as it is
         # created in the GraniteAttention through a split
@@ -549,27 +565,24 @@ class SpyreAttentionImpl(AttentionImpl[SpyreAttentionMetadata]):
         self._scatter_to_device_cache(
             key[:num_actual_tokens],
             value[:num_actual_tokens],
-            attn_metadata.scatter_mask_dev,
-            attn_metadata.scatter_row_sel_dev,
-            attn_metadata.scatter_col_sel_dev,
+            scatter_mask_dev,
+            scatter_row_sel_dev,
+            scatter_col_sel_dev,
             attn_metadata.slot_mapping[:num_actual_tokens],
         )
 
         # Step 2: Gather — sel_mask is precomputed by builder and lives on Spyre
         compact_k, compact_v = self._gather_from_device_cache(
-            attn_metadata.gather_sel_mask_dev,
+            gather_sel_mask_dev,
             attn_metadata.aligned_max_seq_len,
         )
 
         # Step 3: Add batch dim (num_seqs=1)
         query_per_seq = query[:num_actual_tokens].unsqueeze(0)
 
-        # Step 4: Attention mask is precomputed by builder — use directly
-        mask = attn_metadata.attention_mask
-
-        # Step 5: Compute attention
+        # Step 5: Compute attention (mask precomputed by builder)
         attn_output = self._compute_attention(
-            query_per_seq, compact_k, compact_v, mask, query.device, query.dtype
+            query_per_seq, compact_k, compact_v, attention_mask, query.device, query.dtype
         )
 
         # Step 6: Extract actual tokens (num_seqs=1 → simple slice)
@@ -614,7 +627,10 @@ class SpyreAttentionImpl(AttentionImpl[SpyreAttentionMetadata]):
             # output's rank (3D) with the listed dims being singleton.
             head_size = self.head_size
             block_size = self._block_size
+            k_cache_dev = self._k_cache_dev
+            v_cache_dev = self._v_cache_dev
             assert block_size is not None
+            assert k_cache_dev is not None and v_cache_dev is not None
             sm = convert(slot_mapping, device="cpu")
             block_indices = (sm // block_size).tolist()
             block_offsets = (sm % block_size).tolist()
@@ -625,13 +641,15 @@ class SpyreAttentionImpl(AttentionImpl[SpyreAttentionMetadata]):
             # output in eager mode and only becomes in-place via inductor's
             # ReinplacePass — but Attention.forward() runs opaque-to-dynamo,
             # so the clone path persists and writes are lost across forwards.
+            # `torch.ops.spyre.overwrite` is dynamically registered, so its
+            # signature is opaque to the type checker.
             for t in range(num_tokens):
                 br = int(block_indices[t])
                 cs = int(block_offsets[t]) * head_size
                 k_tok = convert(key[t].unsqueeze(1).contiguous(), device=self._target_device)
                 v_tok = convert(value[t].unsqueeze(1).contiguous(), device=self._target_device)
-                torch.ops.spyre.overwrite(k_tok, self._k_cache_dev, [1, 2], [br, cs])
-                torch.ops.spyre.overwrite(v_tok, self._v_cache_dev, [1, 2], [br, cs])
+                torch.ops.spyre.overwrite(k_tok, k_cache_dev, [1, 2], [br, cs])  # ty: ignore[invalid-argument-type]
+                torch.ops.spyre.overwrite(v_tok, v_cache_dev, [1, 2], [br, cs])  # ty: ignore[invalid-argument-type]
             return
 
         # bmm 1: place each token's head_size-vector into its block-width slot.
@@ -652,8 +670,11 @@ class SpyreAttentionImpl(AttentionImpl[SpyreAttentionMetadata]):
         v_vals = torch.bmm(row_sel_dev, v_spread)
 
         # Mutate the persistent KV cache in place.
-        self._k_cache_dev.copy_(self._scatter_cache(self._k_cache_dev, scatter_mask_dev, k_vals))
-        self._v_cache_dev.copy_(self._scatter_cache(self._v_cache_dev, scatter_mask_dev, v_vals))
+        k_cache_dev = self._k_cache_dev
+        v_cache_dev = self._v_cache_dev
+        assert k_cache_dev is not None and v_cache_dev is not None
+        k_cache_dev.copy_(self._scatter_cache(k_cache_dev, scatter_mask_dev, k_vals))
+        v_cache_dev.copy_(self._scatter_cache(v_cache_dev, scatter_mask_dev, v_vals))
 
     def _gather_from_device_cache(
         self,
@@ -664,8 +685,11 @@ class SpyreAttentionImpl(AttentionImpl[SpyreAttentionMetadata]):
         num_kv_heads = self.num_kv_heads
         head_size = self.head_size
 
-        gathered_k = torch.bmm(sel_mask_dev, self._k_cache_dev)
-        gathered_v = torch.bmm(sel_mask_dev, self._v_cache_dev)
+        k_cache_dev = self._k_cache_dev
+        v_cache_dev = self._v_cache_dev
+        assert k_cache_dev is not None and v_cache_dev is not None
+        gathered_k = torch.bmm(sel_mask_dev, k_cache_dev)
+        gathered_v = torch.bmm(sel_mask_dev, v_cache_dev)
 
         gathered_k = gathered_k.reshape(num_kv_heads, aligned_max_seq_len, head_size)
         gathered_v = gathered_v.reshape(num_kv_heads, aligned_max_seq_len, head_size)

--- a/spyre_inference/v1/worker/spyre_model_runner.py
+++ b/spyre_inference/v1/worker/spyre_model_runner.py
@@ -50,6 +50,7 @@ from vllm.config import VllmConfig, CompilationMode
 from vllm.logger import init_logger
 from vllm.model_executor.model_loader import get_model_loader
 from vllm.model_executor.layers.attention.attention import Attention
+from vllm.v1.utils import CpuGpuBuffer
 from vllm.v1.worker.cpu_model_runner import _torch_cuda_wrapper
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 
@@ -59,13 +60,16 @@ from spyre_inference.custom_ops.utils import convert
 logger = init_logger(__name__)
 
 
-class SpyreCpuGpuBuffer:
+class SpyreCpuGpuBuffer(CpuGpuBuffer):
     """Spyre-specific CpuGpuBuffer with Spyre-safe copies and split dtypes.
     This buffer is closely related to the CpuGpuBuffer in vllm/v1/utils.py.
 
     For float dtypes: .cpu on CPU, .gpu on Spyre (float16).
     For int/bool dtypes: .gpu aliased to .cpu (CPUModelRunner pattern).
     All copies are currently synchronous as torch-spyre does not yet support `non_blocking`.
+
+    Inherits from `CpuGpuBuffer` (without invoking its `__init__`) so that
+    `_make_buffer` overrides remain Liskov-compatible with `GPUModelRunner`.
     """
 
     def __init__(
@@ -102,10 +106,13 @@ class SpyreCpuGpuBuffer:
         dst.copy_(src)
         return dst
 
-    # Currently only the copy_to_gpu function is invoked.
-    # If the copy_to_cpu also becomes required, override it here with
-    # spyre-specific aspects.
-    # def copy_to_cpu(self, n: int | None = None) -> torch.Tensor:
+    def copy_to_cpu(self, n: int | None = None) -> torch.Tensor:
+        # Currently only the copy_to_gpu function is invoked.
+        # If the copy_to_cpu also becomes required, override it here with
+        # spyre-specific aspects.
+        raise NotImplementedError(
+            "SpyreCpuGpuBuffer.copy_to_cpu is not implemented"
+        )
 
 
 class _SpyreModelWrapper:
@@ -320,13 +327,23 @@ class TorchSpyreModelRunner(GPUModelRunner):
         logger.info("Warmup done.")
 
     # --- KV cache allocation ---
-    # Potential sub to override KV cache tensor allocation
-    def _allocate_kv_cache_tensors(
+    # The "exp" path stores (k_cache, v_cache) tuples through this dict so
+    # that `_reshape_kv_cache_tensors` (also overridden) can pass them
+    # through unchanged. The base contract is `dict[str, torch.Tensor]`, but
+    # only the matching overridden `_reshape_kv_cache_tensors` consumes the
+    # values for the exp path, so the runtime contract is preserved between
+    # the pair of overrides. ty cannot see this co-evolution, hence the
+    # widened return type and the suppressions.
+    def _allocate_kv_cache_tensors(  # ty: ignore[invalid-method-override]
         self,
         kv_cache_config,
     ) -> dict[str, torch.Tensor | tuple[torch.Tensor, torch.Tensor]]:
         if envs.SPYRE_ATTN_IMPL == "exp":
             kv_cache_raw_tensors: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
+            # `model_config.dtype` is typed as `ModelDType | torch.dtype`, but
+            # `TorchSpyrePlatform.check_and_update_config` rejects anything but
+            # `torch.float16` before this point.
+            assert isinstance(self.dtype, torch.dtype)
             for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
                 block_size = self.vllm_config.cache_config.block_size
                 num_blocks = kv_cache_config.num_blocks
@@ -363,9 +380,9 @@ class TorchSpyreModelRunner(GPUModelRunner):
             assert layer_names == set(kv_cache_raw_tensors.keys()), (
                 "Some layers are not correctly initialized"
             )
-            return kv_cache_raw_tensors
+            return kv_cache_raw_tensors  # ty: ignore[invalid-return-type]
         else:
-            return super()._allocate_kv_cache_tensors(kv_cache_config)
+            return super()._allocate_kv_cache_tensors(kv_cache_config)  # ty: ignore[invalid-return-type]
 
     def _reshape_kv_cache_tensors(
         self,
@@ -402,6 +419,7 @@ class TorchSpyreModelRunner(GPUModelRunner):
         # Unwrap torch.compile's OptimizedModule (has _orig_mod attribute)
         if hasattr(model, "_orig_mod"):
             model = model._orig_mod
+        assert isinstance(model, nn.Module)
         return model
 
     # --- Buffer management ---

--- a/spyre_inference/v1/worker/spyre_model_runner.py
+++ b/spyre_inference/v1/worker/spyre_model_runner.py
@@ -110,9 +110,7 @@ class SpyreCpuGpuBuffer(CpuGpuBuffer):
         # Currently only the copy_to_gpu function is invoked.
         # If the copy_to_cpu also becomes required, override it here with
         # spyre-specific aspects.
-        raise NotImplementedError(
-            "SpyreCpuGpuBuffer.copy_to_cpu is not implemented"
-        )
+        raise NotImplementedError("SpyreCpuGpuBuffer.copy_to_cpu is not implemented")
 
 
 class _SpyreModelWrapper:

--- a/spyre_inference/v1/worker/spyre_model_runner.py
+++ b/spyre_inference/v1/worker/spyre_model_runner.py
@@ -328,24 +328,24 @@ class TorchSpyreModelRunner(GPUModelRunner):
     def initialize_kv_cache_tensors(self, kv_cache_config, kernel_block_sizes):
         """Allocate KV cache as lists of individual page tensors on Spyre.
 
-        Each layer gets its own tuple (k_pages, v_pages) where each is a list
-        of tensors of shape [num_kv_heads, block_size, head_size] on the Spyre
-        device. This matches upstream vLLM's paged model but uses list indices
-        instead of tensor indices — enabling direct per-page bmm without
-        advanced indexing.
+        Each layer gets its own SpyrePagedKVCache(k_pages, v_pages) where each
+        is a list of tensors of shape [num_kv_heads, block_size, head_size] on
+        the Spyre device. This matches upstream vLLM's paged model but uses
+        list indices instead of tensor indices — enabling direct per-page bmm
+        without advanced indexing.
         """
         from vllm.v1.worker.utils import bind_kv_cache
+        from spyre_inference.v1.attention.backends.spyre_attn import SpyrePagedKVCache
 
         # Iterate kv_cache_tensors (one entry per physical buffer)
         spec_by_layer = {
             ln: g.kv_cache_spec for g in kv_cache_config.kv_cache_groups for ln in g.layer_names
         }
 
-        # Each value is a (k_pages, v_pages) tuple of per-page tensor lists.
-        # vLLM's `bind_kv_cache` types this as `dict[str, torch.Tensor]`, but
-        # the matching `SpyreAttentionImpl.forward` unpacks the tuple — see
-        # the suppression on `bind_kv_cache(...)` below.
-        kv_caches: dict[str, tuple[list[torch.Tensor], list[torch.Tensor]]] = {}
+        # vLLM's `bind_kv_cache` types this dict as `dict[str, torch.Tensor]`,
+        # but the matching `SpyreAttentionImpl.forward` consumes the
+        # SpyrePagedKVCache — see the suppression on `bind_kv_cache(...)` below.
+        kv_caches: dict[str, SpyrePagedKVCache] = {}
 
         for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
             # All layers in `shared_by` use the same spec by construction.
@@ -376,7 +376,7 @@ class TorchSpyreModelRunner(GPUModelRunner):
                 for _ in range(num_blocks)
             ]
 
-            page_cache = (k_pages, v_pages)
+            page_cache = SpyrePagedKVCache(k_pages=k_pages, v_pages=v_pages)
             for layer_name in kv_cache_tensor.shared_by:
                 kv_caches[layer_name] = page_cache
 

--- a/spyre_inference/v1/worker/spyre_model_runner.py
+++ b/spyre_inference/v1/worker/spyre_model_runner.py
@@ -341,7 +341,11 @@ class TorchSpyreModelRunner(GPUModelRunner):
             ln: g.kv_cache_spec for g in kv_cache_config.kv_cache_groups for ln in g.layer_names
         }
 
-        kv_caches: dict[str, torch.Tensor] = {}
+        # Each value is a (k_pages, v_pages) tuple of per-page tensor lists.
+        # vLLM's `bind_kv_cache` types this as `dict[str, torch.Tensor]`, but
+        # the matching `SpyreAttentionImpl.forward` unpacks the tuple — see
+        # the suppression on `bind_kv_cache(...)` below.
+        kv_caches: dict[str, tuple[list[torch.Tensor], list[torch.Tensor]]] = {}
 
         for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
             # All layers in `shared_by` use the same spec by construction.
@@ -380,7 +384,7 @@ class TorchSpyreModelRunner(GPUModelRunner):
             kv_caches[layer_name] = kv_caches[target]
 
         bind_kv_cache(
-            kv_caches,
+            kv_caches,  # ty: ignore[invalid-argument-type]
             self.compilation_config.static_forward_context,
             self.kv_caches,
         )

--- a/spyre_inference/v1/worker/spyre_worker.py
+++ b/spyre_inference/v1/worker/spyre_worker.py
@@ -81,7 +81,11 @@ class TorchSpyreWorker(CPUWorker):
         # `set_device(local_rank)` above; tensors created on
         # `torch.device("spyre")` will land on that card.
         original = cpu_worker_module.CPUModelRunner
-        cpu_worker_module.CPUModelRunner = lambda *a, **kw: TorchSpyreModelRunner(
+        # Monkey-patching `CPUModelRunner` (a class attribute) with a factory
+        # function widens its declared class type; `cpu_worker_module` does
+        # not type-annotate the attribute so we cannot avoid the assignment
+        # error from ty without a suppression here.
+        cpu_worker_module.CPUModelRunner = lambda *a, **kw: TorchSpyreModelRunner(  # ty: ignore[invalid-assignment]
             self.vllm_config,
             torch.device("spyre"),
         )
@@ -96,7 +100,7 @@ class TorchSpyreWorker(CPUWorker):
         import time
 
         import torch._inductor.decomposition
-        from torch_spyre._inductor.decompositions import spyre_decompositions  # ty: ignore[unresolved-import]
+        from torch_spyre._inductor.decompositions import spyre_decompositions
 
         for op, impl in spyre_decompositions.items():
             if "addm" in op.name():

--- a/tests/test_spyre_attn.py
+++ b/tests/test_spyre_attn.py
@@ -23,6 +23,7 @@ from vllm.utils.torch_utils import set_random_seed
 from spyre_inference.v1.attention.backends.spyre_attn import (
     SpyreAttentionImpl,
     SpyreAttentionMetadataBuilder,
+    SpyrePagedKVCache,
 )
 
 
@@ -438,7 +439,7 @@ def test_spyre_attn(
     )
 
     output = torch.empty_like(query).to(cache_device)
-    kv_cache = (k_pages, v_pages)
+    kv_cache = SpyrePagedKVCache(k_pages=k_pages, v_pages=v_pages)
     # Note: attn_impl.forward() internally calls _reshape_and_cache() to write
     # the new K/V tokens into the cache, so this test exercises both the cache
     # writing and attention computation paths. TODO: Add a dedicated unit test


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

- Uses the spyre runners to finally run the type checker as part of our `pre-commit` job.
- Fixes up existing type errors in the code base.
- Fixes the UV caching so that:
  - caching is done per-base-image to account for spyre runtime lib updates
  - build timeout is increased to allow concurrent jobs to use the same cache

## Related Issues

Closes #191 

## Test Plan

- [x] unit tests pass
- [x] `ty` checks pass

## Checklist

- [x] I have read the [contributing guidelines](https://torch-spyre.github.io/spyre-inference/contributing/)
- [x] My code follows the project's code style (run `bash format.sh`)
- [x] I have added tests for my changes (if applicable)
- [x] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
