### PR TITLE
Add Spyre paged KV connector NIXL path

### DIFF
--- a/examples/kv_connector/spyre_connector_nixl_smoke.py
+++ b/examples/kv_connector/spyre_connector_nixl_smoke.py
@@ -1,0 +1,499 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Connector-level KV smoke test for InMemorySpyreConnector.
+
+Drives the real connector path — not nixl._api directly:
+
+    register_kv_caches -> bind_connector_metadata
+        -> wait_for_save (prefill) / start_load_kv (decode)
+        -> verify KV block contents
+
+The synthetic KV cache uses the Spyre paged layout: each layer cache is
+``(k_pages, v_pages)`` with per-page tensors ``[num_kv_heads, block_size,
+head_dim]``, so ``SpyrePagedKVCacheAccessor`` is active.
+
+Modes:
+
+* In-process roundtrip (no NIXL): both halves share the global store.
+      python examples/kv_connector/spyre_connector_nixl_smoke.py --role both
+
+* Two-process / two-pod NIXL: the producer saves through
+  ``_save_request_nixl`` (non-blocking), exposes pending transfers, and
+  keeps serving LIST/PULL requests; the consumer pulls through
+  ``_load_saved_requests_nixl`` then loads pages via ``start_load_kv``.
+      # pod 1
+      python ... --role prefill --nixl --listen-port 9100 \
+          --ready-file /shared/prefill_ready.json --expected-json /shared/expected.json
+      # pod 2
+      python ... --role decode --nixl --prefill-ip <pod1-ip> --prefill-port 9100 \
+          --ready-file /shared/prefill_ready.json --expected-json /shared/expected.json
+
+Grep-friendly markers:
+    CONNECTOR_PREFILL_READY / CONNECTOR_SAVE_DONE / CONNECTOR_NIXL_READY
+    CONNECTOR_PREFILL_KEEPALIVE_DONE
+    CONNECTOR_DECODE_START / CONNECTOR_NIXL_PULL_DONE / CONNECTOR_LOAD_DONE
+    CONNECTOR_CONTENT_MATCH true|false
+    CONNECTOR_SMOKE_SUCCESS true|false
+
+This module's helpers (CLI parser, paged cache builder, checksums) import
+without vLLM; the connector itself is imported lazily inside main().
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import pathlib
+import time
+from typing import Any
+
+import torch
+
+MARK_PREFILL_READY = "CONNECTOR_PREFILL_READY"
+MARK_SAVE_DONE = "CONNECTOR_SAVE_DONE"
+MARK_NIXL_READY = "CONNECTOR_NIXL_READY"
+MARK_KEEPALIVE_DONE = "CONNECTOR_PREFILL_KEEPALIVE_DONE"
+MARK_DECODE_START = "CONNECTOR_DECODE_START"
+MARK_NIXL_PULL_DONE = "CONNECTOR_NIXL_PULL_DONE"
+MARK_LOAD_DONE = "CONNECTOR_LOAD_DONE"
+MARK_CONTENT_MATCH = "CONNECTOR_CONTENT_MATCH"
+MARK_SUCCESS = "CONNECTOR_SMOKE_SUCCESS"
+
+PREFILL_REQ_ID = "smoke-prefill-0"
+DECODE_REQ_ID = "smoke-decode-0"
+DEFAULT_NIXL_PORT = 9100
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--role", choices=("prefill", "decode", "both"), required=True)
+    parser.add_argument("--num-layers", type=int, default=2)
+    parser.add_argument("--num-kv-heads", type=int, default=2)
+    parser.add_argument("--block-size", type=int, default=4)
+    parser.add_argument("--head-dim", type=int, default=8)
+    parser.add_argument("--num-pages", type=int, default=4)
+    parser.add_argument("--block-ids", type=int, nargs="+", default=[1, 2])
+    parser.add_argument("--device", default="cpu", help="page tensor device (cpu for smoke)")
+    parser.add_argument(
+        "--result-file",
+        "--result-json",
+        dest="result_file",
+        default="spyre_connector_smoke_result.json",
+        help="where to write the JSON result (--result-json is an alias)",
+    )
+    # Split-process / two-pod NIXL mode.
+    parser.add_argument(
+        "--nixl",
+        action="store_true",
+        help="use the connector NIXL transport (split prefill/decode processes)",
+    )
+    parser.add_argument("--prefill-ip", default="127.0.0.1", help="producer IP (decode side)")
+    parser.add_argument(
+        "--prefill-port", type=int, default=DEFAULT_NIXL_PORT, help="producer port (decode side)"
+    )
+    parser.add_argument(
+        "--listen-port", type=int, default=DEFAULT_NIXL_PORT, help="producer port (prefill side)"
+    )
+    parser.add_argument("--source-request-id", default=PREFILL_REQ_ID)
+    parser.add_argument("--request-id", default=DECODE_REQ_ID)
+    parser.add_argument("--timeout-s", type=float, default=120.0)
+    parser.add_argument(
+        "--ready-file",
+        default="",
+        help="prefill writes this file when NIXL is ready; decode waits for it",
+    )
+    parser.add_argument(
+        "--expected-json",
+        default="",
+        help="prefill writes expected checksums here; decode verifies against it",
+    )
+    parser.add_argument(
+        "--keepalive-s",
+        type=float,
+        default=60.0,
+        help="prefill stays alive serving pull requests for this many seconds",
+    )
+    return parser
+
+
+def layer_names(num_layers: int) -> list[str]:
+    return [f"model.layers.{i}.self_attn.attn" for i in range(num_layers)]
+
+
+def deterministic_block(
+    layer_idx: int,
+    kv_kind: str,
+    block_id: int,
+    *,
+    num_kv_heads: int,
+    block_size: int,
+    head_dim: int,
+) -> torch.Tensor:
+    """Known-value page [num_kv_heads, block_size, head_dim], fp16."""
+    base = layer_idx * 1000.0 + block_id * 10.0 + (0.0 if kv_kind == "k" else 5.0)
+    numel = num_kv_heads * block_size * head_dim
+    ramp = torch.arange(numel, dtype=torch.float16) * 0.125
+    return (base + ramp).reshape(num_kv_heads, block_size, head_dim).to(torch.float16)
+
+
+def build_paged_kv_caches(
+    *,
+    num_layers: int,
+    num_kv_heads: int,
+    block_size: int,
+    head_dim: int,
+    num_pages: int,
+    fill_block_ids: list[int] | None = None,
+    device: str = "cpu",
+) -> dict[str, tuple[list[torch.Tensor], list[torch.Tensor]]]:
+    """Synthetic Spyre paged caches; pages in fill_block_ids get known values."""
+    caches: dict[str, tuple[list[torch.Tensor], list[torch.Tensor]]] = {}
+    for layer_idx, name in enumerate(layer_names(num_layers)):
+        pages = {}
+        for kind in ("k", "v"):
+            pages[kind] = [
+                torch.zeros(num_kv_heads, block_size, head_dim, dtype=torch.float16, device=device)
+                for _ in range(num_pages)
+            ]
+            for block_id in fill_block_ids or []:
+                pages[kind][block_id] = deterministic_block(
+                    layer_idx,
+                    kind,
+                    block_id,
+                    num_kv_heads=num_kv_heads,
+                    block_size=block_size,
+                    head_dim=head_dim,
+                ).to(device)
+        caches[name] = (pages["k"], pages["v"])
+    return caches
+
+
+def block_checksum(page: torch.Tensor) -> str:
+    raw = page.to("cpu").contiguous().view(-1).view(torch.uint8)
+    return hashlib.sha256(bytes(raw.tolist())).hexdigest()
+
+
+def cache_checksums(
+    caches: dict[str, tuple[list[torch.Tensor], list[torch.Tensor]]],
+    block_ids: list[int],
+) -> dict[str, str]:
+    """Checksum per layer/kind/block: {'layer|k|1': sha256}."""
+    sums: dict[str, str] = {}
+    for name, (k_pages, v_pages) in sorted(caches.items()):
+        for kind, pages in (("k", k_pages), ("v", v_pages)):
+            for block_id in block_ids:
+                sums[f"{name}|{kind}|{block_id}"] = block_checksum(pages[block_id])
+    return sums
+
+
+def checksums_match(expected: dict[str, str], actual: dict[str, str]) -> bool:
+    return bool(expected) and expected == actual
+
+
+def expected_checksums(args: argparse.Namespace) -> dict[str, str]:
+    filled = build_paged_kv_caches(
+        num_layers=args.num_layers,
+        num_kv_heads=args.num_kv_heads,
+        block_size=args.block_size,
+        head_dim=args.head_dim,
+        num_pages=args.num_pages,
+        fill_block_ids=list(args.block_ids),
+    )
+    return cache_checksums(filled, list(args.block_ids))
+
+
+def geometry_dict(args: argparse.Namespace) -> dict[str, int]:
+    return {
+        "num_layers": args.num_layers,
+        "num_kv_heads": args.num_kv_heads,
+        "block_size": args.block_size,
+        "head_dim": args.head_dim,
+        "num_pages": args.num_pages,
+    }
+
+
+def split_env(args: argparse.Namespace) -> dict[str, str]:
+    """Environment that selects the connector NIXL path for a split role.
+
+    Producer runs non-blocking so wait_for_save returns after exposing the
+    pending transfer; the LIST/PULL handler then serves the consumer.
+    """
+    env: dict[str, str] = {"VLLM_SPYRE_ENABLE_NIXL_TRANSFER": "1"}
+    if args.role == "prefill":
+        env["VLLM_SPYRE_KV_ROLE"] = "kv_producer"
+        env["VLLM_SPYRE_NIXL_BLOCKING_TRANSFER"] = "0"
+    else:
+        env["VLLM_SPYRE_KV_ROLE"] = "kv_consumer"
+        env["VLLM_SPYRE_NIXL_REMOTE_IP"] = args.prefill_ip
+    return env
+
+
+def _apply_split_env(args: argparse.Namespace) -> None:
+    os.environ.update(split_env(args))
+    # NIXL_PORT is a module constant; override it for non-default ports.
+    port = args.listen_port if args.role == "prefill" else args.prefill_port
+    if port != DEFAULT_NIXL_PORT:
+        from spyre_inference.distributed.kv_transfer.kv_connector.v1 import (
+            inmemory_spyre_connector as mod,
+        )
+
+        mod.NIXL_PORT = port
+
+
+def _wait_for_file(path: str, timeout_s: float) -> None:
+    deadline = time.monotonic() + timeout_s
+    target = pathlib.Path(path)
+    while time.monotonic() < deadline:
+        if target.is_file():
+            return
+        time.sleep(0.2)
+    raise TimeoutError(f"Timed out after {timeout_s}s waiting for {path}")
+
+
+def _pending_count(connector) -> int:
+    lock = connector._pending_transfers_lock
+    if lock is None:
+        return len(connector._pending_transfers)
+    with lock:
+        return len(connector._pending_transfers)
+
+
+def _make_connector(role_name: str):
+    """Build an InMemorySpyreConnector without a full engine.
+
+    KVConnectorBase_V1 requires `vllm_config.kv_transfer_config` to be set,
+    so we attach a minimal KVTransferConfig that selects the Spyre connector
+    and a role that mirrors the script role.
+    """
+    from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
+
+    from spyre_inference.distributed.kv_transfer.kv_connector.v1.inmemory_spyre_connector import (
+        InMemorySpyreConnector,
+    )
+
+    role = KVConnectorRole.WORKER
+    kv_role = "kv_producer" if role_name == "prefill" else "kv_consumer"
+    try:
+        from vllm.config import KVTransferConfig, VllmConfig
+
+        kv_cfg = KVTransferConfig(kv_connector="InMemorySpyreConnector", kv_role=kv_role)
+        vllm_config = VllmConfig(kv_transfer_config=kv_cfg)
+    except Exception:
+        # Minimal duck-typed config: the connector reads cache_config.block_size
+        # and kv_transfer_config.{kv_role,kv_connector} at construction time.
+        from types import SimpleNamespace
+
+        vllm_config = SimpleNamespace(
+            cache_config=SimpleNamespace(block_size=0),
+            kv_transfer_config=SimpleNamespace(
+                kv_role=kv_role,
+                kv_connector="InMemorySpyreConnector",
+                engine_id="smoke-engine",
+                kv_buffer_device="cpu",
+                kv_buffer_size=int(1e9),
+                kv_rank=None,
+                kv_parallel_size=1,
+                kv_ip="127.0.0.1",
+                kv_port=14579,
+                kv_connector_extra_config={},
+                kv_connector_module_path=None,
+                enable_permute_local_kv=False,
+                kv_load_failure_policy="fail",
+            ),
+        )
+    return InMemorySpyreConnector(vllm_config, role)
+
+
+def _make_meta(
+    args: argparse.Namespace,
+    *,
+    is_store: bool,
+    block_ids: list[int] | None = None,
+):
+    from spyre_inference.distributed.kv_transfer.kv_connector.v1.metadata import (
+        SpyreConnectorMeta,
+    )
+
+    meta = SpyreConnectorMeta(
+        layer_names=layer_names(args.num_layers),
+        block_size=args.block_size,
+        dtype="torch.float16",
+        num_layers=args.num_layers,
+        num_kv_heads=args.num_kv_heads,
+        head_dim=args.head_dim,
+    )
+    block_ids = list(block_ids if block_ids is not None else args.block_ids)
+    token_count = len(block_ids) * args.block_size
+    if is_store:
+        meta.add_store_request(args.source_request_id, block_ids, token_count=token_count)
+    else:
+        meta.add_load_request(
+            args.request_id,
+            block_ids,
+            source_req_id=args.source_request_id,
+            token_count=token_count,
+            block_mapping=[(b, b) for b in block_ids],
+        )
+    return meta
+
+
+def run_prefill(args: argparse.Namespace, result: dict[str, Any]) -> None:
+    connector = _make_connector("prefill")
+    caches = build_paged_kv_caches(
+        num_layers=args.num_layers,
+        num_kv_heads=args.num_kv_heads,
+        block_size=args.block_size,
+        head_dim=args.head_dim,
+        num_pages=args.num_pages,
+        fill_block_ids=list(args.block_ids),
+        device=args.device,
+    )
+    connector.register_kv_caches(caches)
+    if not connector.paged_kv_active():
+        raise RuntimeError("paged accessor not active for synthetic page lists")
+    print(MARK_PREFILL_READY, flush=True)
+
+    connector.bind_connector_metadata(_make_meta(args, is_store=True))
+    connector.wait_for_save()
+    connector.clear_connector_metadata()
+    result["connector_stats"]["prefill"] = connector.get_cumulative_metrics()
+    print(MARK_SAVE_DONE, flush=True)
+
+    if not args.nixl:
+        return
+
+    # Non-blocking save exposed the transfer; wait until it is registered.
+    deadline = time.monotonic() + args.timeout_s
+    while _pending_count(connector) == 0:
+        if time.monotonic() > deadline:
+            raise TimeoutError("pending NIXL transfer was not registered before timeout")
+        time.sleep(0.05)
+    result["nixl_pending_requests"] = _pending_count(connector)
+    print(MARK_NIXL_READY, flush=True)
+
+    if args.expected_json:
+        pathlib.Path(args.expected_json).write_text(json.dumps(result["expected_checksums"]))
+    if args.ready_file:
+        pathlib.Path(args.ready_file).write_text(
+            json.dumps(
+                {
+                    "req_id": args.source_request_id,
+                    "listen_port": args.listen_port,
+                    "block_ids": list(args.block_ids),
+                    "geometry": geometry_dict(args),
+                }
+            )
+        )
+
+    # Serve LIST/PULL requests while the consumer connects and pulls.
+    deadline = time.monotonic() + args.keepalive_s
+    while time.monotonic() < deadline:
+        time.sleep(0.5)
+    result["nixl_pending_requests_after_keepalive"] = _pending_count(connector)
+    print(MARK_KEEPALIVE_DONE, flush=True)
+
+
+def run_decode(args: argparse.Namespace, result: dict[str, Any]) -> tuple[bool, bool]:
+    print(MARK_DECODE_START, flush=True)
+    if args.nixl and args.ready_file:
+        _wait_for_file(args.ready_file, args.timeout_s)
+
+    connector = _make_connector("decode")
+    caches = build_paged_kv_caches(
+        num_layers=args.num_layers,
+        num_kv_heads=args.num_kv_heads,
+        block_size=args.block_size,
+        head_dim=args.head_dim,
+        num_pages=args.num_pages,
+        fill_block_ids=None,  # decode starts empty
+        device=args.device,
+    )
+    connector.register_kv_caches(caches)
+    if not connector.paged_kv_active():
+        raise RuntimeError("paged accessor not active for synthetic page lists")
+
+    load_block_ids = list(args.block_ids)
+    if args.nixl:
+        records = connector._load_saved_requests_nixl()
+        if not records:
+            raise RuntimeError("NIXL pull returned no saved requests")
+        by_id = {record.req_id: record for record in records}
+        record = by_id.get(args.source_request_id, records[-1])
+        result["nixl_pulled_request_ids"] = sorted(by_id)
+        load_block_ids = list(record.block_ids)
+        print(MARK_NIXL_PULL_DONE, flush=True)
+
+    connector.bind_connector_metadata(_make_meta(args, is_store=False, block_ids=load_block_ids))
+    connector.start_load_kv(None)
+    load_errors = connector.get_block_ids_with_load_errors()
+    connector.clear_connector_metadata()
+    result["connector_stats"]["decode"] = connector.get_cumulative_metrics()
+    result["load_error_block_ids"] = sorted(load_errors)
+    print(MARK_LOAD_DONE, flush=True)
+
+    actual = cache_checksums(caches, load_block_ids)
+    result["actual_checksums"] = actual
+    match = checksums_match(result["expected_checksums"], actual) and not load_errors
+    return match, bool(load_errors)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    result: dict[str, Any] = {
+        "role": args.role,
+        "layout": "list_of_pages",
+        "nixl": bool(args.nixl),
+        "request_ids": {"prefill": args.source_request_id, "decode": args.request_id},
+        "block_ids": list(args.block_ids),
+        "geometry": geometry_dict(args),
+        "connector_stats": {},
+        "expected_checksums": expected_checksums(args),
+        "actual_checksums": {},
+        "content_match": None,
+        "success": False,
+        "error": None,
+    }
+
+    try:
+        if max(args.block_ids) >= args.num_pages or min(args.block_ids) < 0:
+            raise ValueError("--block-ids must be within [0, --num-pages)")
+        if args.nixl and args.role == "both":
+            raise ValueError("--nixl requires split --role prefill / --role decode processes")
+        if args.nixl:
+            _apply_split_env(args)
+        if args.nixl and args.role == "decode" and args.expected_json:
+            result["expected_checksums"] = json.loads(pathlib.Path(args.expected_json).read_text())
+
+        if args.role in ("prefill", "both"):
+            run_prefill(args, result)
+        if args.role in ("decode", "both"):
+            match, _ = run_decode(args, result)
+            result["content_match"] = match
+            print(f"{MARK_CONTENT_MATCH} {str(match).lower()}", flush=True)
+            result["success"] = match
+        else:
+            result["success"] = True  # prefill-only success = save (+ NIXL expose) done
+    except Exception as exc:  # noqa: BLE001 — smoke must always emit a verdict
+        result["error"] = f"{type(exc).__name__}: {exc}"
+
+    print(f"{MARK_SUCCESS} {str(result['success']).lower()}", flush=True)
+    pathlib.Path(args.result_file).write_text(json.dumps(result, indent=2))
+    return 0 if result["success"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,8 @@ line-length = 100
 "spyre_inference/version.py" = ["F401"]
 "spyre_inference/_version.py" = ["ALL"]
 "spyre_inference/custom_ops/__init__.py" = ["F401"]
+# Ported from llm-d-on-spyre KV connector baseline; kept close to source.
+"spyre_inference/distributed/kv_transfer/**" = ["E501"]
 
 [tool.ruff.lint]
 select = [

--- a/spyre_inference/__init__.py
+++ b/spyre_inference/__init__.py
@@ -36,6 +36,44 @@ def register():
     return "spyre_inference.platform.TorchSpyrePlatform"
 
 
+_kv_connector_registered = False
+
+
+def register_kv_connector() -> None:
+    """Register the Spyre KV connector with vLLM's connector factory.
+
+    Registration only stores a module path, but it must run after
+    vllm.config is fully loaded (the factory imports vllm.config).
+    Called from TorchSpyrePlatform.check_and_update_config on the
+    scheduler side and TorchSpyreWorker.init_device on the worker side,
+    not at module import time.
+    """
+    global _kv_connector_registered
+    if _kv_connector_registered:
+        return
+
+    import logging
+
+    logger = logging.getLogger(__name__)
+    try:
+        from vllm.distributed.kv_transfer.kv_connector.factory import (
+            KVConnectorFactory,
+        )
+
+        KVConnectorFactory.register_connector(
+            "InMemorySpyreConnector",
+            "spyre_inference.distributed.kv_transfer.kv_connector.v1.inmemory_spyre_connector",
+            "InMemorySpyreConnector",
+        )
+        _kv_connector_registered = True
+        logger.info("Registered InMemorySpyreConnector")
+    except ValueError:
+        # Another import path registered it first.
+        _kv_connector_registered = True
+    except (ImportError, ModuleNotFoundError, AttributeError) as exc:
+        logger.error("Failed to register InMemorySpyreConnector: %s", exc)
+
+
 def register_ops():
     """Register OOT custom ops for Spyre."""
     from spyre_inference.custom_ops import register_all

--- a/spyre_inference/distributed/kv_transfer/__init__.py
+++ b/spyre_inference/distributed/kv_transfer/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/spyre_inference/distributed/kv_transfer/kv_connector/__init__.py
+++ b/spyre_inference/distributed/kv_transfer/kv_connector/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/spyre_inference/distributed/kv_transfer/kv_connector/v1/__init__.py
+++ b/spyre_inference/distributed/kv_transfer/kv_connector/v1/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/spyre_inference/distributed/kv_transfer/kv_connector/v1/heap_kv_accessor.py
+++ b/spyre_inference/distributed/kv_transfer/kv_connector/v1/heap_kv_accessor.py
@@ -1,0 +1,224 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import importlib
+import json
+import mmap
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+import torch
+
+
+def resolve_heap_kv_paths(
+    *,
+    perfdsc_dir: str | None = None,
+    export_dir: str | None = None,
+) -> tuple[Path, Path]:
+    perfdsc_root = perfdsc_dir or os.getenv("VLLM_SPYRE_HEAP_KV_PERFDSC_DIR", "")
+    export_root = export_dir or os.getenv("VLLM_SPYRE_HEAP_KV_EXPORT_DIR", "")
+
+    if not perfdsc_root:
+        base = os.getenv("PERFDSC_DUMP_DIR", "perfdsc_dumps")
+        base_path = Path(base)
+        if base_path.name.startswith("execute_itr"):
+            perfdsc_root = str(base_path)
+        else:
+            perfdsc_root = str(base_path / "execute_itr0")
+
+    if not export_root:
+        export_root = "export_dtcompiler/r0_1/export_deeprt"
+
+    return Path(perfdsc_root), Path(export_root)
+
+
+def get_layer_kv_tensor_info(perfdsc_dump_dir: str | Path) -> dict[str, dict[str, Any]]:
+    perfdsc_dump_dir = str(perfdsc_dump_dir)
+    node_tensor_prop_json = os.path.join(
+        perfdsc_dump_dir, "sengraph", "nodeTensorProp_after_rcuOpt.json"
+    )
+    sdsc_dir = os.path.join(perfdsc_dump_dir, "sdsc")
+    if not os.path.exists(node_tensor_prop_json) or not os.path.exists(sdsc_dir):
+        raise FileNotFoundError(
+            f"Missing perfdsc metadata under {perfdsc_dump_dir}: "
+            f"expected {node_tensor_prop_json} and {sdsc_dir}"
+        )
+
+    with open(node_tensor_prop_json) as f:
+        nodes = json.load(f)["NodeTensorProperties"]
+
+    kv_tensors: dict[str, dict[str, Any]] = {}
+    pattern = re.compile(r"paged_attn_store_*([0-9]*)-Scatter([KV])")
+
+    for node in nodes:
+        name = node["name"]
+        if not name.startswith("paged_attn_store") or "OutputTensors" not in node:
+            continue
+
+        output_tensor = None
+        for tensor in node["OutputTensors"]:
+            if tensor.get("isKvCacheTensor"):
+                output_tensor = tensor
+                break
+        if output_tensor is None:
+            continue
+
+        matches = pattern.findall(name)
+        if not matches:
+            continue
+        layer_idx = int(matches[0][0]) if matches[0][0] else 0
+        kv_kind = matches[0][1].lower()
+
+        tensor_json = os.path.join(sdsc_dir, f"{name}.json")
+        if not os.path.exists(tensor_json):
+            raise FileNotFoundError(f"Missing tensor metadata file {tensor_json}")
+
+        with open(tensor_json) as g:
+            tensor_meta = json.load(g)[name]["datadscs_"]
+
+        kv_tensor: dict[str, Any] = {"name": name}
+        for item in tensor_meta:
+            if name not in item:
+                continue
+            data = item[name]
+            for labeled in data["labeledDs_"]:
+                if labeled["ldsName_"] != f"{name}_out":
+                    continue
+                phys_addr = int(labeled["hbmStartAddress_"]["data_"]["[0]"])
+                phys_size = int(labeled["hbmSize_"])
+                kv_tensor["flit_offset"] = phys_addr - 4 * (1 << 27)
+                kv_tensor["size"] = phys_size
+                break
+            if "flit_offset" in kv_tensor:
+                break
+
+        if "flit_offset" not in kv_tensor:
+            raise RuntimeError(f"Failed to find flit_offset for {name}")
+
+        kv_tensors[f"{layer_idx}.{kv_kind}"] = kv_tensor
+
+    if not kv_tensors:
+        raise RuntimeError(f"No paged_attn_store KV metadata found in {perfdsc_dump_dir}")
+    return kv_tensors
+
+
+def get_heap_hbm_start_bytes(segment_size_json: str | Path, *, flit_size: int = 128) -> int:
+    with open(segment_size_json) as f:
+        seg_dict = json.load(f)["memReqPerSegment"]
+
+    total_flits = 1
+    permanent_flits = 0
+    for seg_idx in ("2", "3", "7"):
+        permanent_flits += seg_dict[seg_idx]["size"]
+
+    page_flits = mmap.PAGESIZE // flit_size
+    total_flits += (permanent_flits + page_flits - 1) // page_flits * page_flits
+
+    for seg_idx in ("0", "1"):
+        total_flits += seg_dict[seg_idx]["size"]
+
+    return total_flits * flit_size
+
+
+class HeapKVAccessor:
+    def __init__(
+        self,
+        *,
+        kv_heads: int,
+        offsets: dict[str, dict[str, Any]],
+        block_size: int,
+        head_dim: int,
+        dtype: torch.dtype,
+        start_of_heap_bytes: int,
+        flit_size: int = 128,
+    ) -> None:
+        if dtype != torch.float16:
+            raise ValueError(f"Experimental heap accessor only supports torch.float16, got {dtype}")
+
+        self._offsets = offsets
+        self._flit_size = flit_size
+        self._heap_addr = int(start_of_heap_bytes)
+        self._block_size = int(block_size)
+        self._head_dim = int(head_dim)
+        self._kv_heads = int(kv_heads)
+        self._dtype = dtype
+        self._nbytes = torch.tensor([], dtype=dtype).element_size()
+
+        self._C = importlib.import_module("torch_spyre._C")
+
+    @classmethod
+    def from_metadata(
+        cls,
+        *,
+        kv_heads: int,
+        block_size: int,
+        head_dim: int,
+        dtype: torch.dtype,
+        perfdsc_dir: str | Path,
+        export_dir: str | Path,
+    ) -> HeapKVAccessor:
+        offsets = get_layer_kv_tensor_info(perfdsc_dir)
+        start_of_heap_bytes = get_heap_hbm_start_bytes(Path(export_dir) / "segment_size.json")
+        return cls(
+            kv_heads=kv_heads,
+            offsets=offsets,
+            block_size=block_size,
+            head_dim=head_dim,
+            dtype=dtype,
+            start_of_heap_bytes=start_of_heap_bytes,
+        )
+
+    def _block_addr(self, *, layer_idx: int, kv_kind: str, block_id: int) -> int:
+        flit_offset = int(self._offsets[f"{layer_idx}.{kv_kind}"]["flit_offset"])
+        addr = self._heap_addr
+        addr += flit_offset * self._flit_size
+        addr += block_id * self._kv_heads * self._block_size * self._head_dim * self._nbytes
+        return addr
+
+    def read_block(self, *, layer_idx: int, kv_kind: str, block_id: int) -> torch.Tensor:
+        addr = self._block_addr(layer_idx=layer_idx, kv_kind=kv_kind, block_id=block_id)
+        block = self._C.spyre_from_blob(
+            addr,
+            size=(self._kv_heads, self._block_size, self._head_dim),
+            stride=(self._block_size * self._head_dim, self._head_dim, 1),
+            dtype=self._dtype,
+        )
+        return block.to("cpu").permute(1, 0, 2).contiguous()
+
+    def write_block(
+        self,
+        *,
+        layer_idx: int,
+        kv_kind: str,
+        block_id: int,
+        values: torch.Tensor,
+    ) -> None:
+        if values.shape != (self._block_size, self._kv_heads, self._head_dim):
+            raise ValueError(
+                "Expected block tensor shape "
+                f"{(self._block_size, self._kv_heads, self._head_dim)}, got {tuple(values.shape)}"
+            )
+
+        addr = self._block_addr(layer_idx=layer_idx, kv_kind=kv_kind, block_id=block_id)
+        block = self._C.spyre_from_blob(
+            addr,
+            size=(self._kv_heads, self._block_size, self._head_dim),
+            stride=(self._block_size * self._head_dim, self._head_dim, 1),
+            dtype=self._dtype,
+        )
+        block.copy_(values.permute(1, 0, 2).contiguous())

--- a/spyre_inference/distributed/kv_transfer/kv_connector/v1/heap_kv_helper.py
+++ b/spyre_inference/distributed/kv_transfer/kv_connector/v1/heap_kv_helper.py
@@ -1,0 +1,199 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+
+
+def _load_heap_kv_accessor_module() -> Any:
+    module_path = Path(__file__).with_name("heap_kv_accessor.py")
+    spec = importlib.util.spec_from_file_location("_spyre_heap_kv_accessor", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load heap_kv_accessor module from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_HEAP_KV_ACCESSOR = _load_heap_kv_accessor_module()
+_RUNTIME_WARMED = False
+
+
+def _ensure_spyre_runtime_ready() -> dict[str, Any]:
+    global _RUNTIME_WARMED
+    if _RUNTIME_WARMED:
+        return {
+            "runtime_ready": True,
+            "runtime_warmup_performed": False,
+        }
+
+    torch_spyre = importlib.import_module("torch_spyre")
+    torch_spyre_c = importlib.import_module("torch_spyre._C")
+    autoload = getattr(torch_spyre, "_autoload", None)
+    if callable(autoload):
+        autoload()
+
+    orig_mode = os.environ.get("COMPILATION_MODE")
+    os.environ["COMPILATION_MODE"] = "offline"
+    try:
+        x_cpu = torch.arange(256, dtype=torch.float16).reshape(4, 64)
+        x_spyre = x_cpu.to("spyre")
+        addr = torch_spyre_c.get_dmpa(x_spyre)
+        roundtrip = torch_spyre_c.spyre_from_blob(
+            addr,
+            size=tuple(x_spyre.shape),
+            stride=tuple(x_spyre.stride()),
+            dtype=torch.float16,
+        ).to("cpu")
+    finally:
+        if orig_mode is None:
+            os.environ.pop("COMPILATION_MODE", None)
+        else:
+            os.environ["COMPILATION_MODE"] = orig_mode
+
+    _RUNTIME_WARMED = True
+    return {
+        "runtime_ready": True,
+        "runtime_warmup_performed": True,
+        "runtime_backend_name": str(torch._C._get_privateuse1_backend_name()),
+        "runtime_warmup_device": str(x_spyre.device),
+        "runtime_warmup_shape": list(x_spyre.shape),
+        "runtime_warmup_equal": bool(torch.equal(roundtrip, x_cpu)),
+        "torch_spyre": getattr(torch_spyre, "__file__", "<extension>"),
+    }
+
+
+def _load_plan(path: str | Path) -> dict[str, Any]:
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _build_accessor(plan: dict[str, Any]) -> Any:
+    _ensure_spyre_runtime_ready()
+    dtype_name = str(plan["dtype"])
+    if dtype_name != "torch.float16":
+        raise ValueError(f"Unsupported dtype {dtype_name}; expected torch.float16")
+
+    return _HEAP_KV_ACCESSOR.HeapKVAccessor.from_metadata(
+        kv_heads=int(plan["kv_heads"]),
+        block_size=int(plan["block_size"]),
+        head_dim=int(plan["head_dim"]),
+        dtype=torch.float16,
+        perfdsc_dir=plan["perfdsc_dir"],
+        export_dir=plan["export_dir"],
+    )
+
+
+def _probe() -> dict[str, Any]:
+    torch_spyre = importlib.import_module("torch_spyre")
+    torch_spyre_c = importlib.import_module("torch_spyre._C")
+    result = {
+        "action": "probe",
+        "torch_version": torch.__version__,
+        "torch_spyre": getattr(torch_spyre, "__file__", "<extension>"),
+        "torch_spyre_c": getattr(torch_spyre_c, "__file__", "<extension>"),
+    }
+    result.update(_ensure_spyre_runtime_ready())
+    return result
+
+
+def _read(plan: dict[str, Any], data_path: str | Path) -> dict[str, Any]:
+    accessor = _build_accessor(plan)
+    arrays: dict[str, np.ndarray] = {}
+    for block in plan["blocks"]:
+        key = str(block["key"])
+        tensor = accessor.read_block(
+            layer_idx=int(block["layer_idx"]),
+            kv_kind=str(block["kv_kind"]),
+            block_id=int(block["block_id"]),
+        )
+        arrays[key] = tensor.numpy()
+
+    np.savez(data_path, **arrays)
+    return {
+        "action": "read",
+        "block_count": len(plan["blocks"]),
+        "data_path": str(data_path),
+    }
+
+
+def _write(plan: dict[str, Any], data_path: str | Path) -> dict[str, Any]:
+    accessor = _build_accessor(plan)
+    with np.load(data_path) as payloads:
+        for block in plan["blocks"]:
+            key = str(block["key"])
+            values = torch.from_numpy(np.array(payloads[key], copy=True))
+            accessor.write_block(
+                layer_idx=int(block["layer_idx"]),
+                kv_kind=str(block["kv_kind"]),
+                block_id=int(block["block_id"]),
+                values=values,
+            )
+
+    return {
+        "action": "write",
+        "block_count": len(plan["blocks"]),
+        "data_path": str(data_path),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Experimental helper boundary for old-stack heap-backed KV block IO. "
+            "This script is intended to run inside the dt-inductor env."
+        )
+    )
+    parser.add_argument(
+        "--action",
+        choices=("probe", "read", "write"),
+        required=True,
+    )
+    parser.add_argument("--plan", required=False, help="Path to the JSON plan file.")
+    parser.add_argument(
+        "--data",
+        required=False,
+        help="Path to the .npz payload file for read/write operations.",
+    )
+    args = parser.parse_args()
+
+    if args.action == "probe":
+        print(json.dumps(_probe(), sort_keys=True))
+        return 0
+
+    if not args.plan or not args.data:
+        parser.error("--plan and --data are required for read/write")
+
+    plan = _load_plan(args.plan)
+    if args.action == "read":
+        result = _read(plan, args.data)
+    else:
+        result = _write(plan, args.data)
+
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/spyre_inference/distributed/kv_transfer/kv_connector/v1/heap_kv_helper_client.py
+++ b/spyre_inference/distributed/kv_transfer/kv_connector/v1/heap_kv_helper_client.py
@@ -1,0 +1,167 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+
+
+def make_block_key(*, layer_idx: int, kv_kind: str, block_id: int) -> str:
+    return f"layer{layer_idx}_{kv_kind}_block{block_id}"
+
+
+class HeapKVHelperClient:
+    def __init__(
+        self,
+        *,
+        kv_heads: int,
+        block_size: int,
+        head_dim: int,
+        dtype: torch.dtype,
+        perfdsc_dir: str | Path,
+        export_dir: str | Path,
+        dti_root: str | Path,
+        dev_env_script: str | Path,
+        timeout_s: int,
+    ) -> None:
+        self._kv_heads = int(kv_heads)
+        self._block_size = int(block_size)
+        self._head_dim = int(head_dim)
+        self._dtype = dtype
+        self._perfdsc_dir = str(perfdsc_dir)
+        self._export_dir = str(export_dir)
+        self._dti_root = str(dti_root)
+        self._dev_env_script = str(dev_env_script)
+        self._timeout_s = int(timeout_s)
+
+        self._repo_root = Path(__file__).resolve().parents[5]
+        self._helper_script = Path(__file__).with_name("heap_kv_helper.py")
+
+    def _plan_dict(self, blocks: list[dict[str, Any]]) -> dict[str, Any]:
+        return {
+            "kv_heads": self._kv_heads,
+            "block_size": self._block_size,
+            "head_dim": self._head_dim,
+            "dtype": str(self._dtype),
+            "perfdsc_dir": self._perfdsc_dir,
+            "export_dir": self._export_dir,
+            "blocks": blocks,
+        }
+
+    def _run_helper(
+        self,
+        *,
+        action: str,
+        plan_path: str | Path | None = None,
+        data_path: str | Path | None = None,
+    ) -> str:
+        home = os.environ.get("HOME", "")
+        plan_arg = f" --plan {shlex.quote(str(plan_path))}" if plan_path else ""
+        data_arg = f" --data {shlex.quote(str(data_path))}" if data_path else ""
+        script = (
+            "set -euo pipefail\n"
+            f"export HOME={shlex.quote(home)}\n"
+            f"export DTI_PROJECT_ROOT={shlex.quote(self._dti_root)}\n"
+            f"source {shlex.quote(self._dev_env_script)}\n"
+            "export TORCH_DEVICE_BACKEND_AUTOLOAD=0\n"
+            f"export PYTHONPATH={shlex.quote(str(self._repo_root))}${{PYTHONPATH:+:$PYTHONPATH}}\n"
+            f"python {shlex.quote(str(self._helper_script))} --action {shlex.quote(action)}"
+            f"{plan_arg}{data_arg}\n"
+        )
+        result = subprocess.run(
+            ["bash", "-lc", script],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=self._timeout_s,
+        )
+        if result.returncode != 0:
+            stderr = result.stderr.strip()
+            stdout = result.stdout.strip()
+            raise RuntimeError(
+                f"heap helper failed action={action} rc={result.returncode} "
+                f"stdout={stdout!r} stderr={stderr!r}"
+            )
+        return result.stdout.strip()
+
+    def probe(self) -> dict[str, Any]:
+        stdout = self._run_helper(action="probe")
+        return json.loads(stdout.splitlines()[-1])
+
+    def read_blocks(
+        self,
+        block_refs: list[tuple[int, str, int]],
+    ) -> dict[tuple[int, str, int], torch.Tensor]:
+        blocks = [
+            {
+                "key": make_block_key(layer_idx=layer_idx, kv_kind=kv_kind, block_id=block_id),
+                "layer_idx": int(layer_idx),
+                "kv_kind": str(kv_kind),
+                "block_id": int(block_id),
+            }
+            for layer_idx, kv_kind, block_id in block_refs
+        ]
+        with tempfile.TemporaryDirectory(prefix="spyre-heap-read-") as tmpdir:
+            plan_path = Path(tmpdir) / "plan.json"
+            data_path = Path(tmpdir) / "payloads.npz"
+            with open(plan_path, "w", encoding="utf-8") as f:
+                json.dump(self._plan_dict(blocks), f)
+            self._run_helper(action="read", plan_path=plan_path, data_path=data_path)
+            tensors: dict[tuple[int, str, int], torch.Tensor] = {}
+            with np.load(data_path) as payloads:
+                for layer_idx, kv_kind, block_id in block_refs:
+                    key = make_block_key(
+                        layer_idx=layer_idx,
+                        kv_kind=kv_kind,
+                        block_id=block_id,
+                    )
+                    tensors[(layer_idx, kv_kind, block_id)] = torch.from_numpy(
+                        np.array(payloads[key], copy=True)
+                    )
+            return tensors
+
+    def write_blocks(
+        self,
+        block_values: dict[tuple[int, str, int], torch.Tensor],
+    ) -> None:
+        blocks: list[dict[str, Any]] = []
+        arrays: dict[str, np.ndarray] = {}
+        for (layer_idx, kv_kind, block_id), tensor in block_values.items():
+            key = make_block_key(layer_idx=layer_idx, kv_kind=kv_kind, block_id=block_id)
+            blocks.append(
+                {
+                    "key": key,
+                    "layer_idx": int(layer_idx),
+                    "kv_kind": str(kv_kind),
+                    "block_id": int(block_id),
+                }
+            )
+            arrays[key] = tensor.detach().cpu().numpy()
+
+        with tempfile.TemporaryDirectory(prefix="spyre-heap-write-") as tmpdir:
+            plan_path = Path(tmpdir) / "plan.json"
+            data_path = Path(tmpdir) / "payloads.npz"
+            with open(plan_path, "w", encoding="utf-8") as f:
+                json.dump(self._plan_dict(blocks), f)
+            np.savez(data_path, **arrays)
+            self._run_helper(action="write", plan_path=plan_path, data_path=data_path)

--- a/spyre_inference/distributed/kv_transfer/kv_connector/v1/heap_kv_inprocess_client.py
+++ b/spyre_inference/distributed/kv_transfer/kv_connector/v1/heap_kv_inprocess_client.py
@@ -1,0 +1,133 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import importlib
+import os
+from pathlib import Path
+
+import torch
+
+from spyre_inference.distributed.kv_transfer.kv_connector.v1.heap_kv_accessor import (
+    HeapKVAccessor,
+)
+
+
+class InProcessHeapKVClient:
+    def __init__(
+        self,
+        *,
+        kv_heads: int,
+        block_size: int,
+        head_dim: int,
+        dtype: torch.dtype,
+        perfdsc_dir: str | Path,
+        export_dir: str | Path,
+    ) -> None:
+        self._kv_heads = int(kv_heads)
+        self._block_size = int(block_size)
+        self._head_dim = int(head_dim)
+        self._dtype = dtype
+        self._perfdsc_dir = str(perfdsc_dir)
+        self._export_dir = str(export_dir)
+
+        self._runtime_ready = False
+        self._probe_info: dict[str, object] | None = None
+        self._accessor: HeapKVAccessor | None = None
+
+    def _ensure_runtime_ready(self) -> dict[str, object]:
+        if self._probe_info is not None:
+            return self._probe_info
+
+        torch_spyre = importlib.import_module("torch_spyre")
+        autoload = getattr(torch_spyre, "_autoload", None)
+        if callable(autoload):
+            autoload()
+        C = importlib.import_module("torch_spyre._C")
+
+        orig_mode = os.environ.get("COMPILATION_MODE")
+        os.environ["COMPILATION_MODE"] = "offline"
+        try:
+            x_cpu = torch.arange(256, dtype=torch.float16).reshape(4, 64)
+            x_spyre = x_cpu.to("spyre")
+            addr = C.get_dmpa(x_spyre)
+            roundtrip = C.spyre_from_blob(
+                addr,
+                size=tuple(x_spyre.shape),
+                stride=tuple(x_spyre.stride()),
+                dtype=torch.float16,
+            ).to("cpu")
+        finally:
+            if orig_mode is None:
+                os.environ.pop("COMPILATION_MODE", None)
+            else:
+                os.environ["COMPILATION_MODE"] = orig_mode
+
+        self._runtime_ready = True
+        self._probe_info = {
+            "torch_version": torch.__version__,
+            "torch_file": torch.__file__,
+            "torch_spyre": getattr(torch_spyre, "__file__", "<extension>"),
+            "torch_spyre_c": getattr(C, "__file__", "<extension>"),
+            "backend_name": str(torch._C._get_privateuse1_backend_name()),
+            "device": str(x_spyre.device),
+            "equal": bool(torch.equal(roundtrip, x_cpu)),
+        }
+        return self._probe_info
+
+    def _ensure_accessor(self) -> HeapKVAccessor:
+        if self._accessor is not None:
+            return self._accessor
+
+        self._ensure_runtime_ready()
+        self._accessor = HeapKVAccessor.from_metadata(
+            kv_heads=self._kv_heads,
+            block_size=self._block_size,
+            head_dim=self._head_dim,
+            dtype=self._dtype,
+            perfdsc_dir=self._perfdsc_dir,
+            export_dir=self._export_dir,
+        )
+        return self._accessor
+
+    def probe(self) -> dict[str, object]:
+        return dict(self._ensure_runtime_ready())
+
+    def read_blocks(
+        self,
+        block_refs: list[tuple[int, str, int]],
+    ) -> dict[tuple[int, str, int], torch.Tensor]:
+        accessor = self._ensure_accessor()
+        return {
+            (layer_idx, kv_kind, block_id): accessor.read_block(
+                layer_idx=layer_idx,
+                kv_kind=kv_kind,
+                block_id=block_id,
+            )
+            for layer_idx, kv_kind, block_id in block_refs
+        }
+
+    def write_blocks(
+        self,
+        block_values: dict[tuple[int, str, int], torch.Tensor],
+    ) -> None:
+        accessor = self._ensure_accessor()
+        for (layer_idx, kv_kind, block_id), values in block_values.items():
+            accessor.write_block(
+                layer_idx=layer_idx,
+                kv_kind=kv_kind,
+                block_id=block_id,
+                values=values,
+            )

--- a/spyre_inference/distributed/kv_transfer/kv_connector/v1/inmemory_spyre_connector.py
+++ b/spyre_inference/distributed/kv_transfer/kv_connector/v1/inmemory_spyre_connector.py
@@ -1,0 +1,2420 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import atexit
+import json
+import logging
+import os
+import signal
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+import spyre_inference.envs as envs_spyre
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorBase_V1,
+    KVConnectorMetadata,
+    KVConnectorRole,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
+    KVConnectorStats,
+)
+from vllm.v1.core.sched.output import SchedulerOutput
+
+from spyre_inference.distributed.kv_transfer.kv_connector.v1.metadata import (
+    KVKind,
+    SavedRequestRecord,
+    SpyreConnectorMeta,
+    SpyreConnectorRequestMeta,
+    SpyreConnectorStats,
+    SpyreKVStoreBackend,
+    StoreKey,
+    build_spyre_kv_store_backend,
+)
+from spyre_inference.distributed.kv_transfer.kv_connector.v1.heap_kv_accessor import (
+    resolve_heap_kv_paths,
+)
+from spyre_inference.distributed.kv_transfer.kv_connector.v1.heap_kv_inprocess_client import (
+    InProcessHeapKVClient,
+)
+from spyre_inference.distributed.kv_transfer.kv_connector.v1.spyre_paged_kv_accessor import (
+    SpyrePagedKVCacheAccessor,
+)
+
+# NIXL imports for KV cache transfer
+try:
+    from nixl._api import nixl_agent, nixl_agent_config
+
+    NIXL_AVAILABLE = True
+except ImportError:
+    NIXL_AVAILABLE = False
+    nixl_agent = None
+    nixl_agent_config = None
+
+NIXL_PORT = 9100
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+    from vllm.forward_context import ForwardContext
+    from vllm.v1.attention.backend import AttentionMetadata
+    from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+    from vllm.v1.kv_cache_interface import KVCacheConfig
+    from vllm.v1.request import Request
+
+logger = logging.getLogger(__name__)
+_CONNECTOR_PROBE_PREFIX = "[KV_CONNECTOR_PROBE]"
+
+_GLOBAL_STORE: SpyreKVStoreBackend | None = None
+
+
+def _build_configured_store(store_backend_name: str | None = None) -> SpyreKVStoreBackend:
+    backend_name = store_backend_name or envs_spyre.VLLM_SPYRE_KV_STORE_BACKEND
+    return build_spyre_kv_store_backend(
+        backend_name,
+        max_bytes=envs_spyre.VLLM_SPYRE_KV_STORE_MAX_BYTES,
+        max_saved_requests=envs_spyre.VLLM_SPYRE_KV_REUSE_REGISTRY_MAX_SIZE,
+        service_socket=envs_spyre.VLLM_SPYRE_KV_SERVICE_SOCKET,
+    )
+
+
+def get_global_store(store_backend_name: str | None = None) -> SpyreKVStoreBackend:
+    global _GLOBAL_STORE
+    if _GLOBAL_STORE is None:
+        _GLOBAL_STORE = _build_configured_store(store_backend_name)
+    return _GLOBAL_STORE
+
+
+def reset_global_store(store_backend_name: str | None = None) -> None:
+    global _GLOBAL_STORE
+    if _GLOBAL_STORE is not None:
+        _GLOBAL_STORE.shutdown()
+    _GLOBAL_STORE = _build_configured_store(store_backend_name)
+
+
+def _emit_connector_probe(phase: str, **payload: Any) -> None:
+    if not envs_spyre.VLLM_SPYRE_KV_PLACEMENT_PROBE_ENABLED:
+        return
+    logger.info(
+        "%s %s", _CONNECTOR_PROBE_PREFIX, json.dumps({"phase": phase, **payload}, sort_keys=True)
+    )
+
+
+@dataclass(frozen=True)
+class _PendingLoadSource:
+    source: SavedRequestRecord
+    matched_tokens_total: int
+    num_local_computed_tokens: int
+
+
+class InMemorySpyreConnector(KVConnectorBase_V1):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        role: KVConnectorRole,
+        kv_cache_config: KVCacheConfig | None = None,
+        store: SpyreKVStoreBackend | None = None,
+    ):
+        super().__init__(
+            vllm_config=vllm_config,
+            role=role,
+            kv_cache_config=kv_cache_config,
+        )
+        self._role_name = "scheduler" if role == KVConnectorRole.SCHEDULER else "worker"
+        self._block_size = vllm_config.cache_config.block_size
+        self._store = store if store is not None else get_global_store()
+
+        # Step 2: Store KV role for file-based transfer
+        self._kv_role = os.environ.get("VLLM_SPYRE_KV_ROLE", "")
+
+        self._pending_requests: list[SpyreConnectorRequestMeta] = []
+        self._saved_requests: OrderedDict[str, SavedRequestRecord] = OrderedDict()
+        self._saved_requests_max_size = envs_spyre.VLLM_SPYRE_KV_REUSE_REGISTRY_MAX_SIZE
+        self._pending_load_sources: dict[str, _PendingLoadSource] = {}
+
+        self._kv_caches: dict[str, torch.Tensor] = {}
+        self._num_layers = 0
+        self._num_kv_heads = 0
+        self._head_dim = 0
+        self._dtype_str = ""
+        self._layer_names: list[str] = []
+
+        self._step_stores: set[str] = set()
+        self._step_loads: set[str] = set()
+        self._load_error_block_ids: set[int] = set()
+        self._blocks_saved = 0
+        self._blocks_loaded = 0
+        self._blocks_missing = 0
+        self._stats = SpyreConnectorStats()
+        self._use_heap_kv = bool(envs_spyre.VLLM_SPYRE_EXPERIMENTAL_HEAP_KV_ENABLE)
+        self._heap_kv_strict = bool(envs_spyre.VLLM_SPYRE_EXPERIMENTAL_HEAP_KV_STRICT)
+        self._heap_kv_client: InProcessHeapKVClient | None = None
+        self._heap_kv_init_error: str | None = None
+        self._paged_accessor: SpyrePagedKVCacheAccessor | None = None
+
+        # Step 2: Store prompt tokens for file transfer (before request_finished)
+        self._pending_prompt_tokens: dict[str, list[int]] = {}
+
+        # Per-request tracking of computed tokens (fixes cache hit degradation bug)
+        self._request_computed_tokens: dict[str, int] = {}
+
+        # NIXL integration for KV cache transfer
+        self._use_nixl = envs_spyre.VLLM_SPYRE_ENABLE_NIXL_TRANSFER
+        self._nixl_agent = None
+        self._nixl_register_descs = None
+        self._nixl_remote_ip = os.environ.get("VLLM_SPYRE_NIXL_REMOTE_IP", "10.130.2.89")
+
+        # Decode-initiated pull: Prefill stores pending transfers, decode requests them
+        self._pending_transfers = {}  # Map: req_id -> {metadata, descriptors, register_descs, timestamp}
+        self._pending_transfers_lock = None  # Thread lock for map access
+        self._pull_request_handler_thread = None  # Background thread to handle PULL_REQUEST
+        self._pull_request_handler_stop = False  # Signal to stop thread
+
+        if self._use_nixl:
+            if not NIXL_AVAILABLE:
+                logger.warning("[InMemorySpyreConnector] NIXL requested but not available")
+                self._use_nixl = False
+            else:
+                # Defer NIXL agent initialization until first use to avoid metadata errors
+                # when remote peer is not yet available
+                logger.info(
+                    "[InMemorySpyreConnector] NIXL enabled, will initialize on first transfer"
+                )
+
+                # Initialize thread lock for pending_transfers map
+                import threading
+
+                self._pending_transfers_lock = threading.Lock()
+
+                # Register cleanup handlers for graceful shutdown
+                atexit.register(self._cleanup_nixl)
+                signal.signal(signal.SIGTERM, self._signal_handler)
+                signal.signal(signal.SIGINT, self._signal_handler)
+
+    def _init_nixl_agent(self) -> None:
+        """Initialize NIXL agent for KV cache transfer (lazy initialization)"""
+        if self._nixl_agent is not None:
+            return  # Already initialized
+
+        try:
+            port = NIXL_PORT if self._kv_role == "kv_producer" else 0
+            config = nixl_agent_config(True, True, port)
+            role = "server" if self._kv_role == "kv_producer" else "client"
+            self._nixl_agent = nixl_agent(role, config)
+            logger.info(
+                "[InMemorySpyreConnector] NIXL agent initialized: role=%s, port=%d", role, port
+            )
+
+            # For client role, establish connection to server
+            if self._kv_role == "kv_consumer":
+                logger.info(
+                    "[InMemorySpyreConnector] Client connecting to server at %s:%d",
+                    self._nixl_remote_ip,
+                    NIXL_PORT,
+                )
+                self._nixl_agent.fetch_remote_metadata("server", self._nixl_remote_ip, NIXL_PORT)
+                self._nixl_agent.send_local_metadata(self._nixl_remote_ip, NIXL_PORT)
+
+                # Wait for server to register us before sending signal
+                logger.info(
+                    "[InMemorySpyreConnector] Waiting for server to complete metadata exchange..."
+                )
+                wait_count = 0
+                while not self._nixl_agent.check_remote_metadata("server") and wait_count < 500:
+                    time.sleep(0.01)
+                    wait_count += 1
+
+                if not self._nixl_agent.check_remote_metadata("server"):
+                    logger.error(
+                        "[InMemorySpyreConnector] Server metadata not available after %d checks",
+                        wait_count,
+                    )
+                    raise RuntimeError("Server metadata exchange timeout")
+
+                logger.info(
+                    "[InMemorySpyreConnector] Server metadata available after %d checks", wait_count
+                )
+
+                # Now send READY signal to server so it knows we're about to start polling
+                logger.info("[InMemorySpyreConnector] Sending READY signal to server")
+                self._nixl_agent.send_notif("server", b"CLIENT_READY")
+                logger.info("[InMemorySpyreConnector] CLIENT_READY signal sent successfully")
+        except Exception as exc:
+            logger.error("[InMemorySpyreConnector] Failed to initialize NIXL agent: %s", exc)
+            self._use_nixl = False
+            self._nixl_agent = None
+
+    def _cleanup_nixl(self) -> None:
+        """Cleanup NIXL resources on shutdown"""
+        # Stop pull request handler thread first
+        self._stop_pull_request_handler()
+
+        # Deregister any pending memory from pending_transfers map
+        if self._nixl_agent is not None and self._pending_transfers:
+            with self._pending_transfers_lock:
+                for req_id, transfer_data in self._pending_transfers.items():
+                    try:
+                        self._nixl_agent.deregister_memory(transfer_data["register_descs"])
+                        logger.info(
+                            "[InMemorySpyreConnector] Deregistered memory for req_id=%s", req_id
+                        )
+                    except Exception as exc:
+                        logger.warning(
+                            "[InMemorySpyreConnector] Error deregistering memory for %s: %s",
+                            req_id,
+                            exc,
+                        )
+                self._pending_transfers.clear()
+
+        if self._nixl_agent is not None:
+            try:
+                peer = "client" if self._kv_role == "kv_producer" else "server"
+                self._nixl_agent.remove_remote_agent(peer)
+                logger.info(
+                    "[InMemorySpyreConnector] NIXL agent cleaned up via atexit/signal handler"
+                )
+            except Exception as exc:
+                logger.warning("[InMemorySpyreConnector] NIXL cleanup error: %s", exc)
+            self._nixl_agent = None
+
+    def _signal_handler(self, signum, frame):
+        """Handle termination signals to cleanup NIXL resources"""
+        logger.info("[InMemorySpyreConnector] Received signal %d, cleaning up NIXL...", signum)
+        self._cleanup_nixl()
+        # Re-raise the signal to allow normal termination
+        signal.signal(signum, signal.SIG_DFL)
+        os.kill(os.getpid(), signum)
+
+    def _reset_nixl_transfer_state(self) -> None:
+        """Reset NIXL transfer state for next request"""
+        if self._nixl_agent is None:
+            return
+
+        try:
+            # Clear pending notifications (drain the queue)
+            drained_count = 0
+            while True:
+                notifs = self._nixl_agent.get_new_notifs()
+                if not notifs or all(len(v) == 0 for v in notifs.values()):
+                    break
+                drained_count += sum(len(v) for v in notifs.values())
+
+            if drained_count > 0:
+                logger.info(
+                    "[InMemorySpyreConnector] Drained %d pending notifications", drained_count
+                )
+
+            # Deregister any leftover memory registrations
+            if self._nixl_register_descs is not None:
+                try:
+                    self._nixl_agent.deregister_memory(self._nixl_register_descs)
+                    logger.info("[InMemorySpyreConnector] Deregistered previous memory")
+                except Exception as exc:
+                    logger.warning("[InMemorySpyreConnector] Error deregistering memory: %s", exc)
+                self._nixl_register_descs = None
+
+            logger.info("[InMemorySpyreConnector] NIXL transfer state reset complete")
+        except Exception as exc:
+            logger.warning("[InMemorySpyreConnector] Error resetting NIXL state: %s", exc)
+
+    def _start_pull_request_handler(self) -> None:
+        """Start background thread to handle PULL_REQUEST from decode (prefill side)"""
+        if self._pull_request_handler_thread is not None:
+            return  # Already started
+
+        self._pull_request_handler_stop = False
+
+        def pull_request_handler():
+            """Background worker that handles PULL_REQUEST from decode"""
+            logger.info("[InMemorySpyreConnector] Pull request handler thread started")
+
+            cleanup_counter = 0
+            while not self._pull_request_handler_stop:
+                import time
+
+                # Periodic cleanup of old pending transfers (every 1000 iterations = ~10 seconds)
+                # TEMPORARILY DISABLED FOR TESTING - investigating cache hit rate degradation
+                cleanup_counter += 1
+                if cleanup_counter >= 1000:
+                    # self._cleanup_old_pending_transfers()  # DISABLED
+                    cleanup_counter = 0
+
+                # Poll for PULL_REQUEST notifications from client
+                try:
+                    notifs = self._nixl_agent.get_new_notifs()
+                    if not notifs or "client" not in notifs:
+                        time.sleep(0.01)
+                        continue
+
+                    for notif in notifs["client"]:
+                        notif_str = notif.decode("utf-8")
+
+                        # Handle LIST_REQUEST - send available req_ids
+                        if notif_str == "LIST_REQUEST":
+                            with self._pending_transfers_lock:
+                                available_ids = ",".join(self._pending_transfers.keys())
+                            response = f"LIST:{available_ids}".encode()
+                            self._nixl_agent.send_notif("client", response)
+                            logger.info(
+                                "[InMemorySpyreConnector] Sent LIST response: %d req_ids available",
+                                len(self._pending_transfers),
+                            )
+                            continue
+
+                        # Check if it's a PULL_REQUEST
+                        if not notif_str.startswith("PULL:"):
+                            continue
+
+                        req_id = notif_str[5:]  # Extract req_id from "PULL:req_id"
+                        logger.info(
+                            "[InMemorySpyreConnector] Received PULL_REQUEST for req_id=%s", req_id
+                        )
+
+                        # Check if we have this transfer ready
+                        with self._pending_transfers_lock:
+                            if req_id not in self._pending_transfers:
+                                logger.warning(
+                                    "[InMemorySpyreConnector] PULL_REQUEST for unknown req_id=%s, sending RETRY",
+                                    req_id,
+                                )
+                                self._nixl_agent.send_notif("client", b"RETRY")
+                                continue
+
+                            transfer_data = self._pending_transfers[req_id]
+
+                        # Send metadata and descriptors
+                        try:
+                            logger.info(
+                                "[InMemorySpyreConnector] Sending transfer data for req_id=%s",
+                                req_id,
+                            )
+                            self._nixl_agent.send_notif("client", transfer_data["metadata"])
+                            logger.info("[InMemorySpyreConnector] Sent metadata")
+                            time.sleep(0.05)
+                            self._nixl_agent.send_notif("client", transfer_data["descriptors"])
+                            logger.info(
+                                "[InMemorySpyreConnector] Sent descriptors for req_id=%s", req_id
+                            )
+                        except Exception as exc:
+                            logger.error(
+                                "[InMemorySpyreConnector] Error sending transfer data for req_id=%s: %s",
+                                req_id,
+                                exc,
+                            )
+
+                except Exception as exc:
+                    logger.error("[InMemorySpyreConnector] Error in pull request handler: %s", exc)
+                    time.sleep(0.1)
+
+            logger.info("[InMemorySpyreConnector] Pull request handler thread stopped")
+
+        import threading
+
+        self._pull_request_handler_thread = threading.Thread(
+            target=pull_request_handler, daemon=True
+        )
+        self._pull_request_handler_thread.start()
+        logger.info("[InMemorySpyreConnector] Started pull request handler thread")
+
+    def _stop_pull_request_handler(self) -> None:
+        """Stop pull request handler thread"""
+        if self._pull_request_handler_thread is None:
+            return
+
+        self._pull_request_handler_stop = True
+        self._pull_request_handler_thread.join(timeout=5.0)
+        self._pull_request_handler_thread = None
+        logger.info("[InMemorySpyreConnector] Stopped pull request handler thread")
+
+    def _cleanup_old_pending_transfers(self, max_age_seconds: float = 300.0) -> None:
+        """Cleanup pending transfers older than max_age_seconds (default 5 minutes)"""
+        if not self._pending_transfers:
+            return
+
+        import time
+
+        current_time = time.time()
+        to_remove = []
+
+        with self._pending_transfers_lock:
+            for req_id, transfer_data in self._pending_transfers.items():
+                age = current_time - transfer_data["timestamp"]
+                if age > max_age_seconds:
+                    to_remove.append(req_id)
+
+            for req_id in to_remove:
+                transfer_data = self._pending_transfers[req_id]
+                try:
+                    self._nixl_agent.deregister_memory(transfer_data["register_descs"])
+                    logger.info(
+                        "[InMemorySpyreConnector] Cleaned up stale transfer: req_id=%s, age=%.1fs",
+                        req_id,
+                        current_time - transfer_data["timestamp"],
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "[InMemorySpyreConnector] Error deregistering stale transfer %s: %s",
+                        req_id,
+                        exc,
+                    )
+                del self._pending_transfers[req_id]
+
+        if to_remove:
+            logger.info("[InMemorySpyreConnector] Cleaned up %d stale transfers", len(to_remove))
+
+    def _prune_saved_request(self, req_id: str, *, remove_store: bool = False) -> bool:
+        if self._store.has_persistent_saved_requests():
+            removed = self._store.remove_saved_request(req_id)
+        else:
+            removed = self._saved_requests.pop(req_id, None) is not None
+        if remove_store:
+            self._store.remove_by_req(req_id)
+        return removed
+
+    def _load_saved_requests(self) -> list[SavedRequestRecord]:
+        if not self._store.has_persistent_saved_requests():
+            # Check in-memory saved requests first
+            if self._saved_requests:
+                return list(self._saved_requests.values())
+
+            # For consumer role, try NIXL transfer first, then file transfer
+            if self._kv_role == "kv_consumer":
+                if self._use_nixl:
+                    try:
+                        return self._load_saved_requests_nixl()
+                    except Exception as exc:
+                        logger.warning(
+                            "[InMemorySpyreConnector] NIXL load failed, falling back to file: %s",
+                            exc,
+                        )
+
+                if envs_spyre.VLLM_SPYRE_ENABLE_FILE_TRANSFER:
+                    kv_cache_file = (
+                        envs_spyre.VLLM_SPYRE_KV_CACHE_FILE_PATH
+                        or f"/tmp/{os.getpid()}/kv_cache.pt"
+                    )
+                    if os.path.exists(kv_cache_file):
+                        try:
+                            kv_data = torch.load(kv_cache_file, weights_only=False)
+                            if "prompt_token_ids" in kv_data and kv_data["prompt_token_ids"]:
+                                saved = SavedRequestRecord(
+                                    req_id=kv_data["req_id"],
+                                    prompt_token_ids=tuple(kv_data["prompt_token_ids"]),
+                                    block_ids=kv_data["block_ids"],
+                                    num_tokens=kv_data["token_count"],
+                                )
+
+                                # CRITICAL FIX: Load KV cache blocks into store NOW
+                                # This ensures available_prefix_blocks() returns correct count
+                                from spyre_inference.distributed.kv_transfer.kv_connector.v1.metadata import (
+                                    StoreKey,
+                                    KVKind,
+                                )
+
+                                layer_data = kv_data.get("layer_data", {})
+                                blocks_loaded = 0
+
+                                # Iterate over layer_data keys directly (layer_names may not be set yet)
+                                for layer_idx in sorted(layer_data.keys()):
+                                    layer_blocks = layer_data.get(layer_idx, [])
+                                    # Each block is a tuple of (key_tensor, value_tensor)
+                                    for block_idx, block_tuple in enumerate(layer_blocks):
+                                        if isinstance(block_tuple, tuple) and len(block_tuple) == 2:
+                                            # Get block_id from saved request
+                                            block_id = (
+                                                saved.block_ids[block_idx]
+                                                if block_idx < len(saved.block_ids)
+                                                else block_idx
+                                            )
+
+                                            # Store key tensor
+                                            key_store_key = StoreKey(
+                                                req_id=saved.req_id,
+                                                layer_idx=layer_idx,
+                                                block_id=block_id,
+                                                kv_kind=KVKind.K,
+                                            )
+                                            self._store.put(key_store_key, block_tuple[0])
+                                            blocks_loaded += 1
+
+                                            # Store value tensor
+                                            value_store_key = StoreKey(
+                                                req_id=saved.req_id,
+                                                layer_idx=layer_idx,
+                                                block_id=block_id,
+                                                kv_kind=KVKind.V,
+                                            )
+                                            self._store.put(value_store_key, block_tuple[1])
+                                            blocks_loaded += 1
+
+                                logger.info(
+                                    "[InMemorySpyreConnector] Loaded saved request from file: "
+                                    "req_id=%s, prompt_tokens=%d, block_ids=%s, blocks_loaded=%d",
+                                    saved.req_id,
+                                    len(saved.prompt_token_ids),
+                                    saved.block_ids,
+                                    blocks_loaded,
+                                )
+                                return [saved]
+                        except Exception as exc:
+                            logger.warning(
+                                "[InMemorySpyreConnector] Failed to load saved request from file %s: %s",
+                                kv_cache_file,
+                                exc,
+                            )
+
+            return list(self._saved_requests.values())
+
+        records = [
+            SavedRequestRecord(
+                req_id=str(record.req_id),
+                prompt_token_ids=tuple(record.prompt_token_ids),
+                block_ids=list(record.block_ids),
+                num_tokens=int(record.num_tokens),
+            )
+            for record in self._store.get_saved_requests()
+        ]
+        self._saved_requests = OrderedDict((record.req_id, record) for record in records)
+        return records
+
+    def _nixl_receive_dtype(self) -> torch.dtype:
+        """Dtype for NIXL receive buffers and descriptor-size math.
+
+        Spyre paged pages are fp16, so descriptor byte counts must use the
+        registered cache dtype — fp32 sizing halves the element count and
+        NIXL rejects the transfer with NIXL_ERR_INVALID_PARAM.
+        """
+        if self._paged_accessor is not None:
+            return self._paged_accessor.dtype
+        if self._kv_caches:
+            first_cache = next(iter(self._kv_caches.values()))
+            dtype = getattr(first_cache, "dtype", None)
+            if isinstance(dtype, torch.dtype):
+                return dtype
+        if self._dtype_str.startswith("torch."):
+            dtype = getattr(torch, self._dtype_str.removeprefix("torch."), None)
+            if isinstance(dtype, torch.dtype):
+                return dtype
+        return torch.float32
+
+    def _load_saved_requests_nixl(self) -> list[SavedRequestRecord]:
+        """Load saved requests via NIXL transfer (consumer/decode side)"""
+        # Ensure NIXL agent is initialized (lazy init)
+        if self._nixl_agent is None:
+            self._init_nixl_agent()
+
+        if self._nixl_agent is None:
+            raise RuntimeError("NIXL agent initialization failed")
+
+        # DON'T reset NIXL state on decode side - it drains notifications we need!
+
+        logger.info("[InMemorySpyreConnector] Starting NIXL KV cache transfer (client)")
+
+        # Step 1: Request list of available req_ids from prefill
+        import time
+        import json
+
+        logger.info("[InMemorySpyreConnector] Sending LIST_REQUEST to prefill")
+        self._nixl_agent.send_notif("server", b"LIST_REQUEST")
+
+        # Step 2: Poll for LIST response
+        max_wait_seconds = 60
+        wait_count = 0
+        available_req_ids = []
+
+        while wait_count < max_wait_seconds * 100:
+            notifs = self._nixl_agent.get_new_notifs()
+            if len(notifs) > 0 and "server" in notifs and len(notifs["server"]) > 0:
+                for notif in notifs["server"]:
+                    try:
+                        notif_str = notif.decode("utf-8")
+                        if notif_str.startswith("LIST:"):
+                            ids_str = notif_str[5:]  # Extract after "LIST:"
+                            available_req_ids = [
+                                rid.strip() for rid in ids_str.split(",") if rid.strip()
+                            ]
+                            logger.info(
+                                "[InMemorySpyreConnector] Received LIST response: %d req_ids available",
+                                len(available_req_ids),
+                            )
+                            break
+                    except UnicodeDecodeError:
+                        # Skip binary notifications (e.g., tensor descriptors from previous transfers)
+                        logger.debug(
+                            "[InMemorySpyreConnector] Skipping non-UTF-8 notification (likely binary data)"
+                        )
+                        continue
+                if available_req_ids:
+                    break
+            time.sleep(0.01)
+            wait_count += 1
+
+        if not available_req_ids:
+            raise RuntimeError(
+                f"Timeout waiting for LIST response from prefill (waited {max_wait_seconds}s)"
+            )
+
+        # Step 3: Select LAST (most recent) req_id to avoid pulling stale cached data
+        # CRITICAL FIX: Use [-1] to get newest request, not [0] which gets oldest
+        req_id = available_req_ids[-1]
+        logger.info(
+            "[InMemorySpyreConnector] Selected req_id=%s from available list (total: %d)",
+            req_id,
+            len(available_req_ids),
+        )
+
+        # Step 4: Send PULL_REQUEST for selected req_id
+        logger.info("[InMemorySpyreConnector] Sending PULL_REQUEST for req_id=%s", req_id)
+
+        # First, receive metadata (req_id, prompt_tokens, block_ids)
+        import time
+
+        # Send PULL_REQUEST to prefill
+        pull_request_msg = f"PULL:{req_id}".encode()
+        self._nixl_agent.send_notif("server", pull_request_msg)
+        logger.info("[InMemorySpyreConnector] Sent PULL_REQUEST")
+
+        # Poll for response with exponential backoff
+        max_wait_seconds = 60
+        wait_count = 0
+        backoff_delay = 0.01  # Start with 10ms
+        max_backoff = 1.0  # Max 1 second
+        notifs = {}
+        retry_count = 0
+
+        while wait_count < max_wait_seconds * 100:  # 100 iterations per second
+            notifs = self._nixl_agent.get_new_notifs()
+
+            if len(notifs) > 0 and "server" in notifs and len(notifs["server"]) > 0:
+                # Check if it's a RETRY response
+                first_notif = notifs["server"][0]
+                if first_notif == b"RETRY":
+                    retry_count += 1
+                    logger.info(
+                        "[InMemorySpyreConnector] Received RETRY, attempt %d, waiting %.2fs before retry",
+                        retry_count,
+                        backoff_delay,
+                    )
+                    time.sleep(backoff_delay)
+                    # Exponential backoff
+                    backoff_delay = min(backoff_delay * 2, max_backoff)
+                    # Resend PULL_REQUEST
+                    self._nixl_agent.send_notif("server", pull_request_msg)
+                    wait_count += int(backoff_delay * 100)
+                    continue
+                else:
+                    # Got actual data
+                    logger.info(
+                        "[InMemorySpyreConnector] Received transfer data after %d iterations, %d retries",
+                        wait_count,
+                        retry_count,
+                    )
+                    break
+
+            time.sleep(0.01)
+            wait_count += 1
+
+        if len(notifs) == 0 or "server" not in notifs or len(notifs["server"]) == 0:
+            raise RuntimeError(
+                f"Timeout waiting for NIXL transfer data from server (waited {max_wait_seconds}s, retries={retry_count})"
+            )
+
+        # Check if we received multiple notifications at once
+        server_notifs = notifs["server"]
+        logger.info(
+            "[InMemorySpyreConnector] Received %d notifications from server", len(server_notifs)
+        )
+
+        # First notification should be metadata
+        metadata_bytes = server_notifs[0]
+        metadata = json.loads(metadata_bytes.decode("utf-8"))
+
+        req_id = metadata["req_id"]
+        prompt_token_ids = tuple(metadata["prompt_token_ids"])
+        block_ids = metadata["block_ids"]
+        num_tokens = metadata["num_tokens"]
+        num_layers = metadata["num_layers"]
+
+        logger.info(
+            "[InMemorySpyreConnector] Received metadata: req_id=%s, prompt_tokens=%d, blocks=%d",
+            req_id,
+            len(prompt_token_ids),
+            len(block_ids),
+        )
+
+        # Check if descriptor is already in the same batch
+        remote_xfer_descs = None
+        if len(server_notifs) > 1:
+            logger.info("[InMemorySpyreConnector] Descriptor already received in same batch")
+            try:
+                remote_xfer_descs = self._nixl_agent.deserialize_descs(server_notifs[1])
+            except Exception as e:
+                logger.warning("[InMemorySpyreConnector] Failed to deserialize second notif: %s", e)
+
+        # If not received yet, wait for it
+        if remote_xfer_descs is None:
+            logger.info("[InMemorySpyreConnector] Waiting for tensor descriptors...")
+            max_wait = 30
+            wait_count = 0
+
+            while remote_xfer_descs is None and wait_count < max_wait * 100:
+                notifs = self._nixl_agent.get_new_notifs()
+                if len(notifs) > 0 and "server" in notifs:
+                    try:
+                        remote_xfer_descs = self._nixl_agent.deserialize_descs(notifs["server"][0])
+                        logger.info("[InMemorySpyreConnector] Received tensor descriptors")
+                        break
+                    except Exception as e:
+                        logger.warning("[InMemorySpyreConnector] Failed to deserialize: %s", e)
+                time.sleep(0.01)
+                wait_count += 1
+
+            if remote_xfer_descs is None:
+                raise RuntimeError("Timeout waiting for tensor descriptors from server")
+
+        while not self._nixl_agent.check_remote_metadata("server"):
+            time.sleep(0.01)
+
+        # Reallocate buffers based on remote descriptors
+        # CRITICAL: Must match the producer's registered block layout.
+        desc_count = remote_xfer_descs.descCount()
+        tensors = []
+        recv_dtype = self._nixl_receive_dtype()
+        recv_itemsize = recv_dtype.itemsize
+
+        # Get KV cache shape - if not yet registered, infer from descriptor size
+        if self._paged_accessor is not None:
+            # The producer registers store-resident blocks in heap-block layout
+            # (see _save_kv_bulk -> SpyrePagedKVCacheAccessor.read_block), so the
+            # receive buffers must match: [block_size, num_kv_heads, head_dim].
+            kv_block_shape = self._paged_accessor.block_shape
+        elif self._kv_caches:
+            first_cache = next(iter(self._kv_caches.values()))
+            kv_block_shape = (
+                first_cache.shape[2],
+                self._block_size,
+                first_cache.shape[4],
+            )  # [num_kv_heads, block_size, head_dim]
+        else:
+            # KV caches not yet registered - infer shape from first descriptor
+            # CRITICAL: KV cache format is [block_size, num_kv_heads, head_dim], NOT [num_kv_heads, block_size, head_dim]
+            desc = remote_xfer_descs[0]
+            desc_len_bytes = desc[1]
+            num_elements = desc_len_bytes // recv_itemsize
+            # num_elements = block_size * num_kv_heads * head_dim
+            # For granite: 64 * 8 * 128 = 65536
+            num_kv_heads = num_elements // (self._block_size * 128)
+            head_dim = 128
+            kv_block_shape = (self._block_size, num_kv_heads, head_dim)  # CORRECT ORDER
+            logger.info(
+                "[InMemorySpyreConnector] Inferred KV shape from descriptor: %s (num_elements=%d)",
+                kv_block_shape,
+                num_elements,
+            )
+
+        expected_elements = kv_block_shape[0] * kv_block_shape[1] * kv_block_shape[2]
+
+        for i in range(desc_count):
+            desc = remote_xfer_descs[i]
+            desc_len_bytes = desc[1]
+            num_elements = desc_len_bytes // recv_itemsize
+
+            if num_elements != expected_elements:
+                logger.warning(
+                    "[InMemorySpyreConnector] Descriptor %d size mismatch: got %d elements, expected %d",
+                    i,
+                    num_elements,
+                    expected_elements,
+                )
+
+            # Allocate with correct shape and the registered cache dtype so the
+            # byte count matches the producer's registered pages (fp16 on Spyre).
+            tensor = torch.zeros(kv_block_shape, dtype=recv_dtype, device="cpu")
+            tensors.append(tensor)
+
+        # Re-register with actual buffers
+        descs = self._nixl_agent.get_reg_descs(tensors)
+        register_descs = self._nixl_agent.register_memory(descs)
+        local_xfer_descs = register_descs.trim()
+
+        # Initialize and execute transfer with unique tag per request
+        transfer_tag = f"KV_TRANSFER_{req_id}"
+        transfer_handle = self._nixl_agent.initialize_xfer(
+            "READ", local_xfer_descs, remote_xfer_descs, "server", transfer_tag
+        )
+
+        logger.info("[InMemorySpyreConnector] Starting NIXL transfer with tag=%s", transfer_tag)
+        state = self._nixl_agent.transfer(transfer_handle)
+        logger.info("[InMemorySpyreConnector] Initial transfer state: %s", state)
+        if state == "ERR":
+            raise RuntimeError("NIXL transfer initiation failed")
+
+        check_count = 0
+        while True:
+            state = self._nixl_agent.check_xfer_state(transfer_handle)
+            if check_count % 1000 == 0:  # Log every second
+                logger.info(
+                    "[InMemorySpyreConnector] Transfer check %d: state=%s", check_count, state
+                )
+            if state == "ERR":
+                raise RuntimeError("NIXL transfer failed")
+            if state == "DONE":
+                logger.info(
+                    "[InMemorySpyreConnector] Transfer completed after %d checks", check_count
+                )
+                break
+            time.sleep(0.001)
+            check_count += 1
+
+        logger.info(
+            "[InMemorySpyreConnector] NIXL transfer complete, received %d tensors", len(tensors)
+        )
+
+        # Log first received tensor for debugging
+        if len(tensors) > 0:
+            first_tensor = tensors[0]
+            logger.info(
+                "[InMemorySpyreConnector] First received tensor: shape=%s, dtype=%s, min=%.4f, max=%.4f, mean=%.4f",
+                tuple(first_tensor.shape),
+                first_tensor.dtype,
+                first_tensor.min().item(),
+                first_tensor.max().item(),
+                first_tensor.mean().item(),
+            )
+
+        # Use metadata received from server
+        tensor_idx = 0
+        blocks_loaded = 0
+
+        for layer_idx in range(num_layers):
+            for block_id in block_ids:
+                key_tensor = tensors[tensor_idx]
+                value_tensor = tensors[tensor_idx + 1]
+                tensor_idx += 2
+
+                # Log first block for debugging
+                if layer_idx == 0 and block_id == block_ids[0]:
+                    logger.info(
+                        "[InMemorySpyreConnector] Storing first block: layer=%d, block=%d, key_shape=%s, value_shape=%s",
+                        layer_idx,
+                        block_id,
+                        tuple(key_tensor.shape),
+                        tuple(value_tensor.shape),
+                    )
+
+                key_store_key = StoreKey(req_id, layer_idx, block_id, KVKind.K)
+                value_store_key = StoreKey(req_id, layer_idx, block_id, KVKind.V)
+
+                # Receive buffers are allocated in heap-block layout (the
+                # producer's registered layout), so they are stored directly.
+                self._store.put(key_store_key, key_tensor)
+                self._store.put(value_store_key, value_tensor)
+
+                # Verify what was stored by reading it back
+                if layer_idx == 0 and block_id == block_ids[0]:
+                    readback_key = self._store.get(key_store_key)
+                    readback_value = self._store.get(value_store_key)
+                    key_data = readback_key.data if hasattr(readback_key, "data") else readback_key
+                    value_data = (
+                        readback_value.data if hasattr(readback_value, "data") else readback_value
+                    )
+                    logger.info(
+                        "[InMemorySpyreConnector] Readback verification: key_shape=%s, value_shape=%s, key_min=%.4f, key_max=%.4f",
+                        tuple(key_data.shape),
+                        tuple(value_data.shape),
+                        key_data.min().item(),
+                        key_data.max().item(),
+                    )
+
+                blocks_loaded += 2
+
+        saved = SavedRequestRecord(
+            req_id=req_id,
+            prompt_token_ids=prompt_token_ids,
+            block_ids=block_ids,
+            num_tokens=num_tokens,
+        )
+
+        # CRITICAL FIX: Store in _saved_requests dict to accumulate across multiple loads
+        # Without this, each load replaces previous entries, causing cache lookup failures
+        self._saved_requests[req_id] = saved
+
+        logger.info(
+            "[InMemorySpyreConnector] NIXL load complete: req_id=%s, blocks_loaded=%d, total_saved=%d",
+            req_id,
+            blocks_loaded,
+            len(self._saved_requests),
+        )
+
+        # Return full list of all saved requests, not just the newly loaded one
+        return list(self._saved_requests.values())
+
+    def _save_request_nixl(self, record: SavedRequestRecord) -> None:
+        """Save request via NIXL transfer (producer/prefill side)"""
+        # Ensure NIXL agent is initialized (lazy init)
+        if self._nixl_agent is None:
+            self._init_nixl_agent()
+
+        if self._nixl_agent is None:
+            raise RuntimeError("NIXL agent initialization failed")
+
+        # Check if blocking mode is enabled
+        blocking_mode = envs_spyre.VLLM_SPYRE_NIXL_BLOCKING_TRANSFER
+
+        # Only reset state in blocking mode (non-blocking uses background thread for cleanup)
+        if blocking_mode:
+            self._reset_nixl_transfer_state()
+
+        logger.info("[InMemorySpyreConnector] Starting NIXL KV cache transfer (server)")
+
+        # Collect all KV tensors for this request from self._store
+        # NOTE: Called from _save_kv_bulk AFTER blocks are stored
+        tensors = []
+        for layer_idx in range(self._num_layers):
+            for block_id in record.block_ids:
+                key_store_key = StoreKey(record.req_id, layer_idx, block_id, KVKind.K)
+                value_store_key = StoreKey(record.req_id, layer_idx, block_id, KVKind.V)
+
+                key_entry = self._store.get(key_store_key)
+                value_entry = self._store.get(value_store_key)
+
+                if key_entry is None or value_entry is None:
+                    logger.warning(
+                        "[InMemorySpyreConnector] Missing entry in store: layer=%d block=%d",
+                        layer_idx,
+                        block_id,
+                    )
+                    continue
+
+                # Extract tensor from HostMemoryKVEntry
+                key_tensor = key_entry.data if hasattr(key_entry, "data") else key_entry
+                value_tensor = value_entry.data if hasattr(value_entry, "data") else value_entry
+
+                if not key_tensor.is_contiguous():
+                    key_tensor = key_tensor.contiguous()
+                if not value_tensor.is_contiguous():
+                    value_tensor = value_tensor.contiguous()
+
+                # Log first tensor shape for debugging
+                if layer_idx == 0 and block_id == record.block_ids[0]:
+                    logger.info(
+                        "[InMemorySpyreConnector] First tensor shapes: key=%s, value=%s, dtype=%s",
+                        tuple(key_tensor.shape),
+                        tuple(value_tensor.shape),
+                        key_tensor.dtype,
+                    )
+
+                tensors.append(key_tensor)
+                tensors.append(value_tensor)
+
+        if not tensors:
+            logger.warning("[InMemorySpyreConnector] No tensors to transfer via NIXL")
+            return
+
+        # Register memory
+        descs = self._nixl_agent.get_reg_descs(tensors)
+        register_descs = self._nixl_agent.register_memory(descs)
+
+        import json
+        import time
+
+        # Prepare metadata (req_id, prompt_tokens, block_ids) and descriptors
+        # up front; only blocking mode pushes them to a connected client here.
+        metadata = {
+            "req_id": record.req_id,
+            "prompt_token_ids": list(record.prompt_token_ids),
+            "block_ids": list(record.block_ids),
+            "num_tokens": record.num_tokens,
+            "num_layers": self._num_layers,
+        }
+        metadata_bytes = json.dumps(metadata).encode("utf-8")
+        local_xfer_descs = register_descs.trim()
+        desc = self._nixl_agent.get_serialized_descs(local_xfer_descs)
+
+        if blocking_mode:
+            # BLOCKING MODE: wait for the client, push metadata + descriptors,
+            # then wait for transfer completion (original behavior).
+            while not self._nixl_agent.check_remote_metadata("client"):
+                time.sleep(0.01)
+
+            self._nixl_agent.send_notif("client", metadata_bytes)
+            # Give the client a beat to consume metadata before descriptors.
+            time.sleep(0.1)
+            self._nixl_agent.send_notif("client", desc)
+
+            logger.info("[InMemorySpyreConnector] NIXL transfer in BLOCKING mode")
+            while not self._nixl_agent.check_remote_xfer_done("client", b"KV_TRANSFER"):
+                time.sleep(0.001)
+
+            # Cleanup immediately after transfer completes
+            self._nixl_agent.deregister_memory(register_descs)
+            self._nixl_register_descs = None
+
+            logger.info(
+                "[InMemorySpyreConnector] NIXL transfer complete (blocking): req_id=%s, tensors=%d",
+                record.req_id,
+                len(tensors),
+            )
+        else:
+            # NON-BLOCKING MODE: Store in pending_transfers map, decode will pull when ready
+            logger.info(
+                "[InMemorySpyreConnector] NIXL transfer in NON-BLOCKING mode - storing in pending_transfers"
+            )
+
+            # Store transfer data in map for decode to pull
+            with self._pending_transfers_lock:
+                self._pending_transfers[record.req_id] = {
+                    "metadata": metadata_bytes,
+                    "descriptors": desc,
+                    "register_descs": register_descs,
+                    "timestamp": time.time(),
+                }
+
+            # Start pull request handler if not already running
+            if self._pull_request_handler_thread is None:
+                self._start_pull_request_handler()
+
+            logger.info(
+                "[InMemorySpyreConnector] NIXL transfer ready (non-blocking): req_id=%s, tensors=%d, stored in pending_transfers",
+                record.req_id,
+                len(tensors),
+            )
+
+    def _save_request_record(self, record: SavedRequestRecord) -> None:
+        if self._store.has_persistent_saved_requests():
+            self._store.save_request_record(record)
+            self._load_saved_requests()
+            return
+
+        if record.req_id in self._saved_requests:
+            self._saved_requests.move_to_end(record.req_id)
+        self._saved_requests[record.req_id] = record
+
+        if self._saved_requests_max_size > 0:
+            while len(self._saved_requests) > self._saved_requests_max_size:
+                oldest_req_id, _ = self._saved_requests.popitem(last=False)
+                self._store.remove_by_req(oldest_req_id)
+                self._stats.record("evictions")
+
+    def _saved_request_count(self) -> int:
+        if self._store.has_persistent_saved_requests():
+            return self._store.saved_request_count()
+        return len(self._saved_requests)
+
+    def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]) -> None:
+        self._kv_caches = kv_caches
+        if not kv_caches:
+            return
+
+        self._num_layers = len(kv_caches)
+        self._layer_names = sorted(kv_caches.keys())
+
+        # The Spyre attention backend registers SpyrePagedKVCache page lists
+        # (a NamedTuple of k/v page lists), not monolithic staging tensors.
+        self._paged_accessor = SpyrePagedKVCacheAccessor.try_from_kv_caches(kv_caches)
+        if self._paged_accessor is not None:
+            self._num_kv_heads = self._paged_accessor.num_kv_heads
+            self._head_dim = self._paged_accessor.head_dim
+            self._dtype_str = str(self._paged_accessor.dtype)
+            if self._block_size != self._paged_accessor.block_size:
+                logger.warning(
+                    "[InMemorySpyreConnector] Config block_size=%d disagrees with "
+                    "registered page block_size=%d; using page geometry",
+                    self._block_size,
+                    self._paged_accessor.block_size,
+                )
+                self._block_size = self._paged_accessor.block_size
+            logger.info(
+                "[InMemorySpyreConnector] Paged KV cache registered: %s",
+                self._paged_accessor.describe(),
+            )
+            return
+
+        first_tensor = next(iter(kv_caches.values()))
+        self._dtype_str = str(first_tensor.dtype)
+        if first_tensor.dim() >= 4:
+            self._num_kv_heads = first_tensor.shape[-2]
+            self._head_dim = first_tensor.shape[-1]
+
+    @property
+    def uses_heap_kv(self) -> bool:
+        return self._use_heap_kv
+
+    def heap_kv_active(self) -> bool:
+        return self._ensure_heap_kv_client() is not None
+
+    def paged_kv_active(self) -> bool:
+        return self._paged_accessor is not None
+
+    def get_paged_kv_status(self) -> dict[str, Any]:
+        if self._paged_accessor is None:
+            return {"active": False}
+        return {"active": True, **self._paged_accessor.describe()}
+
+    def get_heap_kv_status(self) -> dict[str, Any]:
+        active = self._heap_kv_client is not None
+        return {
+            "requested": bool(self._use_heap_kv),
+            "strict": bool(self._heap_kv_strict),
+            "active": active,
+            "mode": "in_process" if active else None,
+            "init_error": self._heap_kv_init_error,
+        }
+
+    def _ensure_heap_kv_client(self) -> InProcessHeapKVClient | None:
+        if not self._use_heap_kv:
+            return None
+        if self._paged_accessor is not None:
+            # The heap accessor addresses compiled-graph HBM offsets; with
+            # page-list caches the pages are directly accessible tensors and
+            # the heap path is the fallback for older/unknown layouts only.
+            logger.warning_once(
+                "[InMemorySpyreConnector] Heap KV requested but paged KV cache "
+                "is registered; using paged accessor"
+            )
+            return None
+        if self._heap_kv_client is not None:
+            return self._heap_kv_client
+        try:
+            if not self._kv_caches:
+                raise RuntimeError("KV cache geometry is unavailable before register_kv_caches")
+            first_tensor = next(iter(self._kv_caches.values()))
+            perfdsc_dir, export_dir = resolve_heap_kv_paths(
+                perfdsc_dir=envs_spyre.VLLM_SPYRE_HEAP_KV_PERFDSC_DIR or None,
+                export_dir=envs_spyre.VLLM_SPYRE_HEAP_KV_EXPORT_DIR or None,
+            )
+            client = InProcessHeapKVClient(
+                kv_heads=self._num_kv_heads,
+                block_size=self._block_size,
+                head_dim=self._head_dim,
+                dtype=first_tensor.dtype,
+                perfdsc_dir=perfdsc_dir,
+                export_dir=export_dir,
+            )
+            probe = client.probe()
+            self._heap_kv_client = client
+            logger.info(
+                "[InMemorySpyreConnector] Experimental in-process heap KV enabled "
+                "perfdsc_dir=%s export_dir=%s probe=%s",
+                perfdsc_dir,
+                export_dir,
+                probe,
+            )
+            return self._heap_kv_client
+        except Exception as exc:
+            self._heap_kv_init_error = f"{type(exc).__name__}: {exc}"
+            if self._heap_kv_strict:
+                raise RuntimeError(
+                    "Experimental in-process heap KV strict mode is enabled and "
+                    f"initialization failed: {self._heap_kv_init_error}"
+                ) from exc
+            logger.warning(
+                "[InMemorySpyreConnector] Experimental in-process heap KV unavailable, "
+                "falling back to staging path: %s",
+                self._heap_kv_init_error,
+            )
+            return None
+
+    def bind_connector_metadata(self, connector_metadata: KVConnectorMetadata) -> None:
+        if isinstance(connector_metadata, SpyreConnectorMeta):
+            connector_metadata.validate()
+        self._step_stores.clear()
+        self._step_loads.clear()
+        self._load_error_block_ids.clear()
+        super().bind_connector_metadata(connector_metadata)
+
+    def start_load_kv(self, forward_context: ForwardContext, **kwargs: Any) -> None:
+        if not self.has_connector_metadata():
+            return
+
+        meta = self._get_connector_metadata()
+        if not isinstance(meta, SpyreConnectorMeta):
+            return
+
+        # Extract dynamic remote connection info from metadata (for llm-d routing proxy)
+        # Falls back to environment variable for manual deployments
+        remote_ip = None
+        remote_port = None
+        for req_meta in meta.requests:
+            if not req_meta.is_store and req_meta.remote:
+                remote_ip = req_meta.remote.host
+                remote_port = req_meta.remote.port
+                logger.info(
+                    "[InMemorySpyreConnector] Using dynamic remote connection: host=%s, port=%d (from routing proxy)",
+                    remote_ip,
+                    remote_port,
+                )
+                break
+
+        # Update NIXL remote IP if provided dynamically
+        if remote_ip:
+            self._nixl_remote_ip = remote_ip
+            logger.info(
+                "[InMemorySpyreConnector] Updated NIXL remote IP to %s (dynamic from metadata)",
+                self._nixl_remote_ip,
+            )
+        else:
+            # Use environment variable (manual deployment)
+            logger.info(
+                "[InMemorySpyreConnector] Using NIXL remote IP from environment: %s",
+                self._nixl_remote_ip,
+            )
+
+        total_load = 0
+        total_miss = 0
+        self._load_error_block_ids.clear()
+
+        has_load_requests = any(not req_meta.is_store for req_meta in meta.requests)
+        heap_client = self._ensure_heap_kv_client() if has_load_requests else None
+        if has_load_requests and self._paged_accessor is not None:
+            total_load, total_miss = self._load_via_paged_accessor(meta, self._paged_accessor)
+        elif heap_client is not None:
+            total_load, total_miss = self._load_via_heap_helper(meta, heap_client)
+        else:
+            for layer_idx, layer_name in enumerate(self._layer_names):
+                layer_load, layer_miss = self._load_layer(
+                    meta,
+                    layer_idx,
+                    layer_name,
+                )
+                total_load += layer_load
+                total_miss += layer_miss
+
+        self._blocks_loaded += total_load
+        self._blocks_missing += total_miss
+        self._stats.record("loaded_blocks", total_load)
+        self._stats.record("load_misses", total_miss)
+
+        for req_meta in meta.requests:
+            if not req_meta.is_store:
+                self._step_loads.add(req_meta.req_id)
+
+    def _load_layer(
+        self,
+        meta: SpyreConnectorMeta,
+        layer_idx: int,
+        layer_name: str,
+    ) -> tuple[int, int]:
+        staging = self._kv_caches.get(layer_name)
+        if staging is None:
+            return 0, 0
+
+        # Step 2: Try loading from file first if file transfer is enabled
+        if envs_spyre.VLLM_SPYRE_ENABLE_FILE_TRANSFER:
+            kv_cache_file = (
+                envs_spyre.VLLM_SPYRE_KV_CACHE_FILE_PATH or f"/tmp/{os.getpid()}/kv_cache.pt"
+            )
+            if os.path.exists(kv_cache_file):
+                try:
+                    kv_data = torch.load(kv_cache_file, weights_only=False)
+                    layer_data = kv_data.get("layer_data", {}).get(layer_idx, [])
+
+                    if layer_data:
+                        load_count = 0
+                        saved_req_id = kv_data.get("req_id")
+                        saved_block_ids = kv_data.get("block_ids", [])
+
+                        logger.info(
+                            "[InMemorySpyreConnector] Layer %d: Attempting to load from file. "
+                            "Saved req_id=%s, saved_blocks=%s, num_requests=%d",
+                            layer_idx,
+                            saved_req_id,
+                            saved_block_ids,
+                            len(meta.requests),
+                        )
+
+                        for req_meta in meta.requests:
+                            logger.info(
+                                "[InMemorySpyreConnector] Layer %d: Processing req_meta: "
+                                "req_id=%s, is_store=%s, source_req_id=%s, block_ids=%s, block_mapping=%s",
+                                layer_idx,
+                                req_meta.req_id,
+                                req_meta.is_store,
+                                req_meta.source_req_id,
+                                req_meta.block_ids,
+                                req_meta.block_mapping,
+                            )
+
+                            if req_meta.is_store:
+                                logger.info(
+                                    "[InMemorySpyreConnector] Layer %d: Skipping req_id=%s (is_store=True)",
+                                    layer_idx,
+                                    req_meta.req_id,
+                                )
+                                continue
+
+                            # Get the source request ID to match saved data
+                            source_req = req_meta.source_req_id or req_meta.req_id
+
+                            # Check if this matches the saved request
+                            if source_req != saved_req_id:
+                                logger.info(
+                                    "[InMemorySpyreConnector] Layer %d: Skipping req_id=%s "
+                                    "(source_req=%s doesn't match saved_req_id=%s)",
+                                    layer_idx,
+                                    req_meta.req_id,
+                                    source_req,
+                                    saved_req_id,
+                                )
+                                continue
+
+                            mapping = (
+                                list(req_meta.block_mapping)
+                                if req_meta.block_mapping
+                                else [(block_id, block_id) for block_id in req_meta.block_ids]
+                            )
+
+                            logger.info(
+                                "[InMemorySpyreConnector] Layer %d: Loading blocks for req_id=%s, mapping=%s",
+                                layer_idx,
+                                req_meta.req_id,
+                                mapping,
+                            )
+
+                            # Load blocks: layer_data is indexed by position in saved block list
+                            for src_block_id, dest_bid in mapping:
+                                if dest_bid < 0 or dest_bid >= staging.shape[1]:
+                                    logger.warning(
+                                        "[InMemorySpyreConnector] Layer %d: Invalid dest_bid=%d (staging.shape[1]=%d)",
+                                        layer_idx,
+                                        dest_bid,
+                                        staging.shape[1],
+                                    )
+                                    continue
+
+                                # Find the position of src_block_id in saved_block_ids
+                                try:
+                                    block_idx = saved_block_ids.index(src_block_id)
+                                    if block_idx < len(layer_data):
+                                        k_block, v_block = layer_data[block_idx]
+                                        staging[0][dest_bid].copy_(k_block.to(staging.device))
+                                        staging[1][dest_bid].copy_(v_block.to(staging.device))
+                                        load_count += 2  # K and V
+                                        logger.info(
+                                            "[InMemorySpyreConnector] Layer %d: Loaded block src=%d->dest=%d (idx=%d)",
+                                            layer_idx,
+                                            src_block_id,
+                                            dest_bid,
+                                            block_idx,
+                                        )
+                                    else:
+                                        logger.warning(
+                                            "[InMemorySpyreConnector] Layer %d: block_idx=%d >= len(layer_data)=%d",
+                                            layer_idx,
+                                            block_idx,
+                                            len(layer_data),
+                                        )
+                                except ValueError:
+                                    logger.warning(
+                                        "[InMemorySpyreConnector] Layer %d: src_block_id=%d not in saved_block_ids=%s",
+                                        layer_idx,
+                                        src_block_id,
+                                        saved_block_ids,
+                                    )
+                                    continue
+
+                        logger.info(
+                            "[InMemorySpyreConnector] Loaded layer %d from file %s: %d blocks",
+                            layer_idx,
+                            kv_cache_file,
+                            load_count // 2,
+                        )
+                        return load_count, 0
+                except Exception as exc:
+                    logger.warning(
+                        "[InMemorySpyreConnector] Failed to load from file %s: %s",
+                        kv_cache_file,
+                        exc,
+                    )
+
+        # Fall back to existing store-based loading
+        load_count = 0
+        miss_count = 0
+
+        for req_meta in meta.requests:
+            if req_meta.is_store:
+                continue
+
+            source_req = req_meta.source_req_id or req_meta.req_id
+            mapping = (
+                list(req_meta.block_mapping)
+                if req_meta.block_mapping
+                else [(block_id, block_id) for block_id in req_meta.block_ids]
+            )
+
+            for src_block_id, dest_bid in mapping:
+                if dest_bid < 0 or dest_bid >= staging.shape[1]:
+                    miss_count += 1
+                    self._load_error_block_ids.add(dest_bid)
+                    continue
+
+                for kv_kind, kv_dim in ((KVKind.K, 0), (KVKind.V, 1)):
+                    store_key = StoreKey(
+                        req_id=source_req,
+                        layer_idx=layer_idx,
+                        block_id=src_block_id,
+                        kv_kind=kv_kind,
+                    )
+
+                    # Log first load attempt for debugging
+                    if layer_idx == 0 and src_block_id == mapping[0][0] and kv_kind == KVKind.K:
+                        target_tensor = staging[kv_dim][dest_bid]
+                        logger.info(
+                            "[InMemorySpyreConnector] Loading into staging: layer=%d, src_block=%d, dest_block=%d, target_shape=%s, target_device=%s",
+                            layer_idx,
+                            src_block_id,
+                            dest_bid,
+                            tuple(target_tensor.shape),
+                            target_tensor.device,
+                        )
+                        # Check what's in store before load
+                        stored_entry = self._store.get(store_key)
+                        if stored_entry:
+                            stored_data = (
+                                stored_entry.data if hasattr(stored_entry, "data") else stored_entry
+                            )
+                            logger.info(
+                                "[InMemorySpyreConnector] Store contains: shape=%s, device=%s, min=%.4f, max=%.4f",
+                                tuple(stored_data.shape),
+                                stored_data.device,
+                                stored_data.min().item(),
+                                stored_data.max().item(),
+                            )
+
+                    if self._store.load_into(store_key, staging[kv_dim][dest_bid]):
+                        load_count += 1
+
+                        # Verify loaded data
+                        if layer_idx == 0 and src_block_id == mapping[0][0] and kv_kind == KVKind.K:
+                            loaded_tensor = staging[kv_dim][dest_bid]
+                            logger.info(
+                                "[InMemorySpyreConnector] After load_into: shape=%s, min=%.4f, max=%.4f, mean=%.4f",
+                                tuple(loaded_tensor.shape),
+                                loaded_tensor.min().item(),
+                                loaded_tensor.max().item(),
+                                loaded_tensor.mean().item(),
+                            )
+                    else:
+                        miss_count += 1
+                        self._load_error_block_ids.add(dest_bid)
+
+        return load_count, miss_count
+
+    def _load_via_heap_helper(
+        self,
+        meta: SpyreConnectorMeta,
+        heap_client: InProcessHeapKVClient,
+    ) -> tuple[int, int]:
+        block_values: dict[tuple[int, str, int], torch.Tensor] = {}
+        load_count = 0
+        miss_count = 0
+        dtype = next(iter(self._kv_caches.values())).dtype
+
+        for req_meta in meta.requests:
+            if req_meta.is_store:
+                continue
+
+            source_req = req_meta.source_req_id or req_meta.req_id
+            mapping = (
+                list(req_meta.block_mapping)
+                if req_meta.block_mapping
+                else [(block_id, block_id) for block_id in req_meta.block_ids]
+            )
+
+            for src_block_id, dest_bid in mapping:
+                for layer_idx in range(self._num_layers):
+                    for kv_kind in (KVKind.K, KVKind.V):
+                        store_key = StoreKey(
+                            req_id=source_req,
+                            layer_idx=layer_idx,
+                            block_id=src_block_id,
+                            kv_kind=kv_kind,
+                        )
+                        cpu_block = torch.empty(
+                            (self._block_size, self._num_kv_heads, self._head_dim),
+                            dtype=dtype,
+                            device="cpu",
+                        )
+                        if self._store.load_into(store_key, cpu_block):
+                            block_values[(layer_idx, kv_kind.value.lower(), dest_bid)] = cpu_block
+                            load_count += 1
+                        else:
+                            miss_count += 1
+                            self._load_error_block_ids.add(dest_bid)
+
+        if block_values:
+            heap_client.write_blocks(block_values)
+        return load_count, miss_count
+
+    def _load_via_paged_accessor(
+        self,
+        meta: SpyreConnectorMeta,
+        accessor: SpyrePagedKVCacheAccessor,
+    ) -> tuple[int, int]:
+        """Load stored blocks directly into the registered K/V page tensors."""
+        load_count = 0
+        miss_count = 0
+        cpu_block = torch.empty(accessor.block_shape, dtype=accessor.dtype, device="cpu")
+
+        for req_meta in meta.requests:
+            if req_meta.is_store:
+                continue
+
+            source_req = req_meta.source_req_id or req_meta.req_id
+            mapping = (
+                list(req_meta.block_mapping)
+                if req_meta.block_mapping
+                else [(block_id, block_id) for block_id in req_meta.block_ids]
+            )
+
+            for src_block_id, dest_bid in mapping:
+                if not 0 <= dest_bid < accessor.num_pages:
+                    miss_count += 1
+                    self._load_error_block_ids.add(dest_bid)
+                    continue
+                for layer_idx, layer_name in enumerate(accessor.layer_names):
+                    for kv_kind in (KVKind.K, KVKind.V):
+                        store_key = StoreKey(
+                            req_id=source_req,
+                            layer_idx=layer_idx,
+                            block_id=src_block_id,
+                            kv_kind=kv_kind,
+                        )
+                        if self._store.load_into(store_key, cpu_block):
+                            accessor.write_block(
+                                layer_name=layer_name,
+                                kv_kind=kv_kind.value.lower(),
+                                page_id=dest_bid,
+                                values=cpu_block,
+                            )
+                            load_count += 1
+                        else:
+                            miss_count += 1
+                            self._load_error_block_ids.add(dest_bid)
+        return load_count, miss_count
+
+    def save_kv_layer(
+        self,
+        layer_name: str,
+        kv_layer: torch.Tensor,
+        attn_metadata: AttentionMetadata,
+        **kwargs: Any,
+    ) -> None:
+        return
+
+    def _save_kv_bulk(self) -> None:
+        if not self.has_connector_metadata():
+            return
+
+        meta = self._get_connector_metadata()
+        if not isinstance(meta, SpyreConnectorMeta):
+            return
+
+        save_count = 0
+        heap_client = self._ensure_heap_kv_client()
+        for req_meta in meta.requests:
+            if not req_meta.is_store:
+                continue
+
+            logger.info(
+                "[InMemorySpyreConnector] save_kv_bulk req=%s token_count=%d "
+                "block_ids=%s store_stats_before=%s",
+                req_meta.req_id,
+                req_meta.token_count,
+                req_meta.block_ids,
+                self._store.stats(),
+            )
+
+            heap_blocks: dict[tuple[int, str, int], torch.Tensor] = {}
+            if heap_client is not None:
+                block_refs = [
+                    (layer_idx, kv_kind.value.lower(), block_id)
+                    for layer_idx in range(self._num_layers)
+                    for block_id in req_meta.block_ids
+                    for kv_kind in (KVKind.K, KVKind.V)
+                ]
+                if block_refs:
+                    heap_blocks = heap_client.read_blocks(block_refs)
+
+            paged = self._paged_accessor
+            for layer_idx, layer_name in enumerate(self._layer_names):
+                staging = self._kv_caches.get(layer_name)
+                if staging is None and not heap_blocks:
+                    continue
+
+                for block_id in req_meta.block_ids:
+                    if paged is not None and not 0 <= block_id < paged.num_pages:
+                        logger.warning(
+                            "[InMemorySpyreConnector] save_kv_bulk skipping out-of-range "
+                            "block %d (num_pages=%d)",
+                            block_id,
+                            paged.num_pages,
+                        )
+                        continue
+                    for kv_kind, kv_dim in ((KVKind.K, 0), (KVKind.V, 1)):
+                        store_key = StoreKey(
+                            req_id=req_meta.req_id,
+                            layer_idx=layer_idx,
+                            block_id=block_id,
+                            kv_kind=kv_kind,
+                        )
+                        if heap_blocks:
+                            cpu_block = heap_blocks[(layer_idx, kv_kind.value.lower(), block_id)]
+                        elif paged is not None:
+                            cpu_block = paged.read_block(
+                                layer_name=layer_name,
+                                kv_kind=kv_kind.value.lower(),
+                                page_id=block_id,
+                            )
+                        else:
+                            assert staging is not None
+                            cpu_block = staging[kv_dim][block_id]
+                        self._store.put(
+                            store_key,
+                            cpu_block,
+                            source_req=req_meta.req_id,
+                        )
+                        save_count += 1
+
+            logger.info(
+                "[InMemorySpyreConnector] save_kv_bulk req=%s store_stats_after=%s",
+                req_meta.req_id,
+                self._store.stats(),
+            )
+            self._step_stores.add(req_meta.req_id)
+
+            # Step 2: Save to file if file transfer is enabled
+            if envs_spyre.VLLM_SPYRE_ENABLE_FILE_TRANSFER:
+                kv_cache_file = (
+                    envs_spyre.VLLM_SPYRE_KV_CACHE_FILE_PATH or f"/tmp/{os.getpid()}/kv_cache.pt"
+                )
+                try:
+                    # Get prompt tokens from req_meta (passed from scheduler instance)
+                    prompt_tokens = getattr(req_meta, "prompt_token_ids", [])
+
+                    logger.info(
+                        "[InMemorySpyreConnector] Saving to file: req_id=%s, prompt_tokens_count=%d, "
+                        "has_prompt_token_ids_attr=%s",
+                        req_meta.req_id,
+                        len(prompt_tokens),
+                        hasattr(req_meta, "prompt_token_ids"),
+                    )
+
+                    kv_data = {
+                        "req_id": req_meta.req_id,
+                        "token_count": req_meta.token_count,
+                        "block_ids": list(req_meta.block_ids),
+                        "prompt_token_ids": prompt_tokens,
+                        "layer_data": {},
+                    }
+
+                    for layer_idx, layer_name in enumerate(self._layer_names):
+                        staging = self._kv_caches.get(layer_name)
+                        if staging is None:
+                            continue
+
+                        num_blocks = paged.num_pages if paged is not None else staging.shape[1]
+                        layer_blocks = []
+                        for block_id in req_meta.block_ids:
+                            if block_id < num_blocks:
+                                k_block = staging[0][block_id].cpu().clone()
+                                v_block = staging[1][block_id].cpu().clone()
+                                layer_blocks.append((k_block, v_block))
+
+                        kv_data["layer_data"][layer_idx] = layer_blocks
+
+                    torch.save(kv_data, kv_cache_file)
+                    logger.info(
+                        "[InMemorySpyreConnector] Saved KV cache to file %s: req=%s, %d layers, %d blocks, %d prompt_tokens",
+                        kv_cache_file,
+                        req_meta.req_id,
+                        len(kv_data["layer_data"]),
+                        len(req_meta.block_ids),
+                        len(prompt_tokens),
+                    )
+
+                    # Don't clean up yet - might be called multiple times for chunked prefill
+                    # self._pending_prompt_tokens.pop(req_meta.req_id, None)
+                except Exception as exc:
+                    logger.error(
+                        "[InMemorySpyreConnector] Failed to save KV cache to file %s: %s",
+                        kv_cache_file,
+                        exc,
+                    )
+
+            # Step 3: Transfer via NIXL if enabled (after blocks are stored)
+            if self._use_nixl and self._kv_role == "kv_producer":
+                try:
+                    # Create SavedRequestRecord for NIXL transfer
+                    prompt_tokens = getattr(req_meta, "prompt_token_ids", [])
+                    saved_record = SavedRequestRecord(
+                        req_id=req_meta.req_id,
+                        prompt_token_ids=tuple(prompt_tokens) if prompt_tokens else tuple(),
+                        block_ids=list(req_meta.block_ids),
+                        num_tokens=req_meta.token_count,
+                    )
+                    self._save_request_nixl(saved_record)
+                    logger.info(
+                        "[InMemorySpyreConnector] NIXL transfer completed for req=%s",
+                        req_meta.req_id,
+                    )
+                except Exception as exc:
+                    logger.error(
+                        "[InMemorySpyreConnector] NIXL transfer failed for req=%s: %s",
+                        req_meta.req_id,
+                        exc,
+                    )
+
+        self._blocks_saved += save_count
+        self._stats.record("saved_blocks", save_count)
+
+    def wait_for_layer_load(self, layer_name: str) -> None:
+        return
+
+    def wait_for_save(self) -> None:
+        self._save_kv_bulk()
+
+    def get_finished(self, finished_req_ids: set[str]) -> tuple[set[str] | None, set[str] | None]:
+        finished_sending = self._step_stores & finished_req_ids
+        finished_recving = self._step_loads & finished_req_ids
+        return (
+            finished_sending if finished_sending else None,
+            finished_recving if finished_recving else None,
+        )
+
+    def get_block_ids_with_load_errors(self) -> set[int]:
+        return set(self._load_error_block_ids)
+
+    def get_num_new_matched_tokens(
+        self,
+        request: Request,
+        num_computed_tokens: int,
+    ) -> tuple[int | None, bool]:
+        prompt = request.prompt_token_ids
+        saved_requests = self._load_saved_requests()
+
+        logger.info(
+            "[InMemorySpyreConnector] get_num_new_matched_tokens: req_id=%s, "
+            "prompt_len=%d, num_computed_tokens=%d, saved_requests_count=%d",
+            request.request_id,
+            len(prompt) if prompt else 0,
+            num_computed_tokens,
+            len(saved_requests),
+        )
+
+        if not prompt or not saved_requests:
+            self._pending_load_sources.pop(request.request_id, None)
+            self._stats.record("match_attempts")
+            logger.info(
+                "[InMemorySpyreConnector] get_num_new_matched_tokens: No match - "
+                "prompt=%s, saved_requests=%s",
+                bool(prompt),
+                bool(saved_requests),
+            )
+            return 0, False
+
+        prompt_tuple = tuple(prompt)
+        best_match: SavedRequestRecord | None = None
+        best_tokens_total = 0
+        stale_request_ids: list[str] = []
+
+        for saved in saved_requests:
+            saved_len = len(saved.prompt_token_ids)
+            logger.info(
+                "[InMemorySpyreConnector] Checking saved req_id=%s, "
+                "saved_prompt_len=%d, saved_block_ids=%s",
+                saved.req_id,
+                saved_len,
+                saved.block_ids,
+            )
+
+            if saved_len == 0:
+                logger.info(
+                    "[InMemorySpyreConnector] Skipping saved req_id=%s (empty prompt)",
+                    saved.req_id,
+                )
+                continue
+
+            available_blocks = self._store.available_prefix_blocks(
+                saved.req_id,
+                saved.block_ids,
+            )
+            logger.info(
+                "[InMemorySpyreConnector] Saved req_id=%s: available_blocks=%d, required_blocks=%d",
+                saved.req_id,
+                available_blocks,
+                len(saved.block_ids),
+            )
+
+            if available_blocks < len(saved.block_ids):
+                logger.warning(
+                    "[InMemorySpyreConnector] Marking req_id=%s as stale "
+                    "(available_blocks=%d < required=%d)",
+                    saved.req_id,
+                    available_blocks,
+                    len(saved.block_ids),
+                )
+                stale_request_ids.append(saved.req_id)
+                continue
+
+            common_len = 0
+            for prompt_token, saved_token in zip(prompt_tuple, saved.prompt_token_ids):
+                if prompt_token != saved_token:
+                    break
+                common_len += 1
+
+            # Allow partial block matching for prompts shorter than one block
+            if common_len >= self._block_size:
+                # Full blocks only for longer prompts
+                aligned = (common_len // self._block_size) * self._block_size
+            elif common_len == len(saved.prompt_token_ids) and common_len == len(prompt_tuple):
+                # Allow full match for short prompts (< block_size)
+                aligned = common_len
+            else:
+                # Partial match within a block - align to block boundary
+                aligned = (common_len // self._block_size) * self._block_size
+
+            logger.info(
+                "[InMemorySpyreConnector] Saved req_id=%s: common_len=%d, aligned=%d, "
+                "saved_len=%d, prompt_len=%d, block_size=%d",
+                saved.req_id,
+                common_len,
+                aligned,
+                len(saved.prompt_token_ids),
+                len(prompt_tuple),
+                self._block_size,
+            )
+
+            if aligned > best_tokens_total:
+                best_tokens_total = aligned
+                best_match = saved
+                logger.info(
+                    "[InMemorySpyreConnector] New best match: req_id=%s, tokens=%d, "
+                    "common_len=%d, saved_prompt_first_10=%s, request_prompt_first_10=%s",
+                    saved.req_id,
+                    aligned,
+                    common_len,
+                    list(saved.prompt_token_ids[:10]),
+                    list(prompt_tuple[:10]),
+                )
+
+        for req_id in stale_request_ids:
+            logger.info(
+                "[InMemorySpyreConnector] Pruning stale request: %s",
+                req_id,
+            )
+            self._prune_saved_request(req_id, remove_store=True)
+
+        if best_match is None or best_tokens_total == 0:
+            self._pending_load_sources.pop(request.request_id, None)
+            self._stats.record("match_attempts")
+            logger.info(
+                "[InMemorySpyreConnector] No valid match found: best_match=%s, "
+                "best_tokens_total=%d",
+                best_match.req_id if best_match else None,
+                best_tokens_total,
+            )
+            return 0, False
+
+        # CRITICAL FIX: Prefill should NEVER load external tokens
+        # Only decode (consumer) should load from external cache
+        if self._kv_role == "kv_producer":
+            logger.info(
+                "[InMemorySpyreConnector] Prefill side: returning 0 external tokens (req_id=%s)",
+                request.request_id,
+            )
+            return 0, False
+
+        # Per-request tracking: Use tracked value instead of scheduler's accumulated value
+        # This fixes the bug where num_computed_tokens incorrectly accumulates across requests
+        if request.request_id not in self._request_computed_tokens:
+            # New request - initialize to 0
+            self._request_computed_tokens[request.request_id] = 0
+            logger.info(
+                "[InMemorySpyreConnector] New request detected (req_id=%s), initializing num_computed_tokens=0 (scheduler passed=%d)",
+                request.request_id,
+                num_computed_tokens,
+            )
+
+            # CRITICAL FIX: If scheduler passed non-zero num_computed_tokens for a NEW request,
+            # it's using stale data from a previous request. Return 0 to avoid assertion failure.
+            if num_computed_tokens > 0:
+                logger.warning(
+                    "[InMemorySpyreConnector] Scheduler passed num_computed_tokens=%d for NEW request %s, "
+                    "returning 0 external tokens to avoid assertion failure (scheduler will compute locally)",
+                    num_computed_tokens,
+                    request.request_id,
+                )
+                self._pending_load_sources.pop(request.request_id, None)
+                self._stats.record("match_attempts")
+                return 0, False
+
+            num_computed_tokens = 0
+        else:
+            # Existing request - use our tracked value, ignore scheduler's value
+            tracked_value = self._request_computed_tokens[request.request_id]
+            logger.info(
+                "[InMemorySpyreConnector] Existing request (req_id=%s), using tracked num_computed_tokens=%d (scheduler passed=%d)",
+                request.request_id,
+                tracked_value,
+                num_computed_tokens,
+            )
+            num_computed_tokens = tracked_value
+
+        num_local = max(0, num_computed_tokens)
+
+        # Calculate external tokens based on matched tokens and what's already computed
+        # Only load tokens that are:
+        # 1. Part of the match (up to best_tokens_total)
+        # 2. Not already computed locally (subtract num_local)
+        # 3. Block-aligned (must be multiple of block_size)
+
+        logger.info(
+            "[InMemorySpyreConnector] Calculating num_external: num_local=%d, "
+            "best_tokens_total=%d, block_size=%d",
+            num_local,
+            best_tokens_total,
+            self._block_size,
+        )
+
+        if num_local == 0:
+            # First call: no tokens computed yet
+            # CRITICAL: Must satisfy TWO constraints:
+            # 1. num_external must be block-aligned (divisible by block_size)
+            # 2. num_external < prompt_len (leave at least 1 token for computation)
+
+            prompt_len = len(prompt_tuple)
+
+            # For prompts < block_size: no external cache benefit
+            if prompt_len < self._block_size:
+                num_external = 0
+                logger.info(
+                    "[InMemorySpyreConnector] First call (num_local=0): num_external=0 "
+                    "(prompt_len=%d < block_size=%d, no cache benefit)",
+                    prompt_len,
+                    self._block_size,
+                )
+            else:
+                # For prompts >= block_size: load all complete blocks that fit
+                # CRITICAL: Must leave at least 1 token for local computation
+                # The scheduler requires num_new_tokens = prompt_len - num_external - num_local > 0
+
+                # Calculate how many complete blocks we can load
+                # We must ensure: prompt_len - (blocks * block_size) - num_local > 0
+                # Since num_local = 0 on first call: prompt_len - (blocks * block_size) > 0
+                # Therefore: blocks * block_size < prompt_len
+                # Maximum blocks: (prompt_len - 1) // block_size
+
+                max_blocks_to_load = (prompt_len - 1) // self._block_size
+
+                # Limit by available blocks
+                available_blocks = len(best_match.block_ids)
+                blocks_to_load = min(max_blocks_to_load, available_blocks)
+
+                num_external = blocks_to_load * self._block_size
+
+                logger.info(
+                    "[InMemorySpyreConnector] First call (num_local=0): num_external=%d "
+                    "(matched=%d, block_size=%d, prompt_len=%d, max_blocks=%d, available_blocks=%d, loading_blocks=%d)",
+                    num_external,
+                    best_tokens_total,
+                    self._block_size,
+                    prompt_len,
+                    max_blocks_to_load,
+                    available_blocks,
+                    blocks_to_load,
+                )
+        else:
+            # Subsequent call: some tokens already computed
+            # This happens with chunked prefill
+            # Don't load anything - already processed
+            num_external = 0
+            logger.warning(
+                "[InMemorySpyreConnector] Subsequent call (num_local=%d > 0): "
+                "Setting num_external=0 (assuming chunked prefill already processed)",
+                num_local,
+            )
+
+        logger.info(
+            "[InMemorySpyreConnector] External token calculation: "
+            "best_tokens_total=%d, num_local=%d, num_external=%d, "
+            "prompt_len=%d, block_size=%d",
+            best_tokens_total,
+            num_local,
+            num_external,
+            len(prompt_tuple),
+            self._block_size,
+        )
+
+        if num_external == 0:
+            self._pending_load_sources.pop(request.request_id, None)
+            self._stats.record("match_attempts")
+            return 0, False
+
+        self._pending_load_sources[request.request_id] = _PendingLoadSource(
+            source=best_match,
+            matched_tokens_total=best_tokens_total,
+            num_local_computed_tokens=num_local,
+        )
+        _emit_connector_probe(
+            "match_selected",
+            req_id=request.request_id,
+            source_req_id=best_match.req_id,
+            prompt_token_count=len(prompt_tuple),
+            matched_tokens_total=best_tokens_total,
+            num_local_computed_tokens=num_local,
+            num_external_tokens=num_external,
+            source_block_ids=list(best_match.block_ids),
+            source_num_tokens=best_match.num_tokens,
+        )
+        self._stats.record("match_attempts")
+        self._stats.record("matched_tokens", num_external)
+
+        # CRITICAL FIX: Update tracked computed tokens to include external tokens we're loading
+        # This prevents the scheduler from thinking we need to compute these tokens again
+        self._request_computed_tokens[request.request_id] = num_local + num_external
+        logger.info(
+            "[InMemorySpyreConnector] Updated tracked computed tokens for req_id=%s: %d (was %d, added %d external)",
+            request.request_id,
+            num_local + num_external,
+            num_local,
+            num_external,
+        )
+
+        return num_external, False
+
+    def update_state_after_alloc(
+        self,
+        request: Request,
+        blocks: KVCacheBlocks,
+        num_external_tokens: int,
+    ) -> None:
+        if blocks is None:
+            block_id_lists = ()
+        elif hasattr(blocks, "get_block_ids"):
+            block_id_lists = blocks.get_block_ids()
+        else:
+            block_id_lists = tuple(list(group) for group in blocks)
+        if block_id_lists:
+            assert len(block_id_lists) == 1, (
+                "InMemorySpyreConnector assumes a single KV cache group"
+            )
+
+        flat_block_ids: list[int] = []
+        for group in block_id_lists:
+            flat_block_ids.extend(group)
+
+        # Step 2: Capture prompt tokens early for file transfer
+        logger.info(
+            "[InMemorySpyreConnector] update_state_after_alloc: req_id=%s, "
+            "has_prompt_token_ids=%s, prompt_len=%d, num_external_tokens=%d",
+            request.request_id,
+            hasattr(request, "prompt_token_ids") and request.prompt_token_ids is not None,
+            len(request.prompt_token_ids)
+            if hasattr(request, "prompt_token_ids") and request.prompt_token_ids
+            else 0,
+            num_external_tokens,
+        )
+        if hasattr(request, "prompt_token_ids") and request.prompt_token_ids:
+            self._pending_prompt_tokens[request.request_id] = list(request.prompt_token_ids)
+            logger.info(
+                "[InMemorySpyreConnector] Captured %d prompt tokens for req_id=%s",
+                len(request.prompt_token_ids),
+                request.request_id,
+            )
+
+        # CRITICAL: Track processed requests to prevent duplicate calls from overwriting load metadata
+        # Use a separate tracking dict since _pending_requests is appended at the end
+        if not hasattr(self, "_processed_alloc_requests"):
+            self._processed_alloc_requests = {}
+
+        if request.request_id in self._processed_alloc_requests:
+            prev_num_external = self._processed_alloc_requests[request.request_id]
+            logger.info(
+                "[InMemorySpyreConnector] update_state_after_alloc: Already processed req_id=%s "
+                "(prev_num_external=%d, current_num_external=%d), skipping duplicate call",
+                request.request_id,
+                prev_num_external,
+                num_external_tokens,
+            )
+            return
+
+        # Mark as processed with the num_external_tokens value
+        self._processed_alloc_requests[request.request_id] = num_external_tokens
+
+        if num_external_tokens > 0:
+            pending = self._pending_load_sources.get(request.request_id)
+            logger.info(
+                "[InMemorySpyreConnector] update_state_after_alloc: num_external_tokens=%d, "
+                "has_pending_source=%s, pending_source_req_id=%s",
+                num_external_tokens,
+                pending is not None,
+                pending.source.req_id if pending else None,
+            )
+            if pending is None:
+                logger.warning(
+                    "[InMemorySpyreConnector] No pending source for req_id=%s despite num_external_tokens=%d. "
+                    "Setting is_store=True (will not load from cache)",
+                    request.request_id,
+                    num_external_tokens,
+                )
+                req_meta = SpyreConnectorRequestMeta(
+                    req_id=request.request_id,
+                    block_ids=flat_block_ids,
+                    is_store=True,
+                    token_count=len(request.all_token_ids),
+                )
+            else:
+                num_external_blocks = num_external_tokens // self._block_size
+                local_blocks = pending.num_local_computed_tokens // self._block_size
+                source = pending.source
+                block_mapping: list[tuple[int, int]] = []
+
+                if num_external_tokens % self._block_size != 0:
+                    num_external_blocks += 1
+
+                # CRITICAL FIX: Map ALL blocks that the prompt uses, not just external blocks
+                # For 67 tokens with num_external=64 (1 block), we still need blocks [1,2]
+                # because the prompt spans into block 2 (tokens 64-66)
+                total_prompt_blocks = len(flat_block_ids)
+
+                for i in range(total_prompt_blocks):
+                    src_idx = local_blocks + i
+                    dest_idx = local_blocks + i
+                    if src_idx >= len(source.block_ids) or dest_idx >= len(flat_block_ids):
+                        break
+                    block_mapping.append((source.block_ids[src_idx], flat_block_ids[dest_idx]))
+
+                # CRITICAL: Validate against total_prompt_blocks, not num_external_blocks
+                # We map ALL blocks the prompt uses, even if only some are "external"
+                if len(block_mapping) != total_prompt_blocks:
+                    logger.warning(
+                        "[InMemorySpyreConnector] Block mapping incomplete: mapped=%d, expected=%d, setting is_store=True",
+                        len(block_mapping),
+                        total_prompt_blocks,
+                    )
+                    req_meta = SpyreConnectorRequestMeta(
+                        req_id=request.request_id,
+                        block_ids=flat_block_ids,
+                        is_store=True,
+                        token_count=len(request.all_token_ids),
+                    )
+                else:
+                    req_meta = SpyreConnectorRequestMeta(
+                        req_id=request.request_id,
+                        block_ids=flat_block_ids,
+                        is_store=False,
+                        token_count=num_external_tokens,
+                        source_req_id=source.req_id,
+                        block_mapping=block_mapping,
+                    )
+        else:
+            req_meta = SpyreConnectorRequestMeta(
+                req_id=request.request_id,
+                block_ids=flat_block_ids,
+                is_store=True,
+                token_count=len(request.all_token_ids),
+            )
+
+        # Step 2: Add prompt tokens to metadata for cross-instance transfer
+        if hasattr(request, "prompt_token_ids") and request.prompt_token_ids:
+            req_meta.prompt_token_ids = list(request.prompt_token_ids)
+            logger.info(
+                "[InMemorySpyreConnector] Added %d prompt_token_ids to req_meta for req_id=%s",
+                len(request.prompt_token_ids),
+                req_meta.req_id,
+            )
+
+        _emit_connector_probe(
+            "pending_request_meta",
+            req_id=req_meta.req_id,
+            is_store=req_meta.is_store,
+            token_count=req_meta.token_count,
+            num_external_tokens=num_external_tokens,
+            block_ids=list(req_meta.block_ids),
+            source_req_id=req_meta.source_req_id,
+            block_mapping=[list(pair) for pair in req_meta.block_mapping],
+        )
+        self._pending_requests.append(req_meta)
+
+    def build_connector_meta(
+        self,
+        scheduler_output: SchedulerOutput,
+    ) -> KVConnectorMetadata:
+        logger.info(
+            "[InMemorySpyreConnector] build_connector_meta: pending_prompt_tokens_keys=%s, size=%d",
+            list(self._pending_prompt_tokens.keys()),
+            len(self._pending_prompt_tokens),
+        )
+        meta = SpyreConnectorMeta(
+            requests=list(self._pending_requests),
+            layer_names=list(self._layer_names),
+            block_size=self._block_size,
+            dtype=self._dtype_str,
+            layout="NHD",
+            num_layers=self._num_layers,
+            num_kv_heads=self._num_kv_heads,
+            head_dim=self._head_dim,
+        )
+        self._pending_requests.clear()
+        self._pending_load_sources.clear()
+        # Don't clear pending_prompt_tokens here
+        return meta
+
+    def request_finished(
+        self,
+        request: Request,
+        block_ids: list[int],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        prompt = request.prompt_token_ids
+        if prompt and block_ids:
+            num_prompt_blocks = (len(prompt) + self._block_size - 1) // self._block_size
+            prompt_block_ids = list(block_ids[:num_prompt_blocks])
+            if not prompt_block_ids:
+                logger.info(
+                    "[InMemorySpyreConnector] request_finished req=%s prompt_tokens=%d "
+                    "received no prompt block ids from %s",
+                    request.request_id,
+                    len(prompt),
+                    block_ids,
+                )
+                return False, None
+
+            available_blocks = self._store.available_prefix_blocks(
+                request.request_id,
+                prompt_block_ids,
+            )
+            if available_blocks < len(prompt_block_ids):
+                logger.info(
+                    "[InMemorySpyreConnector] request_finished prune req=%s "
+                    "prompt_tokens=%d block_ids=%s prompt_block_ids=%s "
+                    "available_blocks=%d store_stats=%s",
+                    request.request_id,
+                    len(prompt),
+                    block_ids,
+                    prompt_block_ids,
+                    available_blocks,
+                    self._store.stats(),
+                )
+                self._store.remove_by_req(request.request_id)
+                return False, None
+
+            saved = SavedRequestRecord(
+                req_id=request.request_id,
+                prompt_token_ids=tuple(prompt),
+                block_ids=prompt_block_ids,
+                num_tokens=len(prompt),
+            )
+            self._save_request_record(saved)
+            _emit_connector_probe(
+                "request_finished_saved",
+                req_id=request.request_id,
+                prompt_token_count=len(prompt),
+                all_block_ids=list(block_ids),
+                prompt_block_ids=prompt_block_ids,
+            )
+            logger.info(
+                "[InMemorySpyreConnector] request_finished saved req=%s "
+                "prompt_tokens=%d prompt_block_ids=%s store_stats=%s",
+                request.request_id,
+                len(prompt),
+                prompt_block_ids,
+                self._store.stats(),
+            )
+
+        # Cleanup per-request tracking
+        self._request_computed_tokens.pop(request.request_id, None)
+        logger.info(
+            "[InMemorySpyreConnector] Cleaned up tracking for req_id=%s",
+            request.request_id,
+        )
+
+        return False, None
+
+    def get_kv_connector_stats(self) -> KVConnectorStats | None:
+        if self._stats.is_empty():
+            return None
+        snapshot = SpyreConnectorStats(data=dict(self._stats.data))
+        self._stats.reset()
+        return snapshot
+
+    @classmethod
+    def build_kv_connector_stats(
+        cls, data: dict[str, Any] | None = None
+    ) -> KVConnectorStats | None:
+        if data is not None:
+            return SpyreConnectorStats(data=data)
+        return SpyreConnectorStats()
+
+    def get_cumulative_metrics(self) -> dict[str, int]:
+        return {
+            "blocks_saved": self._blocks_saved,
+            "blocks_loaded": self._blocks_loaded,
+            "blocks_missing": self._blocks_missing,
+            "saved_requests_count": self._saved_request_count(),
+        }
+
+    def get_store(self) -> SpyreKVStoreBackend:
+        return self._store
+
+    def reset_probe_state(
+        self,
+        *,
+        clear_store: bool = True,
+        clear_saved_requests: bool = True,
+        clear_metrics: bool = True,
+    ) -> None:
+        self._pending_requests.clear()
+        self._pending_load_sources.clear()
+        self._step_stores.clear()
+        self._step_loads.clear()
+        self._load_error_block_ids.clear()
+        # Don't clear pending_prompt_tokens - they're needed for file save
+        # self._pending_prompt_tokens.clear()
+
+        if clear_saved_requests:
+            if self._store.has_persistent_saved_requests():
+                self._saved_requests.clear()
+                if not clear_store:
+                    self._store.clear_saved_requests()
+            else:
+                self._saved_requests.clear()
+
+        if clear_metrics:
+            self._blocks_saved = 0
+            self._blocks_loaded = 0
+            self._blocks_missing = 0
+            self._stats.reset()
+
+        if clear_store:
+            self._store.clear()
+
+    def shutdown(self) -> None:
+        logger.info("[InMemorySpyreConnector] Shutdown. Store stats: %s", self._store.stats())
+
+        # Cleanup NIXL agent
+        if self._nixl_agent is not None:
+            try:
+                peer = "client" if self._kv_role == "kv_producer" else "server"
+                self._nixl_agent.remove_remote_agent(peer)
+                logger.info("[InMemorySpyreConnector] NIXL agent cleaned up")
+            except Exception as exc:
+                logger.warning("[InMemorySpyreConnector] NIXL cleanup error: %s", exc)
+            self._nixl_agent = None
+
+        self._store.shutdown()

--- a/spyre_inference/distributed/kv_transfer/kv_connector/v1/local_transport_store.py
+++ b/spyre_inference/distributed/kv_transfer/kv_connector/v1/local_transport_store.py
@@ -1,0 +1,160 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+from multiprocessing import get_context
+from multiprocessing.connection import Client, Listener
+from typing import Any
+import contextlib
+
+
+def _run_transport_store_server(socket_path: str) -> None:
+    if os.path.exists(socket_path):
+        os.unlink(socket_path)
+
+    store: dict[Any, bytes] = {}
+    listener = Listener(address=socket_path, family="AF_UNIX")
+    try:
+        while True:
+            conn = listener.accept()
+            try:
+                while True:
+                    try:
+                        message = conn.recv()
+                    except EOFError:
+                        break
+
+                    op = message["op"]
+                    if op == "ping":
+                        conn.send({"ok": True})
+                    elif op == "put":
+                        store[message["key"]] = message["payload"]
+                        conn.send({"ok": True})
+                    elif op == "get":
+                        conn.send({"ok": True, "payload": store.get(message["key"])})
+                    elif op == "delete_keys":
+                        removed = 0
+                        for key in message["keys"]:
+                            if key in store:
+                                del store[key]
+                                removed += 1
+                        conn.send({"ok": True, "removed": removed})
+                    elif op == "clear":
+                        store.clear()
+                        conn.send({"ok": True})
+                    elif op == "shutdown":
+                        store.clear()
+                        conn.send({"ok": True})
+                        return
+                    else:
+                        conn.send({"ok": False, "error": f"Unknown op: {op}"})
+            finally:
+                conn.close()
+    finally:
+        listener.close()
+        if os.path.exists(socket_path):
+            os.unlink(socket_path)
+
+
+class UDSProcessKVTransport:
+    def __init__(self) -> None:
+        self._socket_path = os.path.join(
+            "/tmp",
+            f"spyre-kv-store-{os.getpid()}-{uuid.uuid4().hex[:8]}.sock",
+        )
+        start_method = "fork" if os.name == "posix" else "spawn"
+        self._ctx = get_context(start_method)
+        self._process = self._ctx.Process(
+            target=_run_transport_store_server,
+            args=(self._socket_path,),
+            daemon=True,
+        )
+        self._process.start()
+        self._conn = self._connect_with_retry()
+
+    def _connect_with_retry(self):
+        deadline = time.time() + 30.0
+        while True:
+            try:
+                conn = Client(address=self._socket_path, family="AF_UNIX")
+                conn.send({"op": "ping"})
+                response = conn.recv()
+                if response.get("ok"):
+                    return conn
+                conn.close()
+            except FileNotFoundError:
+                pass
+            except ConnectionRefusedError:
+                pass
+            except OSError:
+                pass
+            if time.time() >= deadline:
+                raise RuntimeError(
+                    f"Timed out connecting to local KV transport server at {self._socket_path}"
+                )
+            time.sleep(0.05)
+
+    def _request(self, message: dict[str, Any]) -> dict[str, Any]:
+        self._conn.send(message)
+        response = self._conn.recv()
+        if not response.get("ok", False):
+            raise RuntimeError(response.get("error", "Unknown local KV transport error"))
+        return response
+
+    def put(self, key: Any, payload: bytes) -> None:
+        self._request({"op": "put", "key": key, "payload": payload})
+
+    def get(self, key: Any) -> bytes | None:
+        response = self._request({"op": "get", "key": key})
+        return response.get("payload")
+
+    def delete_keys(self, keys: list[Any]) -> int:
+        response = self._request({"op": "delete_keys", "keys": keys})
+        return int(response.get("removed", 0))
+
+    def clear(self) -> None:
+        self._request({"op": "clear"})
+
+    def shutdown(self) -> None:
+        conn = getattr(self, "_conn", None)
+        process = getattr(self, "_process", None)
+        try:
+            if conn is not None:
+                try:
+                    conn.send({"op": "shutdown"})
+                    conn.recv()
+                except Exception:
+                    pass
+                conn.close()
+        finally:
+            self._conn = None
+
+        try:
+            if process is not None:
+                process.join(timeout=2.0)
+                if process.is_alive():
+                    process.terminate()
+                    process.join(timeout=2.0)
+        finally:
+            self._process = None
+            if os.path.exists(self._socket_path):
+                os.unlink(self._socket_path)
+
+    def __del__(self) -> None:
+        with contextlib.suppress(Exception):
+            self.shutdown()

--- a/spyre_inference/distributed/kv_transfer/kv_connector/v1/metadata.py
+++ b/spyre_inference/distributed/kv_transfer/kv_connector/v1/metadata.py
@@ -1,0 +1,1379 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections import OrderedDict
+from dataclasses import dataclass, field
+from enum import Enum
+import io
+from multiprocessing import resource_tracker, shared_memory
+from typing import Any
+
+import torch
+
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorMetadata,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
+    KVConnectorStats,
+)
+from spyre_inference.distributed.kv_transfer.kv_connector.v1.local_transport_store import (
+    UDSProcessKVTransport,
+)
+from spyre_inference.distributed.kv_transfer.kv_connector.v1.persistent_kv_service import (
+    PersistentKVServiceClient,
+)
+import contextlib
+
+
+class KVKind(str, Enum):  # noqa: UP042 — str() semantics relied on by store keys
+    K = "K"
+    V = "V"
+
+
+@dataclass(frozen=True)
+class StoreKey:
+    req_id: str
+    layer_idx: int
+    block_id: int
+    kv_kind: KVKind
+
+    @property
+    def layer_name(self) -> str:
+        return f"model.layers.{self.layer_idx}.self_attn"
+
+
+@dataclass
+class HostMemoryKVEntry:
+    data: torch.Tensor
+    dtype: str
+    shape: tuple[int, ...]
+    version: int = 1
+    source_req: str = ""
+
+    def matches_shape_and_dtype(self, expected_shape: tuple[int, ...], expected_dtype: str) -> bool:
+        return self.shape == expected_shape and self.dtype == expected_dtype
+
+
+@dataclass
+class SerializedHostMemoryKVEntry:
+    payload: bytes
+    dtype: str
+    shape: tuple[int, ...]
+    version: int = 1
+    source_req: str = ""
+
+    def matches_shape_and_dtype(self, expected_shape: tuple[int, ...], expected_dtype: str) -> bool:
+        return self.shape == expected_shape and self.dtype == expected_dtype
+
+
+@dataclass
+class SerializedUDSProcessKVEntry:
+    payload_size: int
+    dtype: str
+    shape: tuple[int, ...]
+    version: int = 1
+    source_req: str = ""
+
+    def matches_shape_and_dtype(self, expected_shape: tuple[int, ...], expected_dtype: str) -> bool:
+        return self.shape == expected_shape and self.dtype == expected_dtype
+
+
+@dataclass
+class SerializedSharedMemoryKVEntry:
+    shm_name: str
+    payload_size: int
+    dtype: str
+    shape: tuple[int, ...]
+    version: int = 1
+    source_req: str = ""
+
+    def matches_shape_and_dtype(self, expected_shape: tuple[int, ...], expected_dtype: str) -> bool:
+        return self.shape == expected_shape and self.dtype == expected_dtype
+
+
+def _unregister_shared_memory_attachment(entry_name: str, shm: shared_memory.SharedMemory) -> None:
+    # This process is only attaching to a segment owned elsewhere. Unregister
+    # the attachment so Python does not try to unlink it again at interpreter
+    # shutdown.
+    tracker_name = str(getattr(shm, "_name", entry_name))
+    with contextlib.suppress(Exception):
+        resource_tracker.unregister(tracker_name, "shared_memory")
+
+
+class SpyreKVStoreBackend(ABC):
+    @property
+    @abstractmethod
+    def backend_name(self) -> str: ...
+
+    @property
+    @abstractmethod
+    def size(self) -> int: ...
+
+    @property
+    @abstractmethod
+    def current_bytes(self) -> int: ...
+
+    @property
+    @abstractmethod
+    def max_bytes(self) -> int: ...
+
+    @property
+    @abstractmethod
+    def evictions(self) -> int: ...
+
+    @abstractmethod
+    def put(
+        self,
+        key: StoreKey,
+        data: torch.Tensor,
+        source_req: str = "",
+    ) -> tuple[int, bool]: ...
+
+    @abstractmethod
+    def get(self, key: StoreKey) -> HostMemoryKVEntry | None: ...
+
+    @abstractmethod
+    def load_into(self, key: StoreKey, dest: torch.Tensor) -> bool: ...
+
+    @abstractmethod
+    def contains(self, key: StoreKey) -> bool: ...
+
+    @abstractmethod
+    def available_prefix_blocks(self, req_id: str, block_ids: list[int]) -> int: ...
+
+    @abstractmethod
+    def remove_by_req(self, req_id: str) -> int: ...
+
+    @abstractmethod
+    def clear(self) -> None: ...
+
+    @abstractmethod
+    def shutdown(self) -> None: ...
+
+    @abstractmethod
+    def stats(self) -> dict[str, Any]: ...
+
+    def has_persistent_saved_requests(self) -> bool:
+        return False
+
+    def save_request_record(self, record: SavedRequestRecord) -> None:
+        raise NotImplementedError(
+            f"{self.__class__.__name__} does not support persistent saved requests"
+        )
+
+    def get_saved_requests(self) -> list[SavedRequestRecord]:
+        return []
+
+    def remove_saved_request(self, req_id: str) -> bool:
+        return False
+
+    def clear_saved_requests(self) -> None:
+        return
+
+    def saved_request_count(self) -> int:
+        return 0
+
+
+@dataclass
+class SpyreRemoteMeta:
+    """Remote connection metadata for KV transfer (similar to GPU NixlConnector)"""
+
+    block_ids: list[int]
+    host: str  # Remote prefill IP (dynamic from routing proxy or env var)
+    port: int  # Remote prefill port
+    engine_id: str  # Remote engine identifier
+    request_id: str  # Request ID on remote side
+
+
+@dataclass
+class SpyreConnectorRequestMeta:
+    req_id: str
+    block_ids: list[int] = field(default_factory=list)
+    is_store: bool = True
+    token_count: int = 0
+    source_req_id: str = ""
+    block_mapping: list[tuple[int, int]] = field(default_factory=list)
+    remote: SpyreRemoteMeta | None = None  # Remote connection info for decode-side loads
+
+
+@dataclass(frozen=True)
+class SavedRequestRecord:
+    req_id: str
+    prompt_token_ids: tuple[int, ...]
+    block_ids: list[int]
+    num_tokens: int
+
+
+@dataclass
+class SpyreConnectorMeta(KVConnectorMetadata):
+    schema_version: int = 1
+    requests: list[SpyreConnectorRequestMeta] = field(default_factory=list)
+    layer_names: list[str] = field(default_factory=list)
+    block_size: int = 0
+    dtype: str = ""
+    layout: str = "NHD"
+    num_layers: int = 0
+    num_kv_heads: int = 0
+    head_dim: int = 0
+
+    _SUPPORTED_VERSIONS: frozenset[int] = frozenset({1})
+    _KNOWN_LAYOUTS: frozenset[str] = frozenset({"NHD"})
+
+    def add_store_request(
+        self,
+        req_id: str,
+        block_ids: list[int],
+        token_count: int = 0,
+    ) -> None:
+        self.requests.append(
+            SpyreConnectorRequestMeta(
+                req_id=req_id,
+                block_ids=block_ids,
+                is_store=True,
+                token_count=token_count,
+            )
+        )
+
+    def add_load_request(
+        self,
+        req_id: str,
+        block_ids: list[int],
+        source_req_id: str,
+        token_count: int = 0,
+        block_mapping: list[tuple[int, int]] | None = None,
+        kv_transfer_params: dict[str, Any] | None = None,
+    ) -> None:
+        """Add a load request with optional remote connection parameters.
+
+        Args:
+            req_id: Local request ID
+            block_ids: Local block IDs to load into
+            source_req_id: Source request ID (for local cache lookup)
+            token_count: Number of tokens
+            block_mapping: Optional block mapping
+            kv_transfer_params: Optional dict with remote connection info:
+                - remote_host: Prefill IP (from routing proxy or env var)
+                - remote_port: Prefill port
+                - remote_engine_id: Remote engine ID
+                - remote_request_id: Request ID on remote side
+                - remote_block_ids: Block IDs on remote side
+        """
+        remote_meta = None
+        if kv_transfer_params:
+            # Extract remote connection parameters (similar to GPU NixlConnector)
+            remote_host = kv_transfer_params.get("remote_host")
+            remote_port = kv_transfer_params.get("remote_port")
+            remote_engine_id = kv_transfer_params.get("remote_engine_id")
+            remote_request_id = kv_transfer_params.get("remote_request_id")
+            remote_block_ids = kv_transfer_params.get("remote_block_ids", block_ids)
+
+            if remote_host and remote_port:
+                remote_meta = SpyreRemoteMeta(
+                    block_ids=remote_block_ids,
+                    host=remote_host,
+                    port=remote_port,
+                    engine_id=remote_engine_id or "",
+                    request_id=remote_request_id or source_req_id,
+                )
+
+        self.requests.append(
+            SpyreConnectorRequestMeta(
+                req_id=req_id,
+                block_ids=block_ids,
+                is_store=False,
+                token_count=token_count,
+                source_req_id=source_req_id,
+                block_mapping=block_mapping or [],
+                remote=remote_meta,
+            )
+        )
+
+    def validate_block_mapping(self) -> None:
+        all_dest_blocks: list[int] = []
+        for req in self.requests:
+            if not req.is_store and req.block_mapping:
+                for _, dest_block in req.block_mapping:
+                    all_dest_blocks.append(dest_block)
+            elif not req.is_store:
+                all_dest_blocks.extend(req.block_ids)
+
+        seen: set[int] = set()
+        for block_id in all_dest_blocks:
+            if block_id in seen:
+                raise ValueError(
+                    f"Duplicate destination block ID {block_id} in load requests. "
+                    "This would cause data corruption."
+                )
+            seen.add(block_id)
+
+    def validate(self) -> None:
+        if self.schema_version not in self._SUPPORTED_VERSIONS:
+            raise ValueError(
+                f"Unsupported schema_version {self.schema_version}. "
+                f"Supported: {sorted(self._SUPPORTED_VERSIONS)}"
+            )
+
+        if self.layout and self.layout not in self._KNOWN_LAYOUTS:
+            raise ValueError(f"Unknown layout '{self.layout}'")
+
+        for req in self.requests:
+            if not req.req_id:
+                raise ValueError("Request with empty req_id in metadata")
+            if not req.is_store and not req.source_req_id and req.block_mapping:
+                raise ValueError(
+                    f"Load request {req.req_id} has block_mapping but no source_req_id"
+                )
+            for bid in req.block_ids:
+                if bid < 0:
+                    raise ValueError(f"Request {req.req_id} has negative block_id {bid}")
+            for src, dest in req.block_mapping:
+                if src < 0 or dest < 0:
+                    raise ValueError(f"Request {req.req_id} block_mapping contains negative IDs")
+
+        if self.num_layers < 0 or self.num_kv_heads < 0 or self.head_dim < 0:
+            raise ValueError("Connector metadata dimensions must be non-negative")
+        if self.block_size < 0:
+            raise ValueError("block_size must be non-negative")
+
+        self.validate_block_mapping()
+
+    @staticmethod
+    def make_layer_names(num_layers: int) -> list[str]:
+        return [f"model.layers.{i}.self_attn" for i in range(num_layers)]
+
+
+class HostMemoryKVStoreBackend(SpyreKVStoreBackend):
+    def __init__(self, max_bytes: int = 0) -> None:
+        self._store: dict[StoreKey, HostMemoryKVEntry] = {}
+        self._request_keys: dict[str, set[StoreKey]] = {}
+        self._request_order: OrderedDict[str, None] = OrderedDict()
+        self._version_counter = 0
+        self._max_bytes = max(0, max_bytes)
+        self._current_bytes = 0
+        self._evictions = 0
+
+    @property
+    def backend_name(self) -> str:
+        return "host_memory"
+
+    @property
+    def size(self) -> int:
+        return len(self._store)
+
+    @property
+    def current_bytes(self) -> int:
+        return self._current_bytes
+
+    @property
+    def max_bytes(self) -> int:
+        return self._max_bytes
+
+    @property
+    def evictions(self) -> int:
+        return self._evictions
+
+    @staticmethod
+    def _entry_bytes(entry: HostMemoryKVEntry) -> int:
+        return entry.data.nelement() * entry.data.element_size()
+
+    @staticmethod
+    def _request_id_for(key: StoreKey, source_req: str) -> str:
+        return source_req or key.req_id
+
+    def _track_key(self, req_id: str, key: StoreKey) -> None:
+        keys = self._request_keys.setdefault(req_id, set())
+        keys.add(key)
+        self._request_order.pop(req_id, None)
+        self._request_order[req_id] = None
+
+    def put(
+        self,
+        key: StoreKey,
+        data: torch.Tensor,
+        source_req: str = "",
+    ) -> tuple[int, bool]:
+        req_id = self._request_id_for(key, source_req)
+        self._version_counter += 1
+        version = self._version_counter
+        was_overwrite = key in self._store
+
+        if was_overwrite:
+            old = self._store[key]
+            self._current_bytes -= self._entry_bytes(old)
+
+        entry = HostMemoryKVEntry(
+            data=data.detach().clone().cpu(),
+            dtype=str(data.dtype),
+            shape=tuple(data.shape),
+            version=version,
+            source_req=source_req,
+        )
+        entry_size = self._entry_bytes(entry)
+
+        if self._max_bytes > 0:
+            while self._store and self._current_bytes + entry_size > self._max_bytes:
+                if self._evict_oldest_request(exclude_req_id=req_id) is None:
+                    break
+
+        self._store[key] = entry
+        self._track_key(req_id, key)
+        self._current_bytes += entry_size
+        return version, was_overwrite
+
+    def _evict_oldest_request(self, exclude_req_id: str | None = None) -> str | None:
+        for req_id in list(self._request_order.keys()):
+            if req_id == exclude_req_id:
+                continue
+            if self.remove_by_req(req_id) > 0:
+                self._evictions += 1
+                return req_id
+        return None
+
+    def get(self, key: StoreKey) -> HostMemoryKVEntry | None:
+        return self._store.get(key)
+
+    def load_into(self, key: StoreKey, dest: torch.Tensor) -> bool:
+        entry = self.get(key)
+        if entry is None:
+            return False
+
+        try:
+            dest.copy_(entry.data)
+        except RuntimeError:
+            return False
+        return True
+
+    def contains(self, key: StoreKey) -> bool:
+        return key in self._store
+
+    def available_prefix_blocks(self, req_id: str, block_ids: list[int]) -> int:
+        req_keys = self._request_keys.get(req_id)
+        if not req_keys:
+            return 0
+
+        layer_ids = sorted({key.layer_idx for key in req_keys})
+        if not layer_ids:
+            return 0
+
+        available = 0
+        for block_id in block_ids:
+            block_complete = True
+            for layer_idx in layer_ids:
+                for kv_kind in (KVKind.K, KVKind.V):
+                    if StoreKey(req_id, layer_idx, block_id, kv_kind) not in self._store:
+                        block_complete = False
+                        break
+                if not block_complete:
+                    break
+            if not block_complete:
+                break
+            available += 1
+        return available
+
+    def remove_by_req(self, req_id: str) -> int:
+        keys = list(self._request_keys.pop(req_id, ()))
+        for key in keys:
+            entry = self._store.pop(key, None)
+            if entry is not None:
+                self._current_bytes -= self._entry_bytes(entry)
+        self._request_order.pop(req_id, None)
+        return len(keys)
+
+    def clear(self) -> None:
+        self._store.clear()
+        self._request_keys.clear()
+        self._request_order.clear()
+        self._version_counter = 0
+        self._current_bytes = 0
+        self._evictions = 0
+
+    def stats(self) -> dict[str, Any]:
+        return {
+            "backend_name": self.backend_name,
+            "total_entries": len(self._store),
+            "unique_requests": len(self._request_keys),
+            "version_counter": self._version_counter,
+            "memory_estimate_bytes": self._current_bytes,
+            "max_bytes": self._max_bytes,
+            "evictions": self._evictions,
+        }
+
+    def shutdown(self) -> None:
+        self.clear()
+
+
+class SerializedHostMemoryKVStoreBackend(SpyreKVStoreBackend):
+    def __init__(self, max_bytes: int = 0) -> None:
+        self._store: dict[StoreKey, SerializedHostMemoryKVEntry] = {}
+        self._request_keys: dict[str, set[StoreKey]] = {}
+        self._request_order: OrderedDict[str, None] = OrderedDict()
+        self._version_counter = 0
+        self._max_bytes = max(0, max_bytes)
+        self._current_bytes = 0
+        self._evictions = 0
+
+    @property
+    def backend_name(self) -> str:
+        return "serialized_host_memory"
+
+    @property
+    def size(self) -> int:
+        return len(self._store)
+
+    @property
+    def current_bytes(self) -> int:
+        return self._current_bytes
+
+    @property
+    def max_bytes(self) -> int:
+        return self._max_bytes
+
+    @property
+    def evictions(self) -> int:
+        return self._evictions
+
+    @staticmethod
+    def _entry_bytes(entry: SerializedHostMemoryKVEntry) -> int:
+        return len(entry.payload)
+
+    @staticmethod
+    def _serialize_tensor(data: torch.Tensor) -> bytes:
+        buffer = io.BytesIO()
+        torch.save(data.detach().clone().cpu(), buffer)
+        return buffer.getvalue()
+
+    @staticmethod
+    def _materialize_tensor(entry: SerializedHostMemoryKVEntry) -> torch.Tensor:
+        buffer = io.BytesIO(entry.payload)
+        return torch.load(buffer, map_location="cpu", weights_only=True)
+
+    @staticmethod
+    def _request_id_for(key: StoreKey, source_req: str) -> str:
+        return source_req or key.req_id
+
+    def _track_key(self, req_id: str, key: StoreKey) -> None:
+        keys = self._request_keys.setdefault(req_id, set())
+        keys.add(key)
+        self._request_order.pop(req_id, None)
+        self._request_order[req_id] = None
+
+    def put(
+        self,
+        key: StoreKey,
+        data: torch.Tensor,
+        source_req: str = "",
+    ) -> tuple[int, bool]:
+        req_id = self._request_id_for(key, source_req)
+        self._version_counter += 1
+        version = self._version_counter
+        was_overwrite = key in self._store
+
+        if was_overwrite:
+            old = self._store[key]
+            self._current_bytes -= self._entry_bytes(old)
+
+        entry = SerializedHostMemoryKVEntry(
+            payload=self._serialize_tensor(data),
+            dtype=str(data.dtype),
+            shape=tuple(data.shape),
+            version=version,
+            source_req=source_req,
+        )
+        entry_size = self._entry_bytes(entry)
+
+        if self._max_bytes > 0:
+            while self._store and self._current_bytes + entry_size > self._max_bytes:
+                if self._evict_oldest_request(exclude_req_id=req_id) is None:
+                    break
+
+        self._store[key] = entry
+        self._track_key(req_id, key)
+        self._current_bytes += entry_size
+        return version, was_overwrite
+
+    def _evict_oldest_request(self, exclude_req_id: str | None = None) -> str | None:
+        for req_id in list(self._request_order.keys()):
+            if req_id == exclude_req_id:
+                continue
+            if self.remove_by_req(req_id) > 0:
+                self._evictions += 1
+                return req_id
+        return None
+
+    def get(self, key: StoreKey) -> HostMemoryKVEntry | None:
+        entry = self._store.get(key)
+        if entry is None:
+            return None
+        return HostMemoryKVEntry(
+            data=self._materialize_tensor(entry),
+            dtype=entry.dtype,
+            shape=entry.shape,
+            version=entry.version,
+            source_req=entry.source_req,
+        )
+
+    def load_into(self, key: StoreKey, dest: torch.Tensor) -> bool:
+        entry = self._store.get(key)
+        if entry is None:
+            return False
+
+        try:
+            dest.copy_(self._materialize_tensor(entry))
+        except RuntimeError:
+            return False
+        return True
+
+    def contains(self, key: StoreKey) -> bool:
+        return key in self._store
+
+    def available_prefix_blocks(self, req_id: str, block_ids: list[int]) -> int:
+        req_keys = self._request_keys.get(req_id)
+        if not req_keys:
+            return 0
+
+        layer_ids = sorted({key.layer_idx for key in req_keys})
+        if not layer_ids:
+            return 0
+
+        available = 0
+        for block_id in block_ids:
+            block_complete = True
+            for layer_idx in layer_ids:
+                for kv_kind in (KVKind.K, KVKind.V):
+                    if StoreKey(req_id, layer_idx, block_id, kv_kind) not in self._store:
+                        block_complete = False
+                        break
+                if not block_complete:
+                    break
+            if not block_complete:
+                break
+            available += 1
+        return available
+
+    def remove_by_req(self, req_id: str) -> int:
+        keys = list(self._request_keys.pop(req_id, ()))
+        for key in keys:
+            entry = self._store.pop(key, None)
+            if entry is not None:
+                self._current_bytes -= self._entry_bytes(entry)
+        self._request_order.pop(req_id, None)
+        return len(keys)
+
+    def clear(self) -> None:
+        self._store.clear()
+        self._request_keys.clear()
+        self._request_order.clear()
+        self._version_counter = 0
+        self._current_bytes = 0
+        self._evictions = 0
+
+    def stats(self) -> dict[str, Any]:
+        return {
+            "backend_name": self.backend_name,
+            "total_entries": len(self._store),
+            "unique_requests": len(self._request_keys),
+            "version_counter": self._version_counter,
+            "memory_estimate_bytes": self._current_bytes,
+            "max_bytes": self._max_bytes,
+            "evictions": self._evictions,
+        }
+
+    def shutdown(self) -> None:
+        self.clear()
+
+
+class SerializedSharedMemoryKVStoreBackend(SpyreKVStoreBackend):
+    def __init__(self, max_bytes: int = 0) -> None:
+        self._store: dict[StoreKey, SerializedSharedMemoryKVEntry] = {}
+        self._request_keys: dict[str, set[StoreKey]] = {}
+        self._request_order: OrderedDict[str, None] = OrderedDict()
+        self._version_counter = 0
+        self._max_bytes = max(0, max_bytes)
+        self._current_bytes = 0
+        self._evictions = 0
+
+    @property
+    def backend_name(self) -> str:
+        return "serialized_shared_memory"
+
+    @property
+    def size(self) -> int:
+        return len(self._store)
+
+    @property
+    def current_bytes(self) -> int:
+        return self._current_bytes
+
+    @property
+    def max_bytes(self) -> int:
+        return self._max_bytes
+
+    @property
+    def evictions(self) -> int:
+        return self._evictions
+
+    @staticmethod
+    def _entry_bytes(entry: SerializedSharedMemoryKVEntry) -> int:
+        return entry.payload_size
+
+    @staticmethod
+    def _serialize_tensor(data: torch.Tensor) -> bytes:
+        buffer = io.BytesIO()
+        torch.save(data.detach().clone().cpu(), buffer)
+        return buffer.getvalue()
+
+    @staticmethod
+    def _materialize_tensor(payload: bytes) -> torch.Tensor:
+        buffer = io.BytesIO(payload)
+        return torch.load(buffer, map_location="cpu", weights_only=True)
+
+    @staticmethod
+    def _request_id_for(key: StoreKey, source_req: str) -> str:
+        return source_req or key.req_id
+
+    def _track_key(self, req_id: str, key: StoreKey) -> None:
+        keys = self._request_keys.setdefault(req_id, set())
+        keys.add(key)
+        self._request_order.pop(req_id, None)
+        self._request_order[req_id] = None
+
+    @staticmethod
+    def _write_payload(payload: bytes) -> str:
+        shm = shared_memory.SharedMemory(create=True, size=max(len(payload), 1))
+        try:
+            shm.buf[: len(payload)] = payload
+            return shm.name
+        finally:
+            shm.close()
+
+    @staticmethod
+    def _read_payload(entry: SerializedSharedMemoryKVEntry) -> bytes | None:
+        try:
+            shm = shared_memory.SharedMemory(name=entry.shm_name, create=False)
+        except FileNotFoundError:
+            return None
+
+        with contextlib.suppress(Exception):
+            _unregister_shared_memory_attachment(entry.shm_name, shm)
+
+        try:
+            return bytes(shm.buf[: entry.payload_size])
+        finally:
+            shm.close()
+
+    @staticmethod
+    def _unlink_entry(entry: SerializedSharedMemoryKVEntry) -> None:
+        try:
+            shm = shared_memory.SharedMemory(name=entry.shm_name, create=False)
+        except FileNotFoundError:
+            return
+
+        try:
+            shm.close()
+            shm.unlink()
+        except FileNotFoundError:
+            pass
+
+    def put(
+        self,
+        key: StoreKey,
+        data: torch.Tensor,
+        source_req: str = "",
+    ) -> tuple[int, bool]:
+        req_id = self._request_id_for(key, source_req)
+        self._version_counter += 1
+        version = self._version_counter
+        was_overwrite = key in self._store
+
+        if was_overwrite:
+            old = self._store[key]
+            self._current_bytes -= self._entry_bytes(old)
+            self._unlink_entry(old)
+
+        payload = self._serialize_tensor(data)
+        entry_size = len(payload)
+
+        if self._max_bytes > 0:
+            while self._store and self._current_bytes + entry_size > self._max_bytes:
+                if self._evict_oldest_request(exclude_req_id=req_id) is None:
+                    break
+
+        shm_name = self._write_payload(payload)
+        entry = SerializedSharedMemoryKVEntry(
+            shm_name=shm_name,
+            payload_size=entry_size,
+            dtype=str(data.dtype),
+            shape=tuple(data.shape),
+            version=version,
+            source_req=source_req,
+        )
+
+        self._store[key] = entry
+        self._track_key(req_id, key)
+        self._current_bytes += entry_size
+        return version, was_overwrite
+
+    def _evict_oldest_request(self, exclude_req_id: str | None = None) -> str | None:
+        for req_id in list(self._request_order.keys()):
+            if req_id == exclude_req_id:
+                continue
+            if self.remove_by_req(req_id) > 0:
+                self._evictions += 1
+                return req_id
+        return None
+
+    def get(self, key: StoreKey) -> HostMemoryKVEntry | None:
+        entry = self._store.get(key)
+        if entry is None:
+            return None
+
+        payload = self._read_payload(entry)
+        if payload is None:
+            return None
+
+        return HostMemoryKVEntry(
+            data=self._materialize_tensor(payload),
+            dtype=entry.dtype,
+            shape=entry.shape,
+            version=entry.version,
+            source_req=entry.source_req,
+        )
+
+    def load_into(self, key: StoreKey, dest: torch.Tensor) -> bool:
+        entry = self._store.get(key)
+        if entry is None:
+            return False
+
+        payload = self._read_payload(entry)
+        if payload is None:
+            return False
+
+        try:
+            dest.copy_(self._materialize_tensor(payload))
+        except RuntimeError:
+            return False
+        return True
+
+    def contains(self, key: StoreKey) -> bool:
+        return key in self._store
+
+    def available_prefix_blocks(self, req_id: str, block_ids: list[int]) -> int:
+        req_keys = self._request_keys.get(req_id)
+        if not req_keys:
+            return 0
+
+        layer_ids = sorted({key.layer_idx for key in req_keys})
+        if not layer_ids:
+            return 0
+
+        available = 0
+        for block_id in block_ids:
+            block_complete = True
+            for layer_idx in layer_ids:
+                for kv_kind in (KVKind.K, KVKind.V):
+                    if StoreKey(req_id, layer_idx, block_id, kv_kind) not in self._store:
+                        block_complete = False
+                        break
+                if not block_complete:
+                    break
+            if not block_complete:
+                break
+            available += 1
+        return available
+
+    def remove_by_req(self, req_id: str) -> int:
+        keys = list(self._request_keys.pop(req_id, ()))
+        for key in keys:
+            entry = self._store.pop(key, None)
+            if entry is not None:
+                self._current_bytes -= self._entry_bytes(entry)
+                self._unlink_entry(entry)
+        self._request_order.pop(req_id, None)
+        return len(keys)
+
+    def clear(self) -> None:
+        for entry in list(self._store.values()):
+            self._unlink_entry(entry)
+        self._store.clear()
+        self._request_keys.clear()
+        self._request_order.clear()
+        self._version_counter = 0
+        self._current_bytes = 0
+        self._evictions = 0
+
+    def shutdown(self) -> None:
+        self.clear()
+
+    def stats(self) -> dict[str, Any]:
+        return {
+            "backend_name": self.backend_name,
+            "total_entries": len(self._store),
+            "unique_requests": len(self._request_keys),
+            "version_counter": self._version_counter,
+            "memory_estimate_bytes": self._current_bytes,
+            "max_bytes": self._max_bytes,
+            "evictions": self._evictions,
+        }
+
+
+class SerializedSharedMemoryServiceKVStoreBackend(SpyreKVStoreBackend):
+    def __init__(
+        self,
+        max_bytes: int = 0,
+        *,
+        socket_path: str = "/tmp/spyre-kv-persistent.sock",
+        max_saved_requests: int = 1024,
+    ) -> None:
+        self._socket_path = socket_path
+        self._client = PersistentKVServiceClient(socket_path)
+        self._client.configure(
+            max_bytes=max(0, max_bytes),
+            max_saved_requests=max(0, max_saved_requests),
+        )
+
+    @property
+    def backend_name(self) -> str:
+        return "serialized_shared_memory_service"
+
+    def has_persistent_saved_requests(self) -> bool:
+        return True
+
+    @property
+    def size(self) -> int:
+        return int(self.stats().get("total_entries", 0))
+
+    @property
+    def current_bytes(self) -> int:
+        return int(self.stats().get("memory_estimate_bytes", 0))
+
+    @property
+    def max_bytes(self) -> int:
+        return int(self.stats().get("max_bytes", 0))
+
+    @property
+    def evictions(self) -> int:
+        return int(self.stats().get("evictions", 0))
+
+    @staticmethod
+    def _serialize_tensor(data: torch.Tensor) -> bytes:
+        buffer = io.BytesIO()
+        torch.save(data.detach().clone().cpu(), buffer)
+        return buffer.getvalue()
+
+    @staticmethod
+    def _materialize_tensor(payload: bytes) -> torch.Tensor:
+        buffer = io.BytesIO(payload)
+        return torch.load(buffer, map_location="cpu", weights_only=True)
+
+    @staticmethod
+    def _normalize_entry(entry: dict[str, Any]) -> SerializedSharedMemoryKVEntry:
+        return SerializedSharedMemoryKVEntry(
+            shm_name=str(entry["shm_name"]),
+            payload_size=int(entry["payload_size"]),
+            dtype=str(entry["dtype"]),
+            shape=tuple(entry["shape"]),
+            version=int(entry.get("version", 1)),
+            source_req=str(entry.get("source_req", "")),
+        )
+
+    @staticmethod
+    def _read_payload(entry: SerializedSharedMemoryKVEntry) -> bytes | None:
+        try:
+            shm = shared_memory.SharedMemory(name=entry.shm_name, create=False)
+        except FileNotFoundError:
+            return None
+
+        with contextlib.suppress(Exception):
+            _unregister_shared_memory_attachment(entry.shm_name, shm)
+
+        try:
+            return bytes(shm.buf[: entry.payload_size])
+        finally:
+            shm.close()
+
+    @staticmethod
+    def _normalize_saved_request(record: Any) -> SavedRequestRecord:
+        if isinstance(record, SavedRequestRecord):
+            return record
+        if isinstance(record, dict):
+            return SavedRequestRecord(
+                req_id=str(record["req_id"]),
+                prompt_token_ids=tuple(record["prompt_token_ids"]),
+                block_ids=list(record["block_ids"]),
+                num_tokens=int(record["num_tokens"]),
+            )
+        raise TypeError(f"Unsupported saved request record type: {type(record)!r}")
+
+    def put(
+        self,
+        key: StoreKey,
+        data: torch.Tensor,
+        source_req: str = "",
+    ) -> tuple[int, bool]:
+        payload = self._serialize_tensor(data)
+        return self._client.put(
+            key,
+            payload,
+            str(data.dtype),
+            tuple(data.shape),
+            source_req=source_req,
+        )
+
+    def get(self, key: StoreKey) -> HostMemoryKVEntry | None:
+        entry_dict = self._client.get_entry(key)
+        if entry_dict is None:
+            return None
+
+        entry = self._normalize_entry(entry_dict)
+        payload = self._read_payload(entry)
+        if payload is None:
+            return None
+
+        return HostMemoryKVEntry(
+            data=self._materialize_tensor(payload),
+            dtype=entry.dtype,
+            shape=entry.shape,
+            version=entry.version,
+            source_req=entry.source_req,
+        )
+
+    def load_into(self, key: StoreKey, dest: torch.Tensor) -> bool:
+        entry_dict = self._client.get_entry(key)
+        if entry_dict is None:
+            return False
+
+        entry = self._normalize_entry(entry_dict)
+        payload = self._read_payload(entry)
+        if payload is None:
+            return False
+
+        try:
+            dest.copy_(self._materialize_tensor(payload))
+        except RuntimeError:
+            return False
+        return True
+
+    def contains(self, key: StoreKey) -> bool:
+        return self._client.contains(key)
+
+    def available_prefix_blocks(self, req_id: str, block_ids: list[int]) -> int:
+        return self._client.available_prefix_blocks(req_id, block_ids)
+
+    def remove_by_req(self, req_id: str) -> int:
+        return self._client.remove_by_req(req_id)
+
+    def clear(self) -> None:
+        self._client.clear()
+
+    def shutdown(self) -> None:
+        self._client.close()
+
+    def stats(self) -> dict[str, Any]:
+        return self._client.stats()
+
+    def save_request_record(self, record: SavedRequestRecord) -> None:
+        self._client.save_request_record(record)
+
+    def get_saved_requests(self) -> list[SavedRequestRecord]:
+        return [
+            self._normalize_saved_request(record) for record in self._client.get_saved_requests()
+        ]
+
+    def remove_saved_request(self, req_id: str) -> bool:
+        return self._client.remove_saved_request(req_id)
+
+    def clear_saved_requests(self) -> None:
+        self._client.clear_saved_requests()
+
+    def saved_request_count(self) -> int:
+        return int(self.stats().get("saved_requests_count", 0))
+
+
+class SerializedUDSProcessKVStoreBackend(SpyreKVStoreBackend):
+    def __init__(self, max_bytes: int = 0) -> None:
+        self._store: dict[StoreKey, SerializedUDSProcessKVEntry] = {}
+        self._request_keys: dict[str, set[StoreKey]] = {}
+        self._request_order: OrderedDict[str, None] = OrderedDict()
+        self._transport = UDSProcessKVTransport()
+        self._version_counter = 0
+        self._max_bytes = max(0, max_bytes)
+        self._current_bytes = 0
+        self._evictions = 0
+
+    @property
+    def backend_name(self) -> str:
+        return "serialized_uds_process_store"
+
+    @property
+    def size(self) -> int:
+        return len(self._store)
+
+    @property
+    def current_bytes(self) -> int:
+        return self._current_bytes
+
+    @property
+    def max_bytes(self) -> int:
+        return self._max_bytes
+
+    @property
+    def evictions(self) -> int:
+        return self._evictions
+
+    @staticmethod
+    def _entry_bytes(entry: SerializedUDSProcessKVEntry) -> int:
+        return entry.payload_size
+
+    @staticmethod
+    def _serialize_tensor(data: torch.Tensor) -> bytes:
+        buffer = io.BytesIO()
+        torch.save(data.detach().clone().cpu(), buffer)
+        return buffer.getvalue()
+
+    @staticmethod
+    def _materialize_tensor(payload: bytes) -> torch.Tensor:
+        buffer = io.BytesIO(payload)
+        return torch.load(buffer, map_location="cpu", weights_only=True)
+
+    @staticmethod
+    def _request_id_for(key: StoreKey, source_req: str) -> str:
+        return source_req or key.req_id
+
+    def _track_key(self, req_id: str, key: StoreKey) -> None:
+        keys = self._request_keys.setdefault(req_id, set())
+        keys.add(key)
+        self._request_order.pop(req_id, None)
+        self._request_order[req_id] = None
+
+    def put(
+        self,
+        key: StoreKey,
+        data: torch.Tensor,
+        source_req: str = "",
+    ) -> tuple[int, bool]:
+        req_id = self._request_id_for(key, source_req)
+        self._version_counter += 1
+        version = self._version_counter
+        was_overwrite = key in self._store
+
+        if was_overwrite:
+            old = self._store[key]
+            self._current_bytes -= self._entry_bytes(old)
+
+        payload = self._serialize_tensor(data)
+        entry = SerializedUDSProcessKVEntry(
+            payload_size=len(payload),
+            dtype=str(data.dtype),
+            shape=tuple(data.shape),
+            version=version,
+            source_req=source_req,
+        )
+        entry_size = self._entry_bytes(entry)
+
+        if self._max_bytes > 0:
+            while self._store and self._current_bytes + entry_size > self._max_bytes:
+                if self._evict_oldest_request(exclude_req_id=req_id) is None:
+                    break
+
+        self._transport.put(key, payload)
+        self._store[key] = entry
+        self._track_key(req_id, key)
+        self._current_bytes += entry_size
+        return version, was_overwrite
+
+    def _evict_oldest_request(self, exclude_req_id: str | None = None) -> str | None:
+        for req_id in list(self._request_order.keys()):
+            if req_id == exclude_req_id:
+                continue
+            if self.remove_by_req(req_id) > 0:
+                self._evictions += 1
+                return req_id
+        return None
+
+    def get(self, key: StoreKey) -> HostMemoryKVEntry | None:
+        entry = self._store.get(key)
+        if entry is None:
+            return None
+        payload = self._transport.get(key)
+        if payload is None:
+            return None
+        return HostMemoryKVEntry(
+            data=self._materialize_tensor(payload),
+            dtype=entry.dtype,
+            shape=entry.shape,
+            version=entry.version,
+            source_req=entry.source_req,
+        )
+
+    def load_into(self, key: StoreKey, dest: torch.Tensor) -> bool:
+        entry = self._store.get(key)
+        if entry is None:
+            return False
+
+        payload = self._transport.get(key)
+        if payload is None:
+            return False
+
+        try:
+            dest.copy_(self._materialize_tensor(payload))
+        except RuntimeError:
+            return False
+        return True
+
+    def contains(self, key: StoreKey) -> bool:
+        return key in self._store
+
+    def available_prefix_blocks(self, req_id: str, block_ids: list[int]) -> int:
+        req_keys = self._request_keys.get(req_id)
+        if not req_keys:
+            return 0
+
+        layer_ids = sorted({key.layer_idx for key in req_keys})
+        if not layer_ids:
+            return 0
+
+        available = 0
+        for block_id in block_ids:
+            block_complete = True
+            for layer_idx in layer_ids:
+                for kv_kind in (KVKind.K, KVKind.V):
+                    if StoreKey(req_id, layer_idx, block_id, kv_kind) not in self._store:
+                        block_complete = False
+                        break
+                if not block_complete:
+                    break
+            if not block_complete:
+                break
+            available += 1
+        return available
+
+    def remove_by_req(self, req_id: str) -> int:
+        keys = list(self._request_keys.pop(req_id, ()))
+        removed = 0
+        if keys:
+            removed = self._transport.delete_keys(keys)
+        for key in keys:
+            entry = self._store.pop(key, None)
+            if entry is not None:
+                self._current_bytes -= self._entry_bytes(entry)
+        self._request_order.pop(req_id, None)
+        return removed
+
+    def clear(self) -> None:
+        self._store.clear()
+        self._request_keys.clear()
+        self._request_order.clear()
+        self._version_counter = 0
+        self._current_bytes = 0
+        self._evictions = 0
+        self._transport.clear()
+
+    def shutdown(self) -> None:
+        self._store.clear()
+        self._request_keys.clear()
+        self._request_order.clear()
+        self._version_counter = 0
+        self._current_bytes = 0
+        self._evictions = 0
+        self._transport.shutdown()
+
+    def stats(self) -> dict[str, Any]:
+        return {
+            "backend_name": self.backend_name,
+            "total_entries": len(self._store),
+            "unique_requests": len(self._request_keys),
+            "version_counter": self._version_counter,
+            "memory_estimate_bytes": self._current_bytes,
+            "max_bytes": self._max_bytes,
+            "evictions": self._evictions,
+        }
+
+
+_STORE_BACKEND_TYPES: dict[str, type[SpyreKVStoreBackend]] = {
+    "host_memory": HostMemoryKVStoreBackend,
+    # Compatibility alias: VLLM_SPYRE_KV_STORE_BACKEND defaults to "heap"
+    # in envs.py and prior runbooks/scripts use that name. Map it to the
+    # host-memory backend, matching the InMemoryKVStore = HostMemoryKVStoreBackend
+    # alias maintained below.
+    "heap": HostMemoryKVStoreBackend,
+    "serialized_host_memory": SerializedHostMemoryKVStoreBackend,
+    "serialized_shared_memory": SerializedSharedMemoryKVStoreBackend,
+    "serialized_shared_memory_service": SerializedSharedMemoryServiceKVStoreBackend,
+    "serialized_uds_process_store": SerializedUDSProcessKVStoreBackend,
+}
+
+
+def build_spyre_kv_store_backend(
+    backend_name: str,
+    *,
+    max_bytes: int = 0,
+    max_saved_requests: int = 1024,
+    service_socket: str | None = None,
+) -> SpyreKVStoreBackend:
+    backend_key = backend_name.strip().lower()
+    backend_type = _STORE_BACKEND_TYPES.get(backend_key)
+    if backend_type is None:
+        supported = ", ".join(sorted(_STORE_BACKEND_TYPES))
+        raise ValueError(
+            f"Unknown Spyre KV store backend '{backend_name}'. Supported backends: {supported}"
+        )
+    if backend_key == "serialized_shared_memory_service":
+        return backend_type(
+            max_bytes=max_bytes,
+            socket_path=service_socket or "/tmp/spyre-kv-persistent.sock",
+            max_saved_requests=max_saved_requests,
+        )
+    return backend_type(max_bytes=max_bytes)
+
+
+# Backward-compatible aliases for the current slice, tests, and examples.
+InMemoryKVEntry = HostMemoryKVEntry
+InMemoryKVStore = HostMemoryKVStoreBackend
+
+
+_STATS_KEYS = (
+    "matched_tokens",
+    "loaded_blocks",
+    "saved_blocks",
+    "load_misses",
+    "evictions",
+    "match_attempts",
+)
+
+
+@dataclass
+class SpyreConnectorStats(KVConnectorStats):
+    def __post_init__(self):
+        if not self.data:
+            self.reset()
+
+    def reset(self):
+        self.data = {key: 0 for key in _STATS_KEYS}
+
+    def record(self, key: str, value: int = 1) -> None:
+        self.data[key] = self.data.get(key, 0) + value
+
+    def aggregate(self, other: KVConnectorStats) -> SpyreConnectorStats:
+        for key in _STATS_KEYS:
+            self.data[key] = self.data.get(key, 0) + other.data.get(key, 0)
+        return self
+
+    def reduce(self) -> dict[str, int | float]:
+        return {key: self.data.get(key, 0) for key in _STATS_KEYS}
+
+    def is_empty(self) -> bool:
+        return all(self.data.get(key, 0) == 0 for key in _STATS_KEYS)

--- a/spyre_inference/distributed/kv_transfer/kv_connector/v1/persistent_kv_service.py
+++ b/spyre_inference/distributed/kv_transfer/kv_connector/v1/persistent_kv_service.py
@@ -1,0 +1,436 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from collections import OrderedDict
+import os
+from multiprocessing import shared_memory
+from multiprocessing.connection import Client, Listener
+import time
+from typing import Any
+
+
+def _unlink_socket(socket_path: str) -> None:
+    if os.path.exists(socket_path):
+        os.unlink(socket_path)
+
+
+class _SharedMemoryKVServiceState:
+    def __init__(self) -> None:
+        self._entries: dict[Any, dict[str, Any]] = {}
+        self._request_keys: dict[str, set[Any]] = {}
+        self._request_order: OrderedDict[str, None] = OrderedDict()
+        self._saved_requests: OrderedDict[str, Any] = OrderedDict()
+        self._version_counter = 0
+        self._max_bytes = 0
+        self._max_saved_requests = 1024
+        self._current_bytes = 0
+        self._evictions = 0
+
+    def configure(
+        self, max_bytes: int | None = None, max_saved_requests: int | None = None
+    ) -> None:
+        if max_bytes is not None:
+            self._max_bytes = max(0, int(max_bytes))
+        if max_saved_requests is not None:
+            self._max_saved_requests = max(0, int(max_saved_requests))
+
+    def _entry_bytes(self, entry: dict[str, Any]) -> int:
+        return int(entry["payload_size"])
+
+    def _request_id_for(self, key: Any, source_req: str) -> str:
+        return source_req or key.req_id
+
+    def _track_key(self, req_id: str, key: Any) -> None:
+        keys = self._request_keys.setdefault(req_id, set())
+        keys.add(key)
+        self._request_order.pop(req_id, None)
+        self._request_order[req_id] = None
+
+    def _write_payload(self, payload: bytes) -> str:
+        shm = shared_memory.SharedMemory(create=True, size=max(len(payload), 1))
+        try:
+            shm.buf[: len(payload)] = payload
+            return shm.name
+        finally:
+            shm.close()
+
+    def _unlink_entry(self, entry: dict[str, Any]) -> None:
+        shm_name = entry["shm_name"]
+        try:
+            shm = shared_memory.SharedMemory(name=shm_name, create=False)
+        except FileNotFoundError:
+            return
+
+        try:
+            shm.close()
+            shm.unlink()
+        except FileNotFoundError:
+            pass
+
+    def _evict_oldest_request(self, exclude_req_id: str | None = None) -> str | None:
+        for req_id in list(self._request_order.keys()):
+            if req_id == exclude_req_id:
+                continue
+            if self.remove_by_req(req_id) > 0:
+                self._evictions += 1
+                return req_id
+        return None
+
+    def put(
+        self,
+        key: Any,
+        payload: bytes,
+        dtype: str,
+        shape: tuple[int, ...],
+        source_req: str = "",
+    ) -> tuple[int, bool]:
+        req_id = self._request_id_for(key, source_req)
+        self._version_counter += 1
+        version = self._version_counter
+        was_overwrite = key in self._entries
+
+        if was_overwrite:
+            old = self._entries[key]
+            self._current_bytes -= self._entry_bytes(old)
+            self._unlink_entry(old)
+
+        entry_size = len(payload)
+        if self._max_bytes > 0:
+            while self._entries and self._current_bytes + entry_size > self._max_bytes:
+                if self._evict_oldest_request(exclude_req_id=req_id) is None:
+                    break
+
+        shm_name = self._write_payload(payload)
+        entry = {
+            "shm_name": shm_name,
+            "payload_size": entry_size,
+            "dtype": dtype,
+            "shape": tuple(shape),
+            "version": version,
+            "source_req": source_req,
+        }
+        self._entries[key] = entry
+        self._track_key(req_id, key)
+        self._current_bytes += entry_size
+        return version, was_overwrite
+
+    def get_entry(self, key: Any) -> dict[str, Any] | None:
+        entry = self._entries.get(key)
+        if entry is None:
+            return None
+        return dict(entry)
+
+    def contains(self, key: Any) -> bool:
+        return key in self._entries
+
+    def available_prefix_blocks(self, req_id: str, block_ids: list[int]) -> int:
+        req_keys = self._request_keys.get(req_id)
+        if not req_keys:
+            return 0
+
+        layer_ids = sorted({key.layer_idx for key in req_keys})
+        if not layer_ids:
+            return 0
+
+        present = {
+            (
+                key.layer_idx,
+                key.block_id,
+                getattr(key.kv_kind, "value", key.kv_kind),
+            )
+            for key in req_keys
+        }
+
+        available = 0
+        for block_id in block_ids:
+            block_complete = True
+            for layer_idx in layer_ids:
+                for kv_kind in ("K", "V"):
+                    if (layer_idx, block_id, kv_kind) not in present:
+                        block_complete = False
+                        break
+                if not block_complete:
+                    break
+            if not block_complete:
+                break
+            available += 1
+        return available
+
+    def save_request_record(self, record: Any) -> None:
+        req_id = record.req_id
+        if req_id in self._saved_requests:
+            self._saved_requests.move_to_end(req_id)
+        self._saved_requests[req_id] = record
+
+        if self._max_saved_requests > 0:
+            while len(self._saved_requests) > self._max_saved_requests:
+                oldest_req_id, _ = self._saved_requests.popitem(last=False)
+                self.remove_by_req(oldest_req_id)
+
+    def get_saved_requests(self) -> list[Any]:
+        return list(self._saved_requests.values())
+
+    def remove_saved_request(self, req_id: str) -> bool:
+        return self._saved_requests.pop(req_id, None) is not None
+
+    def clear_saved_requests(self) -> None:
+        self._saved_requests.clear()
+
+    def remove_by_req(self, req_id: str) -> int:
+        keys = list(self._request_keys.pop(req_id, ()))
+        for key in keys:
+            entry = self._entries.pop(key, None)
+            if entry is not None:
+                self._current_bytes -= self._entry_bytes(entry)
+                self._unlink_entry(entry)
+        self._request_order.pop(req_id, None)
+        self._saved_requests.pop(req_id, None)
+        return len(keys)
+
+    def clear(self) -> None:
+        for entry in list(self._entries.values()):
+            self._unlink_entry(entry)
+        self._entries.clear()
+        self._request_keys.clear()
+        self._request_order.clear()
+        self._saved_requests.clear()
+        self._version_counter = 0
+        self._current_bytes = 0
+        self._evictions = 0
+
+    def stats(self) -> dict[str, Any]:
+        return {
+            "backend_name": "serialized_shared_memory_service",
+            "total_entries": len(self._entries),
+            "unique_requests": len(self._request_keys),
+            "saved_requests_count": len(self._saved_requests),
+            "version_counter": self._version_counter,
+            "memory_estimate_bytes": self._current_bytes,
+            "max_bytes": self._max_bytes,
+            "evictions": self._evictions,
+        }
+
+
+def run_persistent_kv_service(socket_path: str) -> None:
+    socket_dir = os.path.dirname(socket_path)
+    if socket_dir:
+        os.makedirs(socket_dir, exist_ok=True)
+    _unlink_socket(socket_path)
+
+    state = _SharedMemoryKVServiceState()
+    listener = Listener(address=socket_path, family="AF_UNIX")
+    try:
+        while True:
+            conn = listener.accept()
+            try:
+                while True:
+                    try:
+                        message = conn.recv()
+                    except EOFError:
+                        break
+
+                    op = message["op"]
+                    if op == "ping":
+                        conn.send({"ok": True})
+                    elif op == "configure":
+                        state.configure(
+                            max_bytes=message.get("max_bytes"),
+                            max_saved_requests=message.get("max_saved_requests"),
+                        )
+                        conn.send({"ok": True})
+                    elif op == "put":
+                        version, was_overwrite = state.put(
+                            message["key"],
+                            message["payload"],
+                            message["dtype"],
+                            tuple(message["shape"]),
+                            source_req=message.get("source_req", ""),
+                        )
+                        conn.send(
+                            {
+                                "ok": True,
+                                "version": version,
+                                "was_overwrite": was_overwrite,
+                            }
+                        )
+                    elif op == "get_entry":
+                        conn.send({"ok": True, "entry": state.get_entry(message["key"])})
+                    elif op == "contains":
+                        conn.send({"ok": True, "contains": state.contains(message["key"])})
+                    elif op == "available_prefix_blocks":
+                        conn.send(
+                            {
+                                "ok": True,
+                                "available": state.available_prefix_blocks(
+                                    message["req_id"],
+                                    list(message["block_ids"]),
+                                ),
+                            }
+                        )
+                    elif op == "save_request_record":
+                        state.save_request_record(message["record"])
+                        conn.send({"ok": True})
+                    elif op == "get_saved_requests":
+                        conn.send({"ok": True, "records": state.get_saved_requests()})
+                    elif op == "remove_saved_request":
+                        conn.send(
+                            {
+                                "ok": True,
+                                "removed": state.remove_saved_request(message["req_id"]),
+                            }
+                        )
+                    elif op == "clear_saved_requests":
+                        state.clear_saved_requests()
+                        conn.send({"ok": True})
+                    elif op == "remove_by_req":
+                        conn.send(
+                            {
+                                "ok": True,
+                                "removed": state.remove_by_req(message["req_id"]),
+                            }
+                        )
+                    elif op == "clear":
+                        state.clear()
+                        conn.send({"ok": True})
+                    elif op == "stats":
+                        conn.send({"ok": True, "stats": state.stats()})
+                    elif op == "shutdown_service":
+                        state.clear()
+                        conn.send({"ok": True})
+                        return
+                    else:
+                        conn.send({"ok": False, "error": f"Unknown op: {op}"})
+            finally:
+                conn.close()
+    finally:
+        listener.close()
+        _unlink_socket(socket_path)
+
+
+class PersistentKVServiceClient:
+    def __init__(self, socket_path: str, *, connect_timeout_s: float = 30.0) -> None:
+        self._socket_path = socket_path
+        self._connect_timeout_s = connect_timeout_s
+
+    def _connect(self):
+        deadline = time.time() + self._connect_timeout_s
+        while True:
+            try:
+                conn = Client(address=self._socket_path, family="AF_UNIX")
+                conn.send({"op": "ping"})
+                response = conn.recv()
+                if response.get("ok"):
+                    return conn
+                conn.close()
+            except FileNotFoundError:
+                pass
+            except ConnectionRefusedError:
+                pass
+            except OSError:
+                pass
+            if time.time() >= deadline:
+                raise RuntimeError(
+                    f"Timed out connecting to persistent KV service at {self._socket_path}"
+                )
+            time.sleep(0.05)
+
+    def _request(self, message: dict[str, Any]) -> dict[str, Any]:
+        conn = self._connect()
+        try:
+            conn.send(message)
+            response = conn.recv()
+        finally:
+            conn.close()
+        if not response.get("ok", False):
+            raise RuntimeError(response.get("error", "Unknown persistent KV service error"))
+        return response
+
+    def configure(
+        self, *, max_bytes: int | None = None, max_saved_requests: int | None = None
+    ) -> None:
+        self._request(
+            {
+                "op": "configure",
+                "max_bytes": max_bytes,
+                "max_saved_requests": max_saved_requests,
+            }
+        )
+
+    def put(
+        self,
+        key: Any,
+        payload: bytes,
+        dtype: str,
+        shape: tuple[int, ...],
+        *,
+        source_req: str = "",
+    ) -> tuple[int, bool]:
+        response = self._request(
+            {
+                "op": "put",
+                "key": key,
+                "payload": payload,
+                "dtype": dtype,
+                "shape": tuple(shape),
+                "source_req": source_req,
+            }
+        )
+        return int(response["version"]), bool(response["was_overwrite"])
+
+    def get_entry(self, key: Any) -> dict[str, Any] | None:
+        response = self._request({"op": "get_entry", "key": key})
+        return response.get("entry")
+
+    def contains(self, key: Any) -> bool:
+        response = self._request({"op": "contains", "key": key})
+        return bool(response.get("contains", False))
+
+    def available_prefix_blocks(self, req_id: str, block_ids: list[int]) -> int:
+        response = self._request(
+            {"op": "available_prefix_blocks", "req_id": req_id, "block_ids": block_ids}
+        )
+        return int(response.get("available", 0))
+
+    def save_request_record(self, record: Any) -> None:
+        self._request({"op": "save_request_record", "record": record})
+
+    def get_saved_requests(self) -> list[Any]:
+        response = self._request({"op": "get_saved_requests"})
+        return list(response.get("records", []))
+
+    def remove_saved_request(self, req_id: str) -> bool:
+        response = self._request({"op": "remove_saved_request", "req_id": req_id})
+        return bool(response.get("removed", False))
+
+    def clear_saved_requests(self) -> None:
+        self._request({"op": "clear_saved_requests"})
+
+    def remove_by_req(self, req_id: str) -> int:
+        response = self._request({"op": "remove_by_req", "req_id": req_id})
+        return int(response.get("removed", 0))
+
+    def clear(self) -> None:
+        self._request({"op": "clear"})
+
+    def stats(self) -> dict[str, Any]:
+        response = self._request({"op": "stats"})
+        return dict(response.get("stats", {}))
+
+    def shutdown_service(self) -> None:
+        self._request({"op": "shutdown_service"})
+
+    def close(self) -> None:
+        return

--- a/spyre_inference/distributed/kv_transfer/kv_connector/v1/spyre_paged_kv_accessor.py
+++ b/spyre_inference/distributed/kv_transfer/kv_connector/v1/spyre_paged_kv_accessor.py
@@ -1,0 +1,243 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Accessor for the Spyre list-of-pages KV cache used by the KV connector.
+
+The Spyre attention backend allocates each layer's KV cache as
+``SpyrePagedKVCache(k_pages, v_pages)`` — a NamedTuple of two equal-length
+lists of per-page tensors of shape ``[num_kv_heads, block_size, head_size]``
+(see ``spyre_inference/v1/attention/backends/spyre_attn.py``). vLLM's
+``bind_kv_cache`` relays those objects through a dict typed
+``dict[str, torch.Tensor]``, so the connector receives page lists where it
+nominally expects monolithic tensors.
+
+This module bridges that gap without importing vLLM, NIXL, or torch_spyre:
+it detects the page-list layout, exposes geometry, and reads/writes whole
+pages in the same block convention as the heap accessor
+(``[block_size, num_kv_heads, head_size]`` on CPU), so the connector's
+staging store interoperates with both paths.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+# Per-page tensor rank in the Spyre paged layout
+# [num_kv_heads, block_size, head_size].
+_PAGE_RANK = 3
+
+
+def is_paged_layer_cache(layer_cache: Any) -> bool:
+    """Return True iff ``layer_cache`` looks like ``(k_pages, v_pages)``.
+
+    Accepts plain tuples/lists of two non-empty equal-length page lists of
+    3-D tensors, as well as the typed ``SpyrePagedKVCache`` NamedTuple
+    (which is a tuple at runtime). Plain staging tensors return False.
+    """
+    if isinstance(layer_cache, torch.Tensor):
+        return False
+    if not isinstance(layer_cache, (tuple, list)) or len(layer_cache) != 2:
+        return False
+    k_pages, v_pages = layer_cache
+    if not isinstance(k_pages, list) or not isinstance(v_pages, list):
+        return False
+    if not k_pages or len(k_pages) != len(v_pages):
+        return False
+    return all(
+        isinstance(page, torch.Tensor) and page.dim() == _PAGE_RANK
+        for page in (k_pages[0], v_pages[0])
+    )
+
+
+class SpyrePagedKVCacheAccessor:
+    """Uniform page read/write access over per-layer Spyre page lists.
+
+    Geometry (layers, pages, heads, block size, head dim, dtype, device) is
+    inferred from the registered cache objects — nothing is hard-coded.
+    Block tensors cross this boundary in the heap-accessor convention
+    ``[block_size, num_kv_heads, head_size]`` on CPU; pages stay in their
+    native ``[num_kv_heads, block_size, head_size]`` layout on their device.
+    """
+
+    def __init__(self, layer_caches: dict[str, Any]) -> None:
+        if not layer_caches:
+            raise ValueError("No layer caches provided")
+
+        self._layer_names = sorted(layer_caches)
+        self._caches: dict[str, tuple[list[torch.Tensor], list[torch.Tensor]]] = {}
+
+        ref_shape: tuple[int, ...] | None = None
+        ref_dtype: torch.dtype | None = None
+        ref_pages: int | None = None
+        for name in self._layer_names:
+            cache = layer_caches[name]
+            if not is_paged_layer_cache(cache):
+                raise ValueError(f"Layer {name!r} is not a (k_pages, v_pages) page list")
+            k_pages, v_pages = cache
+            for page in (k_pages[0], v_pages[0]):
+                shape = tuple(page.shape)
+                if ref_shape is None:
+                    ref_shape, ref_dtype = shape, page.dtype
+                elif shape != ref_shape or page.dtype != ref_dtype:
+                    raise ValueError(
+                        f"Inconsistent page geometry: layer {name!r} has "
+                        f"{shape}/{page.dtype}, expected {ref_shape}/{ref_dtype}"
+                    )
+            if ref_pages is None:
+                ref_pages = len(k_pages)
+            elif len(k_pages) != ref_pages:
+                raise ValueError(f"Layer {name!r} has {len(k_pages)} pages, expected {ref_pages}")
+            self._caches[name] = (k_pages, v_pages)
+
+        assert ref_shape is not None and ref_dtype is not None and ref_pages is not None
+        self._num_kv_heads, self._block_size, self._head_dim = ref_shape
+        self._dtype = ref_dtype
+        self._num_pages = ref_pages
+        self._device = self._caches[self._layer_names[0]][0][0].device
+
+    @classmethod
+    def try_from_kv_caches(cls, kv_caches: dict[str, Any]) -> SpyrePagedKVCacheAccessor | None:
+        """Build an accessor if every registered layer is a page list."""
+        if not kv_caches:
+            return None
+        if not all(is_paged_layer_cache(c) for c in kv_caches.values()):
+            return None
+        return cls(kv_caches)
+
+    @property
+    def layer_names(self) -> list[str]:
+        return list(self._layer_names)
+
+    @property
+    def num_layers(self) -> int:
+        return len(self._layer_names)
+
+    @property
+    def num_pages(self) -> int:
+        return self._num_pages
+
+    @property
+    def num_kv_heads(self) -> int:
+        return self._num_kv_heads
+
+    @property
+    def block_size(self) -> int:
+        return self._block_size
+
+    @property
+    def head_dim(self) -> int:
+        return self._head_dim
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self._dtype
+
+    @property
+    def device(self) -> torch.device:
+        return self._device
+
+    @property
+    def page_shape(self) -> tuple[int, int, int]:
+        return (self._num_kv_heads, self._block_size, self._head_dim)
+
+    @property
+    def block_shape(self) -> tuple[int, int, int]:
+        return (self._block_size, self._num_kv_heads, self._head_dim)
+
+    @property
+    def page_nbytes(self) -> int:
+        return (
+            self._num_kv_heads
+            * self._block_size
+            * self._head_dim
+            * torch.tensor([], dtype=self._dtype).element_size()
+        )
+
+    def _pages(self, layer_name: str, kv_kind: str) -> list[torch.Tensor]:
+        kind = kv_kind.lower()
+        if kind not in ("k", "v"):
+            raise ValueError(f"kv_kind must be 'k' or 'v', got {kv_kind!r}")
+        try:
+            cache = self._caches[layer_name]
+        except KeyError:
+            raise KeyError(f"Unknown layer {layer_name!r}") from None
+        return cache[0] if kind == "k" else cache[1]
+
+    def page(self, layer_name: str, kv_kind: str, page_id: int) -> torch.Tensor:
+        """Native page tensor [num_kv_heads, block_size, head_size], in place."""
+        pages = self._pages(layer_name, kv_kind)
+        if not 0 <= page_id < self._num_pages:
+            raise IndexError(f"page_id {page_id} out of range [0, {self._num_pages})")
+        return pages[page_id]
+
+    def validate_block(self, values: torch.Tensor) -> None:
+        if tuple(values.shape) != self.block_shape:
+            raise ValueError(
+                f"Expected block tensor shape {self.block_shape}, got {tuple(values.shape)}"
+            )
+        if values.dtype != self._dtype:
+            raise ValueError(f"Expected block dtype {self._dtype}, got {values.dtype}")
+
+    def read_block(self, *, layer_name: str, kv_kind: str, page_id: int) -> torch.Tensor:
+        """Copy one page to CPU as [block_size, num_kv_heads, head_size]."""
+        page = self.page(layer_name, kv_kind, page_id)
+        return page.to("cpu").permute(1, 0, 2).contiguous()
+
+    def write_block(
+        self,
+        *,
+        layer_name: str,
+        kv_kind: str,
+        page_id: int,
+        values: torch.Tensor,
+    ) -> None:
+        """Overwrite one page from a CPU block [block_size, num_kv_heads, head_size].
+
+        The full page is replaced in one device copy; pages are never sliced
+        (Spyre slicing of device tensors is unreliable — see spyre_attn.py).
+        """
+        self.validate_block(values)
+        page = self.page(layer_name, kv_kind, page_id)
+        page.copy_(values.permute(1, 0, 2).contiguous().to(page.device))
+
+    def transfer_units(self, block_ids: list[int]) -> dict[str, Any]:
+        """Describe the per-page transfer units for a set of block ids.
+
+        One unit per (layer, kind, page): the page granularity NIXL or any
+        future transport must use, since pages are independent allocations
+        with no contiguous [num_pages, ...] buffer to address.
+        """
+        valid = [b for b in block_ids if 0 <= b < self._num_pages]
+        units = self.num_layers * 2 * len(valid)
+        return {
+            "unit": "page",
+            "unit_shape": self.page_shape,
+            "unit_nbytes": self.page_nbytes,
+            "units_total": units,
+            "total_nbytes": units * self.page_nbytes,
+            "invalid_block_ids": [b for b in block_ids if b not in valid],
+        }
+
+    def describe(self) -> dict[str, Any]:
+        return {
+            "layout": "list_of_pages",
+            "num_layers": self.num_layers,
+            "num_pages": self._num_pages,
+            "page_shape": self.page_shape,
+            "dtype": str(self._dtype),
+            "device": str(self._device),
+            "page_nbytes": self.page_nbytes,
+        }

--- a/spyre_inference/envs.py
+++ b/spyre_inference/envs.py
@@ -18,6 +18,22 @@ from typing import TYPE_CHECKING, Any, Callable
 if TYPE_CHECKING:
     SPYRE_ATTN_IMPL: str = "default"
     SPYRE_SCATTER_USE_OVERWRITE: bool = False
+    VLLM_SPYRE_ENABLE_FILE_TRANSFER: bool = False
+    VLLM_SPYRE_ENABLE_NIXL_TRANSFER: bool = False
+    VLLM_SPYRE_NIXL_BLOCKING_TRANSFER: bool = True
+    VLLM_SPYRE_ENABLE_KV_CONNECTOR_BRIDGE: bool = True
+    VLLM_SPYRE_KV_CACHE_FILE_PATH: str | None = None
+    VLLM_SPYRE_NIXL_REMOTE_IP: str = "10.130.2.89"
+    VLLM_SPYRE_KV_ROLE: str = ""
+    VLLM_SPYRE_KV_STORE_BACKEND: str = "heap"
+    VLLM_SPYRE_KV_STORE_MAX_BYTES: int = 0
+    VLLM_SPYRE_KV_SERVICE_SOCKET: str | None = None
+    VLLM_SPYRE_KV_REUSE_REGISTRY_MAX_SIZE: int = 100
+    VLLM_SPYRE_KV_PLACEMENT_PROBE_ENABLED: bool = False
+    VLLM_SPYRE_EXPERIMENTAL_HEAP_KV_ENABLE: bool = False
+    VLLM_SPYRE_EXPERIMENTAL_HEAP_KV_STRICT: bool = False
+    VLLM_SPYRE_HEAP_KV_EXPORT_DIR: str | None = None
+    VLLM_SPYRE_HEAP_KV_PERFDSC_DIR: str | None = None
 
 _cache: dict[str, Any] = {}
 
@@ -45,6 +61,57 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Requires PR #2084 (specialize_int=True) applied to torch-spyre or
     # the kernel will reuse the first call's offsets.
     "SPYRE_SCATTER_USE_OVERWRITE": lambda: bool(int(os.getenv("SPYRE_SCATTER_USE_OVERWRITE", "0"))),
+    # Enable file-based KV cache transfer for disaggregated prefill-decode.
+    "VLLM_SPYRE_ENABLE_FILE_TRANSFER": lambda: bool(
+        int(os.getenv("VLLM_SPYRE_ENABLE_FILE_TRANSFER", "0"))
+    ),
+    # Enable NIXL-based KV cache transfer for disaggregated prefill-decode.
+    "VLLM_SPYRE_ENABLE_NIXL_TRANSFER": lambda: bool(
+        int(os.getenv("VLLM_SPYRE_ENABLE_NIXL_TRANSFER", "0"))
+    ),
+    # Use blocking mode for NIXL transfers. Set to 0 for non-blocking
+    # async transfers.
+    "VLLM_SPYRE_NIXL_BLOCKING_TRANSFER": lambda: bool(
+        int(os.getenv("VLLM_SPYRE_NIXL_BLOCKING_TRANSFER", "1"))
+    ),
+    # Enable the worker-side KV connector bridge for disaggregated
+    # prefill-decode.
+    "VLLM_SPYRE_ENABLE_KV_CONNECTOR_BRIDGE": lambda: bool(
+        int(os.getenv("VLLM_SPYRE_ENABLE_KV_CONNECTOR_BRIDGE", "1"))
+    ),
+    # Path to KV cache file for file-based transfer.
+    "VLLM_SPYRE_KV_CACHE_FILE_PATH": lambda: os.getenv("VLLM_SPYRE_KV_CACHE_FILE_PATH"),
+    # Remote IP address for NIXL transfer (decode connects to prefill).
+    # Overridden per-request by kv_transfer_params from a routing proxy.
+    "VLLM_SPYRE_NIXL_REMOTE_IP": lambda: os.getenv("VLLM_SPYRE_NIXL_REMOTE_IP", "10.130.2.89"),
+    # KV role: 'kv_producer' (prefill) or 'kv_consumer' (decode).
+    "VLLM_SPYRE_KV_ROLE": lambda: os.getenv("VLLM_SPYRE_KV_ROLE", ""),
+    # KV store backend type ('heap' or 'host_memory').
+    "VLLM_SPYRE_KV_STORE_BACKEND": lambda: os.getenv("VLLM_SPYRE_KV_STORE_BACKEND", "heap"),
+    # Maximum bytes for the KV store (0 = unlimited).
+    "VLLM_SPYRE_KV_STORE_MAX_BYTES": lambda: int(os.getenv("VLLM_SPYRE_KV_STORE_MAX_BYTES", "0")),
+    # Unix socket path for the persistent KV service.
+    "VLLM_SPYRE_KV_SERVICE_SOCKET": lambda: os.getenv("VLLM_SPYRE_KV_SERVICE_SOCKET"),
+    # Maximum number of saved requests in the KV reuse registry.
+    "VLLM_SPYRE_KV_REUSE_REGISTRY_MAX_SIZE": lambda: int(
+        os.getenv("VLLM_SPYRE_KV_REUSE_REGISTRY_MAX_SIZE", "100")
+    ),
+    # Emit structured KV placement probe log lines.
+    "VLLM_SPYRE_KV_PLACEMENT_PROBE_ENABLED": lambda: bool(
+        int(os.getenv("VLLM_SPYRE_KV_PLACEMENT_PROBE_ENABLED", "0"))
+    ),
+    # Experimental: read/write KV directly from the Spyre heap.
+    "VLLM_SPYRE_EXPERIMENTAL_HEAP_KV_ENABLE": lambda: bool(
+        int(os.getenv("VLLM_SPYRE_EXPERIMENTAL_HEAP_KV_ENABLE", "0"))
+    ),
+    # Experimental: fail instead of falling back when heap KV is unavailable.
+    "VLLM_SPYRE_EXPERIMENTAL_HEAP_KV_STRICT": lambda: bool(
+        int(os.getenv("VLLM_SPYRE_EXPERIMENTAL_HEAP_KV_STRICT", "0"))
+    ),
+    # Directory to export heap KV debug dumps.
+    "VLLM_SPYRE_HEAP_KV_EXPORT_DIR": lambda: os.getenv("VLLM_SPYRE_HEAP_KV_EXPORT_DIR"),
+    # Directory containing heap KV performance descriptors.
+    "VLLM_SPYRE_HEAP_KV_PERFDSC_DIR": lambda: os.getenv("VLLM_SPYRE_HEAP_KV_PERFDSC_DIR"),
 }
 # --8<-- [end:env-vars-definition]
 

--- a/spyre_inference/platform.py
+++ b/spyre_inference/platform.py
@@ -168,6 +168,12 @@ class TorchSpyrePlatform(CpuPlatform):
     def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
         cls.log_server_boot(vllm_config)
 
+        # Register the Spyre KV connector before the scheduler instantiates
+        # connectors from kv_transfer_config.
+        from spyre_inference import register_kv_connector
+
+        register_kv_connector()
+
         # Check if the model dtype is different from float16,
         # which is only currently supported in torch-spyre
         if vllm_config.model_config.dtype != torch.float16:

--- a/spyre_inference/v1/worker/spyre_kv_connector_bridge.py
+++ b/spyre_inference/v1/worker/spyre_kv_connector_bridge.py
@@ -1,0 +1,175 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import spyre_inference.envs as envs_spyre
+from vllm.distributed.kv_transfer import (
+    get_kv_transfer_group,
+    has_kv_transfer_group,
+)
+from vllm.forward_context import (
+    get_forward_context,
+    is_forward_context_available,
+    set_forward_context,
+)
+from vllm.logger import init_logger
+from vllm.v1.outputs import KVConnectorOutput
+
+if TYPE_CHECKING:
+    from vllm.config import VllmConfig
+    from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+        KVConnectorBase_V1,
+    )
+    from vllm.v1.core.sched.output import SchedulerOutput
+
+logger = init_logger(__name__)
+
+
+class SpyreKVConnectorBridge:
+    def __init__(self, vllm_config: VllmConfig):
+        self._vllm_config = vllm_config
+        self._kv_connector: KVConnectorBase_V1 | None = None
+        self._active = False
+        self._output: KVConnectorOutput | None = None
+        self._try_acquire_connector()
+
+    def _try_acquire_connector(self) -> bool:
+        if self._kv_connector is not None:
+            return True
+        if not has_kv_transfer_group():
+            return False
+
+        connector = get_kv_transfer_group()
+        from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+            KVConnectorBase_V1,
+        )
+
+        if not isinstance(connector, KVConnectorBase_V1):
+            logger.warning(
+                "KV connector is not a V1 connector (got %s). Bridge disabled.",
+                type(connector).__name__,
+            )
+            return False
+
+        self._kv_connector = connector
+        return True
+
+    @property
+    def is_available(self) -> bool:
+        return self._kv_connector is not None or self._try_acquire_connector()
+
+    @property
+    def uses_heap_kv(self) -> bool:
+        if not self.is_available:
+            return False
+        assert self._kv_connector is not None
+        active_fn = getattr(self._kv_connector, "heap_kv_active", None)
+        if callable(active_fn):
+            return bool(active_fn())
+        return bool(getattr(self._kv_connector, "uses_heap_kv", False))
+
+    def begin_step(self, scheduler_output: SchedulerOutput) -> bool:
+        self._active = False
+        self._output = None
+
+        if not self.is_available:
+            return False
+
+        assert self._kv_connector is not None
+        if scheduler_output.kv_connector_metadata is None:
+            return False
+
+        # vLLM 0.20.x: handle_preemptions takes the connector metadata,
+        # not the preempted request ids.
+        preempted = getattr(scheduler_output, "preempted_req_ids", None)
+        if preempted:
+            self._kv_connector.handle_preemptions(scheduler_output.kv_connector_metadata)
+
+        self._active = True
+        return True
+
+    def before_forward(self, scheduler_output: SchedulerOutput) -> None:
+        if not self._active:
+            return
+
+        assert self._kv_connector is not None
+        assert scheduler_output.kv_connector_metadata is not None
+
+        self._kv_connector.bind_connector_metadata(scheduler_output.kv_connector_metadata)
+
+        if is_forward_context_available():
+            self._kv_connector.start_load_kv(get_forward_context())
+        else:
+            with set_forward_context(None, self._vllm_config):
+                self._kv_connector.start_load_kv(get_forward_context())
+
+    def after_forward(
+        self,
+        scheduler_output: SchedulerOutput,
+        wait_for_save: bool = True,
+    ) -> None:
+        if not self._active:
+            return
+
+        assert self._kv_connector is not None
+        output = KVConnectorOutput()
+        if wait_for_save:
+            self._kv_connector.wait_for_save()
+
+        output.finished_sending, output.finished_recving = self._kv_connector.get_finished(
+            scheduler_output.finished_req_ids
+        )
+        output.invalid_block_ids = self._kv_connector.get_block_ids_with_load_errors()
+        output.kv_connector_stats = self._kv_connector.get_kv_connector_stats()
+        output.kv_cache_events = self._kv_connector.get_kv_connector_kv_cache_events()
+        self._output = output
+
+    def finish_step(self) -> KVConnectorOutput | None:
+        if not self._active:
+            return None
+
+        assert self._kv_connector is not None
+        self._kv_connector.clear_connector_metadata()
+        output = self._output
+        self._output = None
+        self._active = False
+        return output
+
+    def no_forward(
+        self,
+        scheduler_output: SchedulerOutput,
+    ) -> KVConnectorOutput | None:
+        if not self.begin_step(scheduler_output):
+            return None
+        self.before_forward(scheduler_output)
+        self.after_forward(scheduler_output, wait_for_save=False)
+        return self.finish_step()
+
+
+def maybe_create_bridge(
+    vllm_config: VllmConfig,
+) -> SpyreKVConnectorBridge | None:
+    if not envs_spyre.VLLM_SPYRE_ENABLE_KV_CONNECTOR_BRIDGE:
+        return None
+
+    if (
+        vllm_config.kv_transfer_config is None
+        or not vllm_config.kv_transfer_config.is_kv_transfer_instance
+    ):
+        return None
+
+    return SpyreKVConnectorBridge(vllm_config)

--- a/spyre_inference/v1/worker/spyre_worker.py
+++ b/spyre_inference/v1/worker/spyre_worker.py
@@ -46,6 +46,12 @@ class TorchSpyreWorker(CPUWorker):
     """
 
     def init_device(self) -> None:
+        # Register the Spyre KV connector in this worker process before
+        # the model runner initializes the KV transfer group.
+        from spyre_inference import register_kv_connector
+
+        register_kv_connector()
+
         # Populate the env vars that `libspyre_comms.so` reads at dlopen
         # time. `setdefault` leaves torchrun-supplied values intact.
         # DP>1 is rejected in TorchSpyrePlatform.check_and_update_config,

--- a/tests/test_connector_nixl_smoke.py
+++ b/tests/test_connector_nixl_smoke.py
@@ -1,0 +1,309 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the connector-level NIXL smoke script.
+
+Helper coverage (CLI parser, paged cache builder, checksums) runs with
+torch only. The full in-process roundtrip needs vLLM and skips cleanly
+when it is absent. No NIXL or AIU hardware is required anywhere.
+"""
+
+import importlib.util
+import json
+import pathlib
+
+import pytest
+
+torch = pytest.importorskip("torch", reason="torch required for smoke helper tests")
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+CONNECTOR_DIR = REPO / "spyre_inference" / "distributed" / "kv_transfer" / "kv_connector" / "v1"
+
+
+def _load_by_path(name: str, path: pathlib.Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Loading by file path keeps these imports vLLM-free: the smoke script's
+# helpers are torch-only, and spyre_inference/__init__.py would pull vLLM in.
+smoke = _load_by_path(
+    "spyre_connector_nixl_smoke",
+    REPO / "examples" / "kv_connector" / "spyre_connector_nixl_smoke.py",
+)
+accessor_mod = _load_by_path(
+    "spyre_paged_kv_accessor", CONNECTOR_DIR / "spyre_paged_kv_accessor.py"
+)
+
+
+def test_parser_roles_and_defaults():
+    args = smoke.build_parser().parse_args(["--role", "both"])
+    assert args.role == "both"
+    assert args.num_layers == 2
+    assert args.num_kv_heads == 2
+    assert args.block_size == 4
+    assert args.head_dim == 8
+    assert args.num_pages == 4
+    assert args.block_ids == [1, 2]
+    assert args.device == "cpu"
+
+    args = smoke.build_parser().parse_args(
+        ["--role", "decode", "--block-ids", "0", "3", "--num-pages", "6"]
+    )
+    assert args.role == "decode"
+    assert args.block_ids == [0, 3]
+    assert args.num_pages == 6
+
+
+def test_parser_requires_valid_role():
+    with pytest.raises(SystemExit):
+        smoke.build_parser().parse_args([])
+    with pytest.raises(SystemExit):
+        smoke.build_parser().parse_args(["--role", "scheduler"])
+
+
+def test_parser_split_mode_flags():
+    args = smoke.build_parser().parse_args(
+        [
+            "--role",
+            "decode",
+            "--nixl",
+            "--prefill-ip",
+            "10.1.2.3",
+            "--prefill-port",
+            "9200",
+            "--listen-port",
+            "9300",
+            "--source-request-id",
+            "req-src",
+            "--request-id",
+            "req-dst",
+            "--timeout-s",
+            "30",
+            "--ready-file",
+            "/tmp/ready.json",
+            "--expected-json",
+            "/tmp/expected.json",
+            "--keepalive-s",
+            "5",
+        ]
+    )
+    assert args.nixl is True
+    assert args.prefill_ip == "10.1.2.3"
+    assert args.prefill_port == 9200
+    assert args.listen_port == 9300
+    assert args.source_request_id == "req-src"
+    assert args.request_id == "req-dst"
+    assert args.timeout_s == 30.0
+    assert args.ready_file == "/tmp/ready.json"
+    assert args.expected_json == "/tmp/expected.json"
+    assert args.keepalive_s == 5.0
+
+    defaults = smoke.build_parser().parse_args(["--role", "both"])
+    assert defaults.nixl is False
+    assert defaults.prefill_port == smoke.DEFAULT_NIXL_PORT
+    assert defaults.listen_port == smoke.DEFAULT_NIXL_PORT
+    assert defaults.source_request_id == smoke.PREFILL_REQ_ID
+    assert defaults.request_id == smoke.DECODE_REQ_ID
+
+
+def test_result_json_aliases_result_file():
+    a = smoke.build_parser().parse_args(["--role", "both", "--result-json", "/tmp/a.json"])
+    b = smoke.build_parser().parse_args(["--role", "both", "--result-file", "/tmp/a.json"])
+    assert a.result_file == b.result_file == "/tmp/a.json"
+
+
+def test_split_env_role_configs():
+    prefill = smoke.build_parser().parse_args(["--role", "prefill", "--nixl"])
+    env = smoke.split_env(prefill)
+    assert env["VLLM_SPYRE_ENABLE_NIXL_TRANSFER"] == "1"
+    assert env["VLLM_SPYRE_KV_ROLE"] == "kv_producer"
+    assert env["VLLM_SPYRE_NIXL_BLOCKING_TRANSFER"] == "0"
+    assert "VLLM_SPYRE_NIXL_REMOTE_IP" not in env
+
+    decode = smoke.build_parser().parse_args(
+        ["--role", "decode", "--nixl", "--prefill-ip", "10.9.8.7"]
+    )
+    env = smoke.split_env(decode)
+    assert env["VLLM_SPYRE_KV_ROLE"] == "kv_consumer"
+    assert env["VLLM_SPYRE_NIXL_REMOTE_IP"] == "10.9.8.7"
+    assert "VLLM_SPYRE_NIXL_BLOCKING_TRANSFER" not in env
+
+
+def test_expected_json_roundtrip(tmp_path):
+    args = smoke.build_parser().parse_args(["--role", "both"])
+    expected = smoke.expected_checksums(args)
+    path = tmp_path / "expected.json"
+    path.write_text(json.dumps(expected))
+    assert smoke.checksums_match(expected, json.loads(path.read_text()))
+
+
+def test_nixl_with_role_both_rejected(tmp_path):
+    result_file = tmp_path / "result.json"
+    rc = smoke.main(["--role", "both", "--nixl", "--result-file", str(result_file)])
+    assert rc == 1
+    result = json.loads(result_file.read_text())
+    assert result["success"] is False
+    assert "split" in result["error"]
+
+
+def test_split_helpers_import_without_vllm():
+    """Split-mode helper logic must not require vLLM at module import time."""
+    src = (REPO / "examples" / "kv_connector" / "spyre_connector_nixl_smoke.py").read_text()
+    top = src.split("def _apply_split_env", 1)[0]
+    assert "import vllm" not in top
+    assert "from vllm" not in top
+    # module already imported above without vLLM
+    assert smoke.split_env is not None
+
+
+def test_nixl_receive_path_is_dtype_aware():
+    """Decode receive buffers must use the registered cache dtype, not fp32.
+
+    fp32 sizing halves the element count for fp16 pages (a 128-byte page is
+    64 fp16 elements, not 32 fp32) and NIXL rejects the transfer with
+    NIXL_ERR_INVALID_PARAM.
+    """
+    src = (CONNECTOR_DIR / "inmemory_spyre_connector.py").read_text()
+    body = src.split("def _load_saved_requests_nixl", 1)[1].split("def _save_request_nixl", 1)[0]
+    assert "torch.float32.itemsize" not in body
+    assert "dtype=torch.float32" not in body
+    assert "recv_dtype = self._nixl_receive_dtype()" in body
+    assert "desc_len_bytes // recv_itemsize" in body
+    assert "torch.zeros(kv_block_shape, dtype=recv_dtype" in body
+
+    helper = src.split("def _nixl_receive_dtype", 1)[1].split("def _load_saved_requests_nixl", 1)[0]
+    assert "self._paged_accessor.dtype" in helper
+    assert "return torch.float32" in helper  # only as the unregistered fallback
+
+
+def test_nixl_receive_uses_block_layout_buffers_for_paged():
+    """Paged NIXL receive buffers must match the producer's registered layout.
+
+    The producer registers store-resident blocks in heap-block layout
+    [block_size, num_kv_heads, head_dim] (from _save_kv_bulk via
+    SpyrePagedKVCacheAccessor.read_block). Receiving into page-shaped
+    buffers and permuting afterwards transposes cell positions and breaks
+    checksums, so the receive shape is block_shape and tensors are stored
+    directly, with no paged-only permute.
+    """
+    src = (CONNECTOR_DIR / "inmemory_spyre_connector.py").read_text()
+    body = src.split("def _load_saved_requests_nixl", 1)[1].split("def _save_request_nixl", 1)[0]
+    assert "kv_block_shape = self._paged_accessor.block_shape" in body
+    assert "self._paged_accessor.page_shape" not in body
+    assert "key_tensor.permute" not in body
+    assert "value_tensor.permute" not in body
+    assert "self._store.put(key_store_key, key_tensor)" in body
+    assert "self._store.put(value_store_key, value_tensor)" in body
+
+
+def test_connector_nonblocking_save_does_not_wait_for_client():
+    """Producer must expose pending transfers without a connected client."""
+    src = (CONNECTOR_DIR / "inmemory_spyre_connector.py").read_text()
+    body = src.split("def _save_request_nixl", 1)[1].split("def _save_request_record", 1)[0]
+    assert body.count('check_remote_metadata("client")') == 1
+    wait = body.index('check_remote_metadata("client")')
+    blocking_branch = body.index("BLOCKING MODE: wait for the client")
+    assert blocking_branch < wait, "client wait must be inside the blocking-mode branch"
+    assert "_pending_transfers[record.req_id]" in body
+
+
+def test_paged_cache_builder_activates_accessor():
+    caches = smoke.build_paged_kv_caches(
+        num_layers=2, num_kv_heads=2, block_size=4, head_dim=8, num_pages=4
+    )
+    accessor = accessor_mod.SpyrePagedKVCacheAccessor.try_from_kv_caches(caches)
+    assert accessor is not None
+    assert accessor.num_layers == 2
+    assert accessor.num_pages == 4
+    assert accessor.page_shape == (2, 4, 8)
+    assert accessor.dtype == torch.float16
+
+
+def test_deterministic_blocks_distinct_and_reproducible():
+    kw = {"num_kv_heads": 2, "block_size": 4, "head_dim": 8}
+    a = smoke.deterministic_block(0, "k", 1, **kw)
+    assert a.shape == (2, 4, 8)
+    assert a.dtype == torch.float16
+    assert torch.equal(a, smoke.deterministic_block(0, "k", 1, **kw))
+    assert not torch.equal(a, smoke.deterministic_block(0, "v", 1, **kw))
+    assert not torch.equal(a, smoke.deterministic_block(1, "k", 1, **kw))
+    assert not torch.equal(a, smoke.deterministic_block(0, "k", 2, **kw))
+
+
+def test_checksum_match_helper():
+    filled = smoke.build_paged_kv_caches(
+        num_layers=2, num_kv_heads=2, block_size=4, head_dim=8, num_pages=4, fill_block_ids=[1, 2]
+    )
+    empty = smoke.build_paged_kv_caches(
+        num_layers=2, num_kv_heads=2, block_size=4, head_dim=8, num_pages=4
+    )
+    expected = smoke.cache_checksums(filled, [1, 2])
+    assert len(expected) == 2 * 2 * 2  # layers * kinds * blocks
+    assert smoke.checksums_match(expected, smoke.cache_checksums(filled, [1, 2]))
+    assert not smoke.checksums_match(expected, smoke.cache_checksums(empty, [1, 2]))
+    assert not smoke.checksums_match({}, {})
+
+
+def test_expected_checksums_match_builder():
+    args = smoke.build_parser().parse_args(["--role", "both"])
+    assert smoke.expected_checksums(args) == smoke.cache_checksums(
+        smoke.build_paged_kv_caches(
+            num_layers=2,
+            num_kv_heads=2,
+            block_size=4,
+            head_dim=8,
+            num_pages=4,
+            fill_block_ids=[1, 2],
+        ),
+        [1, 2],
+    )
+
+
+def test_inprocess_roundtrip_without_nixl(tmp_path, capsys, monkeypatch):
+    """Full prefill -> store -> decode roundtrip through the real connector."""
+    pytest.importorskip("vllm", reason="vLLM required for connector roundtrip")
+    monkeypatch.delenv("VLLM_SPYRE_ENABLE_NIXL_TRANSFER", raising=False)
+    monkeypatch.delenv("VLLM_SPYRE_EXPERIMENTAL_HEAP_KV_ENABLE", raising=False)
+
+    from spyre_inference.distributed.kv_transfer.kv_connector.v1.inmemory_spyre_connector import (
+        reset_global_store,
+    )
+
+    reset_global_store()
+    result_file = tmp_path / "result.json"
+    rc = smoke.main(["--role", "both", "--result-file", str(result_file)])
+
+    out = capsys.readouterr().out
+    for marker in (
+        smoke.MARK_PREFILL_READY,
+        smoke.MARK_SAVE_DONE,
+        smoke.MARK_DECODE_START,
+        smoke.MARK_LOAD_DONE,
+        f"{smoke.MARK_CONTENT_MATCH} true",
+        f"{smoke.MARK_SUCCESS} true",
+    ):
+        assert marker in out
+
+    result = json.loads(result_file.read_text())
+    assert rc == 0
+    assert result["success"] is True
+    assert result["content_match"] is True
+    assert result["error"] is None
+    assert result["layout"] == "list_of_pages"
+    assert result["expected_checksums"] == result["actual_checksums"]
+    assert result["load_error_block_ids"] == []

--- a/tests/test_kv_connector_registration.py
+++ b/tests/test_kv_connector_registration.py
@@ -1,0 +1,109 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Smoke tests for the Spyre KV connector registration and import path."""
+
+import builtins
+import importlib
+import sys
+
+import pytest
+
+vllm = pytest.importorskip("vllm", reason="vLLM required for connector tests")
+
+CONNECTOR_MODULE = (
+    "spyre_inference.distributed.kv_transfer.kv_connector.v1.inmemory_spyre_connector"
+)
+
+
+def test_register_kv_connector_with_factory():
+    """register_kv_connector registers InMemorySpyreConnector by name."""
+    from vllm.distributed.kv_transfer.kv_connector.factory import KVConnectorFactory
+
+    import spyre_inference
+
+    spyre_inference.register_kv_connector()
+    assert "InMemorySpyreConnector" in KVConnectorFactory._registry
+
+    # Idempotent on second call.
+    spyre_inference.register_kv_connector()
+
+
+def test_connector_module_imports():
+    """The ported connector module imports and exposes the connector class."""
+    mod = importlib.import_module(CONNECTOR_MODULE)
+    assert hasattr(mod, "InMemorySpyreConnector")
+
+
+def test_connector_imports_without_nixl(monkeypatch):
+    """The connector module must not crash when nixl is not importable."""
+    real_import = builtins.__import__
+
+    def block_nixl(name, *args, **kwargs):
+        if name == "nixl" or name.startswith("nixl."):
+            raise ImportError(f"nixl blocked for test: {name}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", block_nixl)
+    for key in [k for k in sys.modules if k == "nixl" or k.startswith("nixl.")]:
+        monkeypatch.delitem(sys.modules, key)
+    monkeypatch.delitem(sys.modules, CONNECTOR_MODULE, raising=False)
+
+    mod = importlib.import_module(CONNECTOR_MODULE)
+    assert mod.NIXL_AVAILABLE is False
+    assert hasattr(mod, "InMemorySpyreConnector")
+
+
+def test_build_spyre_kv_store_backend_heap_alias():
+    """`heap` and `host_memory` must both build a HostMemoryKVStoreBackend.
+
+    This is the runtime counterpart to the structure-test guard against the
+    env-default-vs-registry mismatch. `heap` is the compatibility alias; the
+    canonical name is `host_memory`.
+    """
+    from spyre_inference.distributed.kv_transfer.kv_connector.v1.metadata import (
+        HostMemoryKVStoreBackend,
+        build_spyre_kv_store_backend,
+    )
+
+    heap_backend = build_spyre_kv_store_backend("heap")
+    host_memory_backend = build_spyre_kv_store_backend("host_memory")
+    assert isinstance(heap_backend, HostMemoryKVStoreBackend)
+    assert isinstance(host_memory_backend, HostMemoryKVStoreBackend)
+
+
+def test_build_spyre_kv_store_backend_default_env_value():
+    """The current envs.py default for VLLM_SPYRE_KV_STORE_BACKEND must build."""
+    from spyre_inference import envs as envs_spyre
+    from spyre_inference.distributed.kv_transfer.kv_connector.v1.metadata import (
+        HostMemoryKVStoreBackend,
+        build_spyre_kv_store_backend,
+    )
+
+    default = envs_spyre.VLLM_SPYRE_KV_STORE_BACKEND
+    backend = build_spyre_kv_store_backend(default)
+    assert isinstance(backend, HostMemoryKVStoreBackend), (
+        f"default backend {default!r} did not build a HostMemoryKVStoreBackend; "
+        f"got {type(backend).__name__}"
+    )
+
+
+def test_build_spyre_kv_store_backend_invalid_raises():
+    """Invalid backend names must still raise ValueError with the supported list."""
+    from spyre_inference.distributed.kv_transfer.kv_connector.v1.metadata import (
+        build_spyre_kv_store_backend,
+    )
+
+    with pytest.raises(ValueError, match="Unknown Spyre KV store backend"):
+        build_spyre_kv_store_backend("definitely_not_a_real_backend_xyz")

--- a/tests/test_kv_connector_structure.py
+++ b/tests/test_kv_connector_structure.py
@@ -1,0 +1,144 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Structural checks for the ported KV connector that run without vLLM.
+
+These catch obvious port regressions (bad module paths, missing package
+files, stale env var declarations, leftover vllm_spyre references) on any
+machine, including ones without vLLM installed.
+"""
+
+import ast
+import pathlib
+import re
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+PKG = REPO / "spyre_inference"
+CONNECTOR_DIR = PKG / "distributed" / "kv_transfer" / "kv_connector" / "v1"
+CONNECTOR_MODULE = (
+    "spyre_inference.distributed.kv_transfer.kv_connector.v1.inmemory_spyre_connector"
+)
+METADATA_FILE = CONNECTOR_DIR / "metadata.py"
+
+
+def test_connector_module_path_resolves_to_file():
+    rel = pathlib.Path(*CONNECTOR_MODULE.split(".")).with_suffix(".py")
+    assert (REPO / rel).is_file()
+
+
+def test_registration_uses_existing_module_path():
+    init_src = (PKG / "__init__.py").read_text()
+    assert f'"{CONNECTOR_MODULE}"' in init_src
+    assert '"InMemorySpyreConnector"' in init_src
+
+
+def test_all_connector_packages_have_init_files():
+    parts = PKG / "distributed"
+    for sub in ["", "kv_transfer", "kv_transfer/kv_connector", "kv_transfer/kv_connector/v1"]:
+        assert (parts / sub / "__init__.py").is_file(), f"missing __init__.py under {sub or '.'}"
+
+
+def test_connector_defines_class_and_nixl_guard():
+    src = (CONNECTOR_DIR / "inmemory_spyre_connector.py").read_text()
+    tree = ast.parse(src)
+    classes = {n.name for n in ast.walk(tree) if isinstance(n, ast.ClassDef)}
+    assert "InMemorySpyreConnector" in classes
+    assert "NIXL_AVAILABLE = False" in src, "nixl import must be guarded"
+
+
+def test_no_vllm_spyre_references():
+    offenders = [p for p in PKG.rglob("*.py") if "vllm_spyre" in p.read_text()]
+    assert not offenders, f"leftover vllm_spyre references: {offenders}"
+
+
+def test_kv_env_vars_declared_consistently():
+    src = (PKG / "envs.py").read_text()
+    declared = set(re.findall(r'"(VLLM_SPYRE_[A-Z_]+)":', src))
+    type_checked = set(re.findall(r"(VLLM_SPYRE_[A-Z_]+):", src))
+    assert declared, "expected ported KV env vars in envs.py"
+    assert type_checked == declared, f"TYPE_CHECKING/dict drift: {type_checked ^ declared}"
+    for required in [
+        "VLLM_SPYRE_ENABLE_NIXL_TRANSFER",
+        "VLLM_SPYRE_NIXL_REMOTE_IP",
+        "VLLM_SPYRE_KV_ROLE",
+        "VLLM_SPYRE_KV_STORE_BACKEND",
+    ]:
+        assert required in declared
+
+
+def test_registration_hooks_present():
+    assert "register_kv_connector()" in (PKG / "platform.py").read_text()
+    assert "register_kv_connector()" in (PKG / "v1" / "worker" / "spyre_worker.py").read_text()
+
+
+def _parse_store_backend_type_keys() -> set[str]:
+    """Return the literal keys of `_STORE_BACKEND_TYPES` in metadata.py.
+
+    Parsed via ast so the test does not require vLLM to import the module.
+    """
+    src = METADATA_FILE.read_text()
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.AnnAssign):
+            continue
+        target = node.target
+        if isinstance(target, ast.Name) and target.id == "_STORE_BACKEND_TYPES":
+            value = node.value
+            assert isinstance(value, ast.Dict), "_STORE_BACKEND_TYPES is not a dict literal"
+            keys: set[str] = set()
+            for key in value.keys:
+                assert isinstance(key, ast.Constant) and isinstance(key.value, str), (
+                    f"_STORE_BACKEND_TYPES key is not a string literal: {ast.dump(key)}"
+                )
+                keys.add(key.value)
+            return keys
+    raise AssertionError("_STORE_BACKEND_TYPES not found in metadata.py")
+
+
+def _parse_kv_store_backend_default() -> str:
+    """Return the default value declared for VLLM_SPYRE_KV_STORE_BACKEND in envs.py."""
+    src = (PKG / "envs.py").read_text()
+    match = re.search(
+        r'"VLLM_SPYRE_KV_STORE_BACKEND"\s*:\s*lambda\s*:\s*os\.getenv\(\s*'
+        r'"VLLM_SPYRE_KV_STORE_BACKEND"\s*,\s*"([^"]+)"\s*\)',
+        src,
+    )
+    assert match, "could not parse VLLM_SPYRE_KV_STORE_BACKEND default from envs.py"
+    return match.group(1)
+
+
+def test_kv_store_backend_default_is_supported():
+    """envs.py default for VLLM_SPYRE_KV_STORE_BACKEND must be a key in _STORE_BACKEND_TYPES.
+
+    Guards against the heap/host_memory regression where the env default was
+    "heap" but the backend registry had no "heap" entry, causing every
+    create_connector call with the default env to raise ValueError at engine
+    init.
+    """
+    default = _parse_kv_store_backend_default()
+    keys = _parse_store_backend_type_keys()
+    assert default in keys, (
+        f"VLLM_SPYRE_KV_STORE_BACKEND default {default!r} is not in "
+        f"_STORE_BACKEND_TYPES keys {sorted(keys)}; either add an alias to "
+        "metadata.py or change the env-var default."
+    )
+
+
+def test_heap_and_host_memory_keys_present():
+    """Both 'heap' (compat alias) and 'host_memory' (canonical) must be supported."""
+    keys = _parse_store_backend_type_keys()
+    for required in ("heap", "host_memory"):
+        assert required in keys, (
+            f"_STORE_BACKEND_TYPES is missing key {required!r}; got {sorted(keys)}"
+        )

--- a/tests/test_paged_kv_accessor.py
+++ b/tests/test_paged_kv_accessor.py
@@ -1,0 +1,189 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for SpyrePagedKVCacheAccessor with fake CPU page lists.
+
+These run without vLLM, NIXL, or AIU hardware: the accessor only needs
+torch tensors shaped like the Spyre list-of-pages KV cache
+([num_kv_heads, block_size, head_size] per page).
+"""
+
+import importlib.util
+import pathlib
+from typing import NamedTuple
+
+import pytest
+
+torch = pytest.importorskip("torch", reason="torch required for paged accessor tests")
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+CONNECTOR_DIR = REPO / "spyre_inference" / "distributed" / "kv_transfer" / "kv_connector" / "v1"
+
+# Load by file path: the accessor module is vLLM-free, but importing it through
+# the spyre_inference package would pull vLLM in via spyre_inference/__init__.py.
+_spec = importlib.util.spec_from_file_location(
+    "spyre_paged_kv_accessor", CONNECTOR_DIR / "spyre_paged_kv_accessor.py"
+)
+assert _spec is not None and _spec.loader is not None
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+SpyrePagedKVCacheAccessor = _mod.SpyrePagedKVCacheAccessor
+is_paged_layer_cache = _mod.is_paged_layer_cache
+
+NUM_KV_HEADS = 2
+BLOCK_SIZE = 4
+HEAD_DIM = 8
+NUM_PAGES = 3
+LAYERS = ["model.layers.0.attn", "model.layers.1.attn"]
+
+
+class FakeSpyrePagedKVCache(NamedTuple):
+    """Tuple-compatible stand-in for spyre_attn.SpyrePagedKVCache."""
+
+    k_pages: list[torch.Tensor]
+    v_pages: list[torch.Tensor]
+
+
+def make_pages(fill: float = 0.0) -> list[torch.Tensor]:
+    return [
+        torch.full((NUM_KV_HEADS, BLOCK_SIZE, HEAD_DIM), fill, dtype=torch.float16)
+        for _ in range(NUM_PAGES)
+    ]
+
+
+def make_kv_caches() -> dict[str, FakeSpyrePagedKVCache]:
+    return {
+        name: FakeSpyrePagedKVCache(k_pages=make_pages(), v_pages=make_pages()) for name in LAYERS
+    }
+
+
+def test_is_paged_layer_cache_detects_page_lists():
+    assert is_paged_layer_cache((make_pages(), make_pages()))
+    assert is_paged_layer_cache(FakeSpyrePagedKVCache(make_pages(), make_pages()))
+
+
+def test_is_paged_layer_cache_rejects_other_layouts():
+    staging = torch.zeros(2, NUM_PAGES, BLOCK_SIZE, NUM_KV_HEADS, HEAD_DIM)
+    assert not is_paged_layer_cache(staging)
+    assert not is_paged_layer_cache(None)
+    assert not is_paged_layer_cache(([], []))
+    assert not is_paged_layer_cache((make_pages(), make_pages()[:-1]))
+    assert not is_paged_layer_cache((make_pages()[0], make_pages()[0]))
+
+
+def test_try_from_kv_caches_infers_geometry():
+    accessor = SpyrePagedKVCacheAccessor.try_from_kv_caches(make_kv_caches())
+    assert accessor is not None
+    assert accessor.num_layers == len(LAYERS)
+    assert accessor.layer_names == sorted(LAYERS)
+    assert accessor.num_pages == NUM_PAGES
+    assert accessor.num_kv_heads == NUM_KV_HEADS
+    assert accessor.block_size == BLOCK_SIZE
+    assert accessor.head_dim == HEAD_DIM
+    assert accessor.dtype == torch.float16
+    assert accessor.page_shape == (NUM_KV_HEADS, BLOCK_SIZE, HEAD_DIM)
+    assert accessor.block_shape == (BLOCK_SIZE, NUM_KV_HEADS, HEAD_DIM)
+    assert accessor.page_nbytes == NUM_KV_HEADS * BLOCK_SIZE * HEAD_DIM * 2
+
+
+def test_try_from_kv_caches_returns_none_for_staging_tensors():
+    staging = {"layer": torch.zeros(2, NUM_PAGES, BLOCK_SIZE, NUM_KV_HEADS, HEAD_DIM)}
+    assert SpyrePagedKVCacheAccessor.try_from_kv_caches(staging) is None
+    assert SpyrePagedKVCacheAccessor.try_from_kv_caches({}) is None
+
+
+def test_inconsistent_geometry_rejected():
+    caches = make_kv_caches()
+    caches[LAYERS[1]].k_pages[0] = torch.zeros(
+        NUM_KV_HEADS, BLOCK_SIZE * 2, HEAD_DIM, dtype=torch.float16
+    )
+    with pytest.raises(ValueError, match="Inconsistent page geometry"):
+        SpyrePagedKVCacheAccessor(caches)
+
+
+def test_write_then_read_block_roundtrip():
+    caches = make_kv_caches()
+    accessor = SpyrePagedKVCacheAccessor(caches)
+    block = torch.arange(BLOCK_SIZE * NUM_KV_HEADS * HEAD_DIM, dtype=torch.float16).reshape(
+        BLOCK_SIZE, NUM_KV_HEADS, HEAD_DIM
+    )
+
+    accessor.write_block(layer_name=LAYERS[0], kv_kind="k", page_id=1, values=block)
+
+    assert torch.equal(accessor.read_block(layer_name=LAYERS[0], kv_kind="k", page_id=1), block)
+    # The write landed in the registered page tensor, permuted to page layout.
+    assert torch.equal(caches[LAYERS[0]].k_pages[1], block.permute(1, 0, 2))
+    # Other pages, kinds, and layers stay untouched.
+    assert caches[LAYERS[0]].k_pages[0].abs().sum() == 0
+    assert caches[LAYERS[0]].v_pages[1].abs().sum() == 0
+    assert caches[LAYERS[1]].k_pages[1].abs().sum() == 0
+
+
+def test_write_block_validates_shape_dtype_kind_and_range():
+    accessor = SpyrePagedKVCacheAccessor(make_kv_caches())
+    good = torch.zeros(BLOCK_SIZE, NUM_KV_HEADS, HEAD_DIM, dtype=torch.float16)
+
+    with pytest.raises(ValueError, match="block tensor shape"):
+        accessor.write_block(
+            layer_name=LAYERS[0], kv_kind="k", page_id=0, values=good.permute(1, 0, 2)
+        )
+    with pytest.raises(ValueError, match="block dtype"):
+        accessor.write_block(layer_name=LAYERS[0], kv_kind="k", page_id=0, values=good.float())
+    with pytest.raises(ValueError, match="kv_kind"):
+        accessor.write_block(layer_name=LAYERS[0], kv_kind="q", page_id=0, values=good)
+    with pytest.raises(IndexError):
+        accessor.write_block(layer_name=LAYERS[0], kv_kind="k", page_id=NUM_PAGES, values=good)
+    with pytest.raises(KeyError):
+        accessor.write_block(layer_name="nope", kv_kind="k", page_id=0, values=good)
+
+
+def test_transfer_units_accounting():
+    accessor = SpyrePagedKVCacheAccessor(make_kv_caches())
+    units = accessor.transfer_units([0, 1, NUM_PAGES + 5])
+    assert units["unit"] == "page"
+    assert units["unit_shape"] == (NUM_KV_HEADS, BLOCK_SIZE, HEAD_DIM)
+    assert units["units_total"] == len(LAYERS) * 2 * 2
+    assert units["total_nbytes"] == units["units_total"] * units["unit_nbytes"]
+    assert units["invalid_block_ids"] == [NUM_PAGES + 5]
+
+
+def test_describe_reports_layout():
+    desc = SpyrePagedKVCacheAccessor(make_kv_caches()).describe()
+    assert desc["layout"] == "list_of_pages"
+    assert desc["num_layers"] == len(LAYERS)
+    assert desc["num_pages"] == NUM_PAGES
+
+
+def test_accessor_module_has_no_runtime_imports():
+    """The accessor must stay importable without vLLM, NIXL, or torch_spyre."""
+    src = (CONNECTOR_DIR / "spyre_paged_kv_accessor.py").read_text()
+    for forbidden in (
+        "import vllm",
+        "from vllm",
+        "import nixl",
+        "from nixl",
+        "import torch_spyre",
+        "from torch_spyre",
+    ):
+        assert forbidden not in src
+
+
+def test_connector_dispatches_paged_path():
+    """Structural check: connector wires the paged accessor into load/save."""
+    src = (CONNECTOR_DIR / "inmemory_spyre_connector.py").read_text()
+    assert "SpyrePagedKVCacheAccessor.try_from_kv_caches" in src
+    assert "_load_via_paged_accessor" in src
+    assert "def paged_kv_active" in src
+    assert "paged.read_block" in src


### PR DESCRIPTION
Port the Spyre InMemory KV connector surface into spyre_inference, including environment knobs, factory registration, worker registration, and the worker-side connector bridge.

Add a paged KV cache accessor for the Spyre list-of-pages layout while keeping the heap accessor as the fallback for older or unknown cache layouts.

Add a connector-level NIXL smoke harness and focused tests for registration, structure, paged cache access, and split prefill/decode connector behavior.

<!-- markdownlint-disable -->

## Description

<!-- Provide a clear description of your changes. -->

## Related Issues

<!-- Link related issues, e.g., `Fixes #` or `Relates to #456` -->

## Test Plan

<!-- Describe how you tested your changes. Include commands or steps to reproduce. -->

## Checklist

- [ ] I have read the [contributing guidelines](https://torch-spyre.github.io/spyre-inference/contributing/)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
