### PR TITLE
Enable torch compile

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,12 +11,12 @@ description = "Next iteration of sendnn-inference on the torch-spyre stack"
 readme = "README.md"
 license = {text = "Apache-2.0"}
 dependencies = [
-    "torch-spyre",
-    "vllm",
+    # "torch-spyre",
+    # "vllm",
 
     # Listing as a direct dep to ensure this is picked up from the pytorch-cpu index
     # Version intentionally left out: Compatibility is determined by torch-spyre and vllm
-    "torch",
+    # "torch",
 ]
 requires-python = ">=3.11"
 dynamic = ["version"]
@@ -60,17 +60,17 @@ override-dependencies = [
 
     # Skipping torch-vision temporarily
     # TODO: This will be required in the future for VLM support via vllm
-    "torchvision; sys_platform == 'never'",
+    # "torchvision; sys_platform == 'never'",
 
     # Skip packages on s390x and ppc64le that are expected to be pre-installed
-    "vllm ; platform_machine not in 's390x, ppc64le'",
+    # "vllm ; platform_machine not in 's390x, ppc64le'",
     "ray; platform_machine not in 's390x, ppc64le'",
     # uv doesn't resolve numba->llvmlite constraint correctly...
     #   if numba is updated, this version will likely need to be too
     "llvmlite==0.47.0; platform_machine not in 's390x, ppc64le'",
     "pyarrow; platform_machine not in 's390x, ppc64le'",
     # This torch version must match the one below in `build-constraint-dependencies`
-    "torch==2.11.0 ; platform_machine not in 's390x, ppc64le'",
+    # "torch==2.11.0 ; platform_machine not in 's390x, ppc64le'",
 
     # torch-spyre declares a dependency on numpy>2.3, conflicting with numba needed by vLLM
     # The range here should match the numba dependency

--- a/spyre_inference/custom_ops/__init__.py
+++ b/spyre_inference/custom_ops/__init__.py
@@ -21,7 +21,8 @@ from . import rms_norm
 from . import rotary_embedding
 from . import linear
 from . import silu_and_mul
-from . import vocab_parallel_embedding  # noqa: F401
+from . import vocab_parallel_embedding
+from . import utils
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
@@ -30,5 +31,5 @@ logger = init_logger(__name__)
 @lru_cache(maxsize=1)
 def register_all():
     logger.info("Registering custom ops for spyre_inference")
+    utils.register()
     rotary_embedding.register()
-    rms_norm.register()

--- a/spyre_inference/custom_ops/parallel_lm_head.py
+++ b/spyre_inference/custom_ops/parallel_lm_head.py
@@ -124,9 +124,9 @@ class SpyreParallelLMHead(ParallelLMHead):
         """OOT forward pass — lm_head matmul on Spyre.
 
         Called by SpyreUnquantizedLMHeadMethod.apply() from within
-        LogitsProcessor._get_logits(). Converts x (arriving on cpu)
-        to the weight device (residing on spyre), runs the compiled F.linear on spyre
-        and converts back to the x device (cpu).
+        LogitsProcessor._get_logits(). Runs the compiled F.linear on spyre,
+        performs the tensor slicing operation on CPU and converts back
+        to the original x device (spyre).
 
         At TP>1: Each rank computes logits for its vocabulary shard. The weight
         matrix is [num_embeddings_per_partition, hidden_dim], producing logits
@@ -142,13 +142,10 @@ class SpyreParallelLMHead(ParallelLMHead):
         """
         x_device = x.device
 
-        # Due to indexing operations inside the ModelRunner, which have
-        # to be carried out on cpu due to a torch-spyre limitation,
-        # the input to the SpyreParallelLMHead resides on CPU.
-        # Due to a second limitation of torch-spyre regarding sizes that can be used
+        # Due to a limitation of torch-spyre regarding sizes that can be used
         # in a F.linear layer, the original weights need to be padded
         out = F.linear(
-            convert(x, device=self.weight.device),
+            x,
             self.padded_weight.data,
             bias,
         )

--- a/spyre_inference/custom_ops/rms_norm.py
+++ b/spyre_inference/custom_ops/rms_norm.py
@@ -12,83 +12,43 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Spyre-specific RMSNorm implementation using out-of-tree (OOT) registration.
+"""Spyre OOT replacement for RMSNorm.
 
-This module provides a custom RMSNorm layer for IBM's Spyre device,
-replacing the upstream vLLM implementation (vllm/model_executor/layers/layernorm.py)
-when instantiated.
+Inputs and outputs both reside on Spyre, so forward_oot is fully traceable
+by Dynamo and no custom op boundary is needed. The kernel itself is wrapped
+in _maybe_compile so it is compiled independently when called eagerly.
 
-Architecture:
-    - OOT Registration: @RMSNorm.register_oot() replaces upstream at instantiation
-    - forward_oot(): Entry point for OOT dispatch, calls custom op for
-      torch.compile opacity
-    - Custom Op Boundary: torch.ops.vllm.spyre_rmsnorm is opaque to torch.compile,
-      so _forward_spyre_impl runs eagerly outside the compiled graph
-    - Separate Compilation: forward_spyre is compiled independently via maybe_compile
-
-Spyre Device Constraints:
-    - Minimum batch size: 64 (due to spyre constraint, automatically padded)
-    - Computations performed in torch.float16:
-      Input (dtype defined by model / user) converted to torch.float16 for
-      operations on spyre and then converted back to original dtype for cpu.
-    - Epsilon as tensor: Instead of a scalar, a tensor is created via torch.full()
-
-Limitations:
-    Currently the implementation in `forward_spyre` is similar to the
-    upstream implementation in `forward_static` from vllm/model_executor/layers/layernorm.py,
-    but it DOES NOT use the promotion of the data types, as this is not
-    yet supported in torch-spyre.
+Spyre constraints:
+    - Computation is performed in torch.float16.
+    - No dtype promotion to float32 (not yet supported in torch-spyre), so
+      numerical results may differ slightly from upstream vLLM.
+    - variance_epsilon is materialized as a tensor (scalar broadcast unsupported).
 
 References:
     - Upstream RMSNorm: vllm/model_executor/layers/layernorm.py
 """
 
 import torch
-import torch.utils._pytree as pytree
 
 from vllm.logger import init_logger
-from vllm.utils.torch_utils import direct_register_custom_op
 from vllm.model_executor.layers.layernorm import RMSNorm
-from functools import lru_cache
-
-from .utils import convert, register_layer, get_layer, _fake_impl
 
 logger = init_logger(__name__)
 
 
 @RMSNorm.register_oot(name="RMSNorm")
 class SpyreRMSNorm(RMSNorm):
-    """Out-of-tree (OOT) RMSNorm implementation for IBM's Spyre device.
-
-    This replaces the upstream vLLM RMSNorm (vllm/model_executor/layers/layernorm.py)
-    when instantiated, providing Spyre-specific optimizations and device handling.
-    """
+    """OOT RMSNorm for IBM's Spyre device."""
 
     _dynamic_arg_dims = {"x": [], "residual": []}
 
     def __init__(self, *args, **kwargs):
-        """Initialize SpyreRMSNorm layer.
-
-        Compiles the Spyre kernel based on SPYRE_INFERENCE_RMSNORM_KERNEL
-        environment variable and registers this instance in static_forward_context.
-        """
         super().__init__(*args, **kwargs)
-
-        self._target_device = torch.device("spyre")
-        self._target_dtype = torch.float16
-        self.maybe_compiled_forward_spyre = self.maybe_compile(self.forward_spyre)
-
-        self._layer_name = register_layer(self, "spyre_rmsnorm")
+        self._compiled_forward_spyre = self.maybe_compile(self._forward_spyre_impl)
 
         logger.warning_once(
             "SpyreRMSNorm: no dtype promotion is performed, "
             "expect numerical differences to upstream vLLM."
-        )
-        logger.debug_once(
-            "SpyreRMSNorm: Dispatch: enabled=%s, Forward method=%s, Compiled=%s",
-            self.enabled(),
-            self._forward_method.__name__,
-            self.maybe_compiled_forward_spyre is not self.forward_spyre,
         )
 
     def forward_oot(
@@ -96,52 +56,26 @@ class SpyreRMSNorm(RMSNorm):
         x: torch.Tensor,
         residual: torch.Tensor | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        """OOT forward pass.
+        if self.variance_size_override is not None:
+            raise NotImplementedError("TODO: variance_size_override not yet implemented")
 
-        When input is on Spyre, calls _forward_spyre_impl directly to avoid
-        the custom op boundary (Spyre does not support in-device copy_).
-        When input is on CPU, delegates to torch.ops.vllm.spyre_rmsnorm
-        which retrieves this layer from the layer registry and calls
-        _forward_spyre_impl outside the compilation graph.
-
-        Args:
-            x: Input tensor [batch_size, hidden_size]
-            residual: Optional residual tensor
-
-        Returns:
-            Normalized output, or (output, residual) tuple if residual provided
-        """
-        if x.device.type == "spyre":
-            return self._forward_spyre_impl(x, residual)
-
-        output = torch.empty_like(x)
-        residual_out = torch.empty_like(residual) if residual is not None else None
-
-        # `torch.ops.vllm.spyre_rmsnorm` is dynamically registered, so its
-        # signature is opaque to the type checker (ParamSpec resolves to `...`).
-        torch.ops.vllm.spyre_rmsnorm(x, output, self._layer_name, residual, residual_out)  # ty: ignore[invalid-argument-type]
-
-        if residual_out is not None:
-            return output, residual_out
-        return output
+        return self._compiled_forward_spyre(
+            x,
+            self.variance_epsilon,
+            self.hidden_size,
+            self.weight.data if self.has_weight else None,
+            residual,
+        )
 
     @staticmethod
-    def forward_spyre(
+    def _forward_spyre_impl(
         x: torch.Tensor,
         variance_epsilon: float,
         hidden_size: int,
         weight: torch.Tensor | None = None,
         residual: torch.Tensor | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        """Spyre-optimized RMS norm implementation.
-
-        Based on upstream vLLM's forward_static (vllm/model_executor/layers/layernorm.py)
-        but adapted for Spyre device. Compiled separately via torch.compile in __init__.
-
-        Key differences from upstream:
-            - Creates epsilon tensor via torch.full() instead of scalar
-            - No dtype promotion support to torch.float32 (torch-spyre limitation)
-        """
+        """RMSNorm kernel for Spyre. Compiled separately via maybe_compile."""
         if residual is not None:
             x = x + residual
             residual = x
@@ -163,82 +97,3 @@ class SpyreRMSNorm(RMSNorm):
             return x
         else:
             return x, residual
-
-    def _forward_spyre_impl(
-        self,
-        x: torch.Tensor,
-        residual: torch.Tensor | None = None,
-    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        """Spyre device execution with padding, device transfer, and dtype conversion.
-
-        Handles Spyre-specific constraints:
-            1. Minimum batch size: Pads to 64 if needed
-            2. Device transfer: CPU -> Spyre convert to float16
-            3. Kernel execution: Calls compiled maybe_compiled_forward_spyre
-            4. Result transfer: Spyre -> CPU, trim padding, convert to input dtype
-
-        Limitations:
-            - variance_size_override not implemented (raises NotImplementedError)
-
-        Args:
-            x: Input tensor [batch_size, hidden_size]
-            residual: Optional residual
-
-        Returns:
-            Normalized output [batch_size, hidden_size] in input dtype
-        """
-        x_dtype = x.dtype
-        x_device = x.device
-
-        if self.variance_size_override is not None:
-            raise NotImplementedError("TODO: variance_size_override not yet implemented")
-
-        # Execute compiled kernel on Spyre device
-        outs = self.maybe_compiled_forward_spyre(
-            convert(x, self._target_device, self._target_dtype),
-            self.variance_epsilon,
-            self.hidden_size,
-            convert(self.weight.data, self._target_device, self._target_dtype)
-            if self.has_weight
-            else None,
-            convert(residual, self._target_device, self._target_dtype)
-            if residual is not None
-            else None,
-        )
-
-        # Transfer back to original device/dtype
-        return pytree.tree_map(
-            lambda el: convert(el, dtype=x_dtype, device=x_device),
-            outs,
-        )
-
-
-def _op_func(
-    x: torch.Tensor,
-    output: torch.Tensor,
-    layer_name: str,
-    residual: torch.Tensor | None = None,
-    residual_out: torch.Tensor | None = None,
-) -> None:
-    """Custom op implementation — runs outside torch.compile graph."""
-    layer = get_layer(layer_name)
-    result = layer._forward_spyre_impl(x, residual)
-
-    if residual is not None:
-        output_data, residual_data = result
-        output.copy_(output_data)
-        residual_out.copy_(residual_data)
-    else:
-        output.copy_(result)
-
-
-@lru_cache(maxsize=1)
-def register():
-    """Register the spyre_rmsnorm custom op with vLLM."""
-    direct_register_custom_op(
-        op_name="spyre_rmsnorm",
-        op_func=_op_func,
-        mutates_args=["output", "residual_out"],
-        fake_impl=_fake_impl,
-    )
-    logger.info("Registered custom op: SpyreRMSNorm")

--- a/spyre_inference/custom_ops/rotary_embedding.py
+++ b/spyre_inference/custom_ops/rotary_embedding.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Spyre OOT replacement for RotaryEmbedding (CPU fallback).
+"""Spyre OOT replacement for RotaryEmbedding.
 
-Remove this file once Spyre natively supports rotary embedding ops.
+The CPU body is wrapped in a `direct_register_custom_op` so torch.compile does
+NOT trace into RotaryEmbedding.forward_native.
 """
+
+from functools import lru_cache
 
 import torch
 
@@ -24,23 +27,29 @@ from vllm.model_executor.layers.rotary_embedding.base import (
     RotaryEmbedding,
     RotaryEmbeddingBase,
 )
-from functools import lru_cache
+from vllm.utils.torch_utils import direct_register_custom_op
 
-from .utils import convert
+from .utils import get_layer, register_layer
 
 logger = init_logger(__name__)
 
 
 @RotaryEmbeddingBase.register_oot(name="RotaryEmbedding")
 class SpyreRotaryEmbedding(RotaryEmbedding):
-    """OOT RotaryEmbedding that falls back to CPU execution.
+    """OOT RotaryEmbedding: opaque CPU fallback wrapped as a custom op.
 
-    Keeps cos_sin_cache on CPU via an _apply no-op. Inputs are moved to
-    CPU for computation, and outputs are copied back to the original device.
+    Inductor sees one FallbackKernel returning (query, key); the entire
+    rotary computation including index_select runs eagerly on CPU.
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._spyre_layer_name = register_layer(self, "spyre_rotary")
+
     def _apply(self, fn, recurse=True):
-        # Keep cos_sin_cache on CPU so forward_native can use it directly.
+        # Keep cos_sin_cache (and any other buffers/params) on CPU. Spyre's
+        # fp16 differs from CPU's bit-for-bit; round-tripping the cache
+        # through Spyre corrupts it and produces wrong tokens.
         return self
 
     def forward(
@@ -49,35 +58,74 @@ class SpyreRotaryEmbedding(RotaryEmbedding):
         query: torch.Tensor,
         key: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
-        # positions arrive on Spyre
-        target_device = positions.device
-        target_dtype = query.dtype
-
-        cpu_positions = convert(positions, device="cpu")
-        cpu_query = convert(query, device="cpu")
-        cpu_key = convert(key, device="cpu")
-
-        result_query, result_key = RotaryEmbedding.forward_native(
-            self,
-            cpu_positions,
-            cpu_query,
-            cpu_key,
+        # infer_schema rejects Optional[Tensor] returns, so use an empty
+        # tensor sentinel across the op boundary.
+        key_in = key if key is not None else torch.empty(0, device=query.device, dtype=query.dtype)
+        # cos_sin_cache is fetched inside the op via get_layer(layer_name);
+        # torch.ops dispatcher signature is opaque to the type checker (resolves to `...`).
+        out_q, out_k = torch.ops.vllm.spyre_rotary_cpu(
+            positions,  # ty: ignore[invalid-argument-type]
+            query,  # ty: ignore[invalid-argument-type]
+            key_in,  # ty: ignore[invalid-argument-type]
+            self._spyre_layer_name,  # ty: ignore[invalid-argument-type]
         )
+        if key is None:
+            return out_q, None
+        return out_q, out_k
 
-        out_query = convert(result_query, device=target_device, dtype=target_dtype)
-        out_key = (
-            convert(result_key, device=target_device, dtype=target_dtype)
-            if result_key is not None
-            else None
-        )
-        return out_query, out_key
+
+def _rotary_cpu_op_func(
+    positions: torch.Tensor,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    layer_name: str,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    # cos_sin_cache currently stays CPU permanently (see SpyreRotaryEmbedding._apply)
+    layer = get_layer(layer_name)
+    target_device = positions.device
+    target_dtype = query.dtype
+
+    cpu_positions = positions.to("cpu")
+    cpu_query = query.to("cpu")
+    cpu_key = key.to("cpu") if key.numel() > 0 else None
+
+    out_q, out_k = RotaryEmbedding.forward_static(
+        cpu_positions,
+        cpu_query,
+        cpu_key,
+        layer.head_size,
+        layer.rotary_dim,
+        layer.cos_sin_cache,
+        layer.is_neox_style,
+    )
+
+    out_q = out_q.to(device=target_device, dtype=target_dtype)
+    if out_k is None:
+        out_k = torch.empty(0, device=target_device, dtype=target_dtype)
+    else:
+        out_k = out_k.to(device=target_device, dtype=target_dtype)
+    return out_q, out_k
+
+
+def _rotary_cpu_op_fake(
+    positions: torch.Tensor,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    layer_name: str,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    out_q = torch.empty(query.shape, dtype=query.dtype, device=positions.device)
+    out_k = torch.empty(key.shape, dtype=query.dtype, device=positions.device)
+    return out_q, out_k
 
 
 @lru_cache(maxsize=1)
 def register():
-    # No-op: RotaryEmbedding doesn't require custom op registration.
-
-    # Unlike other Spyre layers (RMSNorm, SiluAndMul, etc.), RotaryEmbedding
-    # only needs a class replacement that overrides _apply() to keep weights on CPU.
-    # This replacement happens at import time via @RotaryEmbedding.register_oot().
-    pass
+    """Register the spyre_rotary_cpu custom op with vLLM."""
+    direct_register_custom_op(
+        op_name="spyre_rotary_cpu",
+        op_func=_rotary_cpu_op_func,
+        fake_impl=_rotary_cpu_op_fake,
+        mutates_args=[],
+        dispatch_key="CompositeExplicitAutograd",
+    )
+    logger.debug_once("Registered custom op: spyre_rotary_cpu")

--- a/spyre_inference/custom_ops/silu_and_mul.py
+++ b/spyre_inference/custom_ops/silu_and_mul.py
@@ -76,8 +76,7 @@ class SpyreSiluAndMul(SiluAndMul):
         original_device = x.device
 
         # Move to CPU if on Spyre (slicing Spyre tensors causes corruption).
-        if x.device.type == "spyre":
-            x = convert(x, device="cpu")
+        x = convert(x, device="cpu")
 
         # Slice and make contiguous before transferring to Spyre.
         # Non-contiguous slices get corrupted during transfer to Spyre!

--- a/spyre_inference/custom_ops/utils.py
+++ b/spyre_inference/custom_ops/utils.py
@@ -19,9 +19,13 @@ for execution on IBM's Spyre device, primarily handling device transfer and
 dtype conversion.
 """
 
+from functools import lru_cache
 from typing import Any
 
+import torch
+
 from vllm.logger import init_logger
+from vllm.utils.torch_utils import direct_register_custom_op
 
 logger = init_logger(__name__)
 
@@ -56,29 +60,21 @@ def get_layer(name: str) -> Any:
     return _LAYER_REGISTRY[name]
 
 
-def _fake_impl(*args, **kwargs) -> None:
-    """No-op fake implementation for shape inference during torch.compile tracing."""
-    return
+def _convert_op_func(
+    tensor: torch.Tensor,
+    device: torch.device | None = None,
+    dtype: torch.dtype | None = None,
+) -> torch.Tensor:
+    """Opaque-op body: device/dtype conversion with the Spyre dtype detour.
 
-
-def convert(tensor, device=None, dtype=None):
-    """Convert tensor device and/or dtype. No-op when both are None.
-
-    Args:
-        tensor: Input tensor, or None (passed through as None).
-        device: Target device (None = keep current).
-        dtype: Target dtype (None = keep current).
-
-    Returns:
-        Converted tensor, or None if input is None.
+    Hidden behind `torch.ops.vllm.spyre_convert` so the device transfers and
+    the spyre `torch.Tensor.to` monkey-patch are not traced into outer
+    torch.compile graphs (no DeviceCopy nodes leak into the Inductor IR).
     """
-    if tensor is None:
-        return None
-
-    target_device = device if device is not None else tensor.device.type
+    target_device = device if device is not None else tensor.device
     target_dtype = dtype if dtype is not None else tensor.dtype
 
-    if tensor.device.type == target_device and tensor.dtype == target_dtype:
+    if tensor.device.type == target_device.type and tensor.dtype == target_dtype:
         return tensor
 
     # Spyre requires CPU for dtype changes
@@ -88,7 +84,54 @@ def convert(tensor, device=None, dtype=None):
     if tensor.dtype != target_dtype:
         tensor = tensor.to(dtype=target_dtype)
 
-    if tensor.device.type != target_device:
+    if tensor.device.type != target_device.type:
         tensor = tensor.to(device=target_device)
 
     return tensor
+
+
+def _convert_op_fake(
+    tensor: torch.Tensor,
+    device: torch.device | None = None,
+    dtype: torch.dtype | None = None,
+) -> torch.Tensor:
+    target_device = device if device is not None else tensor.device
+    target_dtype = dtype if dtype is not None else tensor.dtype
+    return torch.empty(tensor.shape, dtype=target_dtype, device=target_device)
+
+
+def convert(tensor, device=None, dtype=None):
+    """Convert tensor device and/or dtype. No-op when both are None.
+
+    Routes through the opaque custom op `torch.ops.vllm.spyre_convert` so the
+    transfer is invisible to torch.compile / Dynamo. None tensors are
+    short-circuited at the Python boundary because `infer_schema` does not
+    accept Optional[Tensor] returns.
+
+    Args:
+        tensor: Input tensor, or None (passed through as None).
+        device: Target device as `str` or `torch.device` (None = keep current).
+        dtype: Target dtype (None = keep current).
+
+    Returns:
+        Converted tensor, or None if input is None.
+    """
+    if tensor is None:
+        return None
+    if isinstance(device, str):
+        device = torch.device(device)
+    return torch.ops.vllm.spyre_convert(tensor, device, dtype)  # ty: ignore[invalid-argument-type]
+
+
+@lru_cache(maxsize=1)
+def register():
+    """Register the spyre_convert custom op with vLLM."""
+    # CompositeExplicitAutograd so the op dispatches regardless of input device
+    # (convert is called with both CPU and Spyre input tensors).
+    direct_register_custom_op(
+        op_name="spyre_convert",
+        op_func=_convert_op_func,
+        fake_impl=_convert_op_fake,
+        dispatch_key="CompositeExplicitAutograd",
+    )
+    logger.debug_once("Registered custom op: spyre_convert")

--- a/spyre_inference/platform.py
+++ b/spyre_inference/platform.py
@@ -56,12 +56,7 @@ class TorchSpyrePlatform(CpuPlatform):
     device_name: str = "cpu"
     device_type: str = "cpu"
 
-    # Primary dispatch key for direct_register_custom_op. Kept as CPU
-    # because some custom ops receive CPU-only tensors (e.g. rotary_embedding).
-    # All ops are ALSO registered for PrivateUse1 (Spyre) via
-    # register_spyre_dispatch() in each module's register() function,
-    # so dispatch works regardless of tensor device.
-    dispatch_key: str = "CPU"
+    dispatch_key: str = "PrivateUse1"
 
     # Multi-backend init string consumed by both vllm's
     # `init_distributed_environment` and `torch.distributed.new_group`.
@@ -79,18 +74,6 @@ class TorchSpyrePlatform(CpuPlatform):
         _backend_path = "spyre_inference.v1.attention.backends.spyre_attn.SpyreAttentionBackend"
 
     register_backend(AttentionBackendEnum.CUSTOM, _backend_path)
-
-    @classmethod
-    def opaque_attention_op(cls) -> bool:
-        # This is required to keep the output tensor of attention on Spyre.
-        # Inherited from CpuPlatform as True, which would route attention through
-        # torch.ops.vllm.unified_attention_with_output.
-        # This override disables the opaque-op boundary and vLLM then calls the
-        # Attention.forward directly.
-        #
-        # This has though implications for torch.compile, because if
-        # enforce_eager=False, the attention implementation is also traced and compiled.
-        return False
 
     @classmethod
     def get_device_name(cls, device_id: int = 0) -> str:
@@ -137,13 +120,6 @@ class TorchSpyrePlatform(CpuPlatform):
         from vllm.config import CompilationMode
 
         vllm_config.compilation_config.mode = CompilationMode.NONE
-
-        # Force eager execution. torch.compile with the Spyre inductor
-        # backend requires ALL graph tensors on Spyre, but our CPU fallback
-        # ops (embedding, linear, rotary, attention) create intermediate
-        # CPU tensors that the Spyre backend cannot codegen. Once all layers
-        # run natively on Spyre, this can be removed to enable compilation.
-        vllm_config.model_config.enforce_eager = True
 
         # In check_and_update_config we assert this must be float16 for spyre.
         # This must be set here as the default, otherwise all usage (including test fixtures) would

--- a/spyre_inference/v1/attention/backends/spyre_attn.py
+++ b/spyre_inference/v1/attention/backends/spyre_attn.py
@@ -18,6 +18,7 @@ from dataclasses import dataclass
 from typing import Callable, ClassVar, NamedTuple
 
 import torch
+import traceback
 
 from spyre_inference.custom_ops.utils import convert
 
@@ -159,7 +160,11 @@ def _indirect_matmul_mock(
             b = transform_b(b)
 
     # do the actual matmul
-    output = torch.matmul(a, b)
+    try:
+        output = torch.matmul(a, b)
+    except Exception:
+        print(traceback.format_exc())
+        raise Exception('Fail!')
     return output
 
 

--- a/spyre_inference/v1/worker/spyre_model_runner.py
+++ b/spyre_inference/v1/worker/spyre_model_runner.py
@@ -163,6 +163,19 @@ class _SpyreModelWrapper:
 
         return tree_map(_to_cpu, result)
 
+    def compute_logits(self, hidden_states, *args, **kwargs):
+        """Move hidden_states onto Spyre for the lm_head custom op.
+
+        gpu_model_runner.execute_model slices `hidden_states[logits_indices]`
+        on CPU (Spyre cannot slice), so the tensor handed to compute_logits
+        is on CPU. Thus, convert here, perform the lm_head operation and
+        then convert the resulting logits back to CPU
+        for downstream sampling.
+        """
+        hidden_states = convert(hidden_states, device=self._spyre_device)
+        logits = self._model.compute_logits(hidden_states, *args, **kwargs)
+        return convert(logits, device="cpu")
+
     def __getattr__(self, name):
         return getattr(self._model, name)
 

--- a/spyre_inference/v1/worker/spyre_worker.py
+++ b/spyre_inference/v1/worker/spyre_worker.py
@@ -81,10 +81,6 @@ class TorchSpyreWorker(CPUWorker):
         # `set_device(local_rank)` above; tensors created on
         # `torch.device("spyre")` will land on that card.
         original = cpu_worker_module.CPUModelRunner
-        # Monkey-patching `CPUModelRunner` (a class attribute) with a factory
-        # function widens its declared class type; `cpu_worker_module` does
-        # not type-annotate the attribute so we cannot avoid the assignment
-        # error from ty without a suppression here.
         cpu_worker_module.CPUModelRunner = lambda *a, **kw: TorchSpyreModelRunner(  # ty: ignore[invalid-assignment]
             self.vllm_config,
             torch.device("spyre"),

--- a/tests/test_rms_norm.py
+++ b/tests/test_rms_norm.py
@@ -65,17 +65,19 @@ def test_spyre_rmsnorm_matches_reference(batch_size, hidden_size, use_residual):
     expected = reference_rms_norm(x, layer.weight.data, eps, residual)
 
     # Test forward_oot (Spyre device execution via custom op)
-    actual = layer.forward_oot(x, residual)
+    actual = layer.forward_oot(x.to("spyre"), residual.to("spyre") if use_residual else None)
 
     if use_residual:
         expected_norm, expected_resid = expected
         actual_norm, actual_resid = actual
-        torch.testing.assert_close(actual_norm.float(), expected_norm.float(), atol=1e-2, rtol=1e-2)
         torch.testing.assert_close(
-            actual_resid.float(), expected_resid.float(), atol=1e-2, rtol=1e-2
+            actual_norm.cpu().float(), expected_norm.float(), atol=1e-2, rtol=1e-2
+        )
+        torch.testing.assert_close(
+            actual_resid.cpu().float(), expected_resid.float(), atol=1e-2, rtol=1e-2
         )
     else:
-        torch.testing.assert_close(actual.float(), expected.float(), atol=1e-2, rtol=1e-2)
+        torch.testing.assert_close(actual.cpu().float(), expected.float(), atol=1e-2, rtol=1e-2)
 
 
 @pytest.fixture
@@ -83,12 +85,14 @@ def dummy_tensor():
     return torch.randn(4, 128, dtype=torch.float32)
 
 
-def mock_forward_oot(x, residual=None):
+def mock_forward_oot(x, variance_epsilon=None, hidden_size=None, weight=None, residual=None):
     """Mock: return x + 1 (no residual path)."""
     return x + 1
 
 
-def mock_forward_oot_with_residual(x, residual=None):
+def mock_forward_oot_with_residual(
+    x, variance_epsilon=None, hidden_size=None, weight=None, residual=None
+):
     """Mock: return (2 * x, 2 * residual) (residual path)."""
     return 2 * x, 2 * residual
 
@@ -110,9 +114,9 @@ def test_rmsnorm_oot_dispatch(monkeypatch, dummy_tensor, use_residual):
 
     residual = torch.randn(4, 128, dtype=torch.float32) if use_residual else None
 
-    # Mock _forward_spyre_impl (called by the custom op) with a known transform
+    # Mock _compiled_forward_spyre (called by the custom op) with a known transform
     if residual is not None:
-        monkeypatch.setattr(layer, "_forward_spyre_impl", mock_forward_oot_with_residual)
+        monkeypatch.setattr(layer, "_compiled_forward_spyre", mock_forward_oot_with_residual)
         out_x, out_residual = layer.forward(dummy_tensor, residual)
 
         assert torch.allclose(out_x, 2 * dummy_tensor)
@@ -120,7 +124,7 @@ def test_rmsnorm_oot_dispatch(monkeypatch, dummy_tensor, use_residual):
         # The residual is modified in-place
         assert torch.allclose(out_residual, 2 * residual)
     else:
-        monkeypatch.setattr(layer, "_forward_spyre_impl", mock_forward_oot)
+        monkeypatch.setattr(layer, "_compiled_forward_spyre", mock_forward_oot)
         out_x = layer.forward(dummy_tensor, residual)
 
         assert torch.allclose(out_x, dummy_tensor + 1)


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

This PR removes the hard-coded enforce_eager=True from the platform.py, see https://github.com/torch-spyre/spyre-inference/blob/54fafa01df794217388dbc25a1a1781ce96b2dd6/spyre_inference/platform.py#L141-L146
With this, the user can choose to use torch.compile or eager-mode to execute the models. However, there is currently a torch-spyre issue blocking this PR from landing. We will open the respective issue and PR soon.

## Related Issues

https://github.com/torch-spyre/spyre-inference/issues/245

## Test Plan

TBD

## Checklist

- [X] I have read the [contributing guidelines](https://torch-spyre.github.io/spyre-inference/contributing/)
- [X] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [X] My commits include a `Signed-off-by:` line (DCO compliance)
