### PR TITLE
KV connector PR1: add paged KV accessor and config resolvers

### DIFF
--- a/spyre_inference/distributed/kv_transfer/__init__.py
+++ b/spyre_inference/distributed/kv_transfer/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/spyre_inference/distributed/kv_transfer/kv_connector/__init__.py
+++ b/spyre_inference/distributed/kv_transfer/kv_connector/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/spyre_inference/distributed/kv_transfer/kv_connector/v1/__init__.py
+++ b/spyre_inference/distributed/kv_transfer/kv_connector/v1/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/spyre_inference/distributed/kv_transfer/kv_connector/v1/connector_config.py
+++ b/spyre_inference/distributed/kv_transfer/kv_connector/v1/connector_config.py
@@ -1,0 +1,89 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pure resolution of InMemorySpyreConnector runtime settings.
+
+These helpers derive role, NIXL enablement, and the NIXL remote endpoint
+from the two sources the connector accepts:
+
+1. Environment variables (the baked-image/manual deployment path). An
+   explicitly set env var always wins, for backwards compatibility.
+2. vLLM ``kv_transfer_config`` (the ``vllm serve --kv-transfer-config``
+   path): ``kv_role`` for the role, ``kv_connector_extra_config`` for
+   NIXL knobs (``use_nixl``, ``nixl_remote_ip``, ``nixl_port``), and
+   ``kv_ip`` as a remote-IP fallback.
+
+The functions take plain values (no vLLM types) so they unit-test without
+vLLM, NIXL, or AIU installed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+DEFAULT_NIXL_REMOTE_IP = ""
+
+
+def _parse_env_bool(value: str) -> bool:
+    """Match the existing ``bool(int(...))`` env parsing (1/0)."""
+    return bool(int(value))
+
+
+def resolve_kv_role(env_role: str | None, config_role: str | None) -> str:
+    """Non-empty ``VLLM_SPYRE_KV_ROLE`` wins, else config role, else ''."""
+    if env_role:
+        return env_role
+    return config_role or ""
+
+
+def resolve_use_nixl(env_value: str | None, extra_config: dict[str, Any] | None) -> bool:
+    """Explicitly set env wins, else ``extra_config['use_nixl']``, else False.
+
+    ``env_value`` is the raw ``os.environ.get`` result: ``None`` means the
+    env var was not set, so config is consulted.
+    """
+    if env_value is not None:
+        return _parse_env_bool(env_value)
+    if extra_config and "use_nixl" in extra_config:
+        return bool(extra_config["use_nixl"])
+    return False
+
+
+def resolve_nixl_remote_ip(
+    env_value: str | None,
+    extra_config: dict[str, Any] | None,
+    config_ip: str | None,
+    default: str = DEFAULT_NIXL_REMOTE_IP,
+) -> str:
+    """Env override wins, else ``extra_config['nixl_remote_ip']``, else
+    the connector ``kv_ip``, else the caller-supplied default."""
+    if env_value is not None:
+        return env_value
+    if extra_config and extra_config.get("nixl_remote_ip"):
+        return str(extra_config["nixl_remote_ip"])
+    if config_ip:
+        return str(config_ip)
+    return default
+
+
+def resolve_nixl_port(extra_config: dict[str, Any] | None, default: int) -> int:
+    """``extra_config['nixl_port']`` if set, else the module default.
+
+    ``kv_port`` is intentionally not used as a fallback: vLLM auto-assigns
+    it (e.g. 14579), which would silently break the established listen-port
+    contract. Operators wanting a non-default port set ``nixl_port``.
+    """
+    if extra_config and extra_config.get("nixl_port"):
+        return int(extra_config["nixl_port"])
+    return default

--- a/spyre_inference/distributed/kv_transfer/kv_connector/v1/spyre_paged_kv_accessor.py
+++ b/spyre_inference/distributed/kv_transfer/kv_connector/v1/spyre_paged_kv_accessor.py
@@ -1,0 +1,251 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Accessor for the Spyre list-of-pages KV cache used by the KV connector.
+
+The Spyre attention backend allocates each layer's KV cache as
+``SpyrePagedKVCache(k_pages, v_pages)`` — a NamedTuple of two equal-length
+lists of per-page tensors of shape ``[num_kv_heads, block_size, head_size]``
+(see ``spyre_inference/v1/attention/backends/spyre_attn.py``). vLLM's
+``bind_kv_cache`` relays those objects through a dict typed
+``dict[str, torch.Tensor]``, so the connector receives page lists where it
+nominally expects monolithic tensors.
+
+This module bridges that gap without importing vLLM, NIXL, or torch_spyre:
+it detects the page-list layout, exposes geometry, and reads/writes whole
+pages in the same block convention as the heap accessor
+(``[block_size, num_kv_heads, head_size]`` on CPU), so the connector's
+staging store interoperates with both paths.
+"""
+
+from __future__ import annotations
+
+from itertools import chain
+from typing import Any
+
+import torch
+
+# Per-page tensor rank in the Spyre paged layout
+# [num_kv_heads, block_size, head_size].
+_PAGE_RANK = 3
+
+
+def is_paged_layer_cache(layer_cache: Any) -> bool:
+    """Return True iff ``layer_cache`` looks like ``(k_pages, v_pages)``.
+
+    Accepts plain tuples/lists of two non-empty equal-length page lists of
+    3-D tensors, as well as the typed ``SpyrePagedKVCache`` NamedTuple
+    (which is a tuple at runtime). Plain staging tensors return False.
+    """
+    if isinstance(layer_cache, torch.Tensor):
+        return False
+    if not isinstance(layer_cache, (tuple, list)) or len(layer_cache) != 2:
+        return False
+    k_pages, v_pages = layer_cache
+    if not isinstance(k_pages, list) or not isinstance(v_pages, list):
+        return False
+    if not k_pages or len(k_pages) != len(v_pages):
+        return False
+    return all(
+        isinstance(page, torch.Tensor) and page.dim() == _PAGE_RANK
+        for page in chain(k_pages, v_pages)
+    )
+
+
+class SpyrePagedKVCacheAccessor:
+    """Uniform page read/write access over per-layer Spyre page lists.
+
+    Geometry (layers, pages, heads, block size, head dim, dtype, device) is
+    inferred from the registered cache objects — nothing is hard-coded.
+    Block tensors cross this boundary in the heap-accessor convention
+    ``[block_size, num_kv_heads, head_size]`` on CPU; pages stay in their
+    native ``[num_kv_heads, block_size, head_size]`` layout on their device.
+    """
+
+    def __init__(self, layer_caches: dict[str, Any]) -> None:
+        if not layer_caches:
+            raise ValueError("No layer caches provided")
+
+        self._layer_names = sorted(layer_caches)
+        self._caches: dict[str, tuple[list[torch.Tensor], list[torch.Tensor]]] = {}
+
+        ref_shape: tuple[int, ...] | None = None
+        ref_dtype: torch.dtype | None = None
+        ref_device: torch.device | None = None
+        ref_pages: int | None = None
+        for name in self._layer_names:
+            cache = layer_caches[name]
+            if not is_paged_layer_cache(cache):
+                raise ValueError(f"Layer {name!r} is not a (k_pages, v_pages) page list")
+            k_pages, v_pages = cache
+            for page in chain(k_pages, v_pages):
+                shape = tuple(page.shape)
+                if ref_shape is None:
+                    ref_shape, ref_dtype, ref_device = shape, page.dtype, page.device
+                elif shape != ref_shape or page.dtype != ref_dtype or page.device != ref_device:
+                    raise ValueError(
+                        f"Inconsistent page geometry: layer {name!r} has "
+                        f"{shape}/{page.dtype}/{page.device}, "
+                        f"expected {ref_shape}/{ref_dtype}/{ref_device}"
+                    )
+            if ref_pages is None:
+                ref_pages = len(k_pages)
+            elif len(k_pages) != ref_pages:
+                raise ValueError(f"Layer {name!r} has {len(k_pages)} pages, expected {ref_pages}")
+            self._caches[name] = (k_pages, v_pages)
+
+        assert (
+            ref_shape is not None
+            and ref_dtype is not None
+            and ref_device is not None
+            and ref_pages is not None
+        )
+        self._num_kv_heads, self._block_size, self._head_dim = ref_shape
+        self._dtype = ref_dtype
+        self._num_pages = ref_pages
+        self._device = ref_device
+
+    @classmethod
+    def try_from_kv_caches(cls, kv_caches: dict[str, Any]) -> SpyrePagedKVCacheAccessor | None:
+        """Build an accessor if every registered layer is a page list."""
+        if not kv_caches:
+            return None
+        if not all(is_paged_layer_cache(c) for c in kv_caches.values()):
+            return None
+        return cls(kv_caches)
+
+    @property
+    def layer_names(self) -> list[str]:
+        return list(self._layer_names)
+
+    @property
+    def num_layers(self) -> int:
+        return len(self._layer_names)
+
+    @property
+    def num_pages(self) -> int:
+        return self._num_pages
+
+    @property
+    def num_kv_heads(self) -> int:
+        return self._num_kv_heads
+
+    @property
+    def block_size(self) -> int:
+        return self._block_size
+
+    @property
+    def head_dim(self) -> int:
+        return self._head_dim
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self._dtype
+
+    @property
+    def device(self) -> torch.device:
+        return self._device
+
+    @property
+    def page_shape(self) -> tuple[int, int, int]:
+        return (self._num_kv_heads, self._block_size, self._head_dim)
+
+    @property
+    def block_shape(self) -> tuple[int, int, int]:
+        return (self._block_size, self._num_kv_heads, self._head_dim)
+
+    @property
+    def page_nbytes(self) -> int:
+        return (
+            self._num_kv_heads
+            * self._block_size
+            * self._head_dim
+            * torch.tensor([], dtype=self._dtype).element_size()
+        )
+
+    def _pages(self, layer_name: str, kv_kind: str) -> list[torch.Tensor]:
+        kind = kv_kind.lower()
+        if kind not in ("k", "v"):
+            raise ValueError(f"kv_kind must be 'k' or 'v', got {kv_kind!r}")
+        try:
+            cache = self._caches[layer_name]
+        except KeyError:
+            raise KeyError(f"Unknown layer {layer_name!r}") from None
+        return cache[0] if kind == "k" else cache[1]
+
+    def page(self, layer_name: str, kv_kind: str, page_id: int) -> torch.Tensor:
+        """Native page tensor [num_kv_heads, block_size, head_size], in place."""
+        pages = self._pages(layer_name, kv_kind)
+        if not 0 <= page_id < self._num_pages:
+            raise IndexError(f"page_id {page_id} out of range [0, {self._num_pages})")
+        return pages[page_id]
+
+    def validate_block(self, values: torch.Tensor) -> None:
+        if tuple(values.shape) != self.block_shape:
+            raise ValueError(
+                f"Expected block tensor shape {self.block_shape}, got {tuple(values.shape)}"
+            )
+        if values.dtype != self._dtype:
+            raise ValueError(f"Expected block dtype {self._dtype}, got {values.dtype}")
+
+    def read_block(self, *, layer_name: str, kv_kind: str, page_id: int) -> torch.Tensor:
+        """Copy one page to CPU as [block_size, num_kv_heads, head_size]."""
+        page = self.page(layer_name, kv_kind, page_id)
+        return page.to("cpu").permute(1, 0, 2).contiguous()
+
+    def write_block(
+        self,
+        *,
+        layer_name: str,
+        kv_kind: str,
+        page_id: int,
+        values: torch.Tensor,
+    ) -> None:
+        """Overwrite one page from a CPU block [block_size, num_kv_heads, head_size].
+
+        The full page is replaced in one device copy; pages are never sliced
+        (Spyre slicing of device tensors is unreliable — see spyre_attn.py).
+        """
+        self.validate_block(values)
+        page = self.page(layer_name, kv_kind, page_id)
+        page.copy_(values.permute(1, 0, 2).contiguous().to(page.device))
+
+    def transfer_units(self, block_ids: list[int]) -> dict[str, Any]:
+        """Describe the per-page transfer units for a set of block ids.
+
+        One unit per (layer, kind, page): the page granularity NIXL or any
+        future transport must use, since pages are independent allocations
+        with no contiguous [num_pages, ...] buffer to address.
+        """
+        valid = [b for b in block_ids if 0 <= b < self._num_pages]
+        units = self.num_layers * 2 * len(valid)
+        return {
+            "unit": "page",
+            "unit_shape": self.page_shape,
+            "unit_nbytes": self.page_nbytes,
+            "units_total": units,
+            "total_nbytes": units * self.page_nbytes,
+            "invalid_block_ids": [b for b in block_ids if b not in valid],
+        }
+
+    def describe(self) -> dict[str, Any]:
+        return {
+            "layout": "list_of_pages",
+            "num_layers": self.num_layers,
+            "num_pages": self._num_pages,
+            "page_shape": self.page_shape,
+            "dtype": str(self._dtype),
+            "device": str(self._device),
+            "page_nbytes": self.page_nbytes,
+        }

--- a/tests/test_connector_config.py
+++ b/tests/test_connector_config.py
@@ -1,0 +1,98 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for connector setting resolution from env vars and vLLM config.
+
+The pure resolvers are imported by file path so they run without vLLM,
+NIXL, or AIU.
+"""
+
+import importlib.util
+import pathlib
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+CONNECTOR_DIR = REPO / "spyre_inference" / "distributed" / "kv_transfer" / "kv_connector" / "v1"
+
+
+def _load_by_path(name: str, path: pathlib.Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+cfg = _load_by_path("connector_config", CONNECTOR_DIR / "connector_config.py")
+
+
+# --- role -------------------------------------------------------------------
+
+
+def test_role_from_config_when_no_env():
+    assert cfg.resolve_kv_role(None, "kv_producer") == "kv_producer"
+    assert cfg.resolve_kv_role(None, "kv_consumer") == "kv_consumer"
+
+
+def test_role_empty_env_falls_back_to_config():
+    # An empty (but present) env var is not an override.
+    assert cfg.resolve_kv_role("", "kv_consumer") == "kv_consumer"
+
+
+def test_role_env_overrides_config():
+    assert cfg.resolve_kv_role("kv_consumer", "kv_producer") == "kv_consumer"
+
+
+def test_role_default_empty():
+    assert cfg.resolve_kv_role(None, None) == ""
+    assert cfg.resolve_kv_role("", None) == ""
+
+
+# --- use_nixl ---------------------------------------------------------------
+
+
+def test_use_nixl_from_config_when_no_env():
+    assert cfg.resolve_use_nixl(None, {"use_nixl": True}) is True
+    assert cfg.resolve_use_nixl(None, {"use_nixl": False}) is False
+
+
+def test_use_nixl_defaults_false():
+    assert cfg.resolve_use_nixl(None, None) is False
+    assert cfg.resolve_use_nixl(None, {}) is False
+
+
+def test_use_nixl_env_overrides_config():
+    assert cfg.resolve_use_nixl("1", {"use_nixl": False}) is True
+    assert cfg.resolve_use_nixl("0", {"use_nixl": True}) is False
+
+
+# --- remote ip / port -------------------------------------------------------
+
+
+def test_remote_ip_env_overrides_all():
+    assert (
+        cfg.resolve_nixl_remote_ip("1.2.3.4", {"nixl_remote_ip": "5.6.7.8"}, "9.9.9.9") == "1.2.3.4"
+    )
+
+
+def test_remote_ip_extra_config_then_kv_ip_then_default():
+    assert cfg.resolve_nixl_remote_ip(None, {"nixl_remote_ip": "5.6.7.8"}, "9.9.9.9") == "5.6.7.8"
+    assert cfg.resolve_nixl_remote_ip(None, {}, "9.9.9.9") == "9.9.9.9"
+    assert cfg.resolve_nixl_remote_ip(None, None, None) == cfg.DEFAULT_NIXL_REMOTE_IP
+    assert cfg.DEFAULT_NIXL_REMOTE_IP == ""
+
+
+def test_port_extra_config_else_default():
+    assert cfg.resolve_nixl_port({"nixl_port": 9200}, 9100) == 9200
+    assert cfg.resolve_nixl_port({}, 9100) == 9100
+    assert cfg.resolve_nixl_port(None, 9100) == 9100

--- a/tests/test_paged_kv_accessor.py
+++ b/tests/test_paged_kv_accessor.py
@@ -1,0 +1,192 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for SpyrePagedKVCacheAccessor with fake CPU page lists.
+
+These run without vLLM, NIXL, or AIU hardware: the accessor only needs
+torch tensors shaped like the Spyre list-of-pages KV cache
+([num_kv_heads, block_size, head_size] per page).
+"""
+
+import importlib.util
+import pathlib
+from typing import NamedTuple
+
+import pytest
+
+torch = pytest.importorskip("torch", reason="torch required for paged accessor tests")
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+CONNECTOR_DIR = REPO / "spyre_inference" / "distributed" / "kv_transfer" / "kv_connector" / "v1"
+
+# Load by file path: the accessor module is vLLM-free, but importing it through
+# the spyre_inference package would pull vLLM in via spyre_inference/__init__.py.
+_spec = importlib.util.spec_from_file_location(
+    "spyre_paged_kv_accessor", CONNECTOR_DIR / "spyre_paged_kv_accessor.py"
+)
+assert _spec is not None and _spec.loader is not None
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+SpyrePagedKVCacheAccessor = _mod.SpyrePagedKVCacheAccessor
+is_paged_layer_cache = _mod.is_paged_layer_cache
+
+NUM_KV_HEADS = 2
+BLOCK_SIZE = 4
+HEAD_DIM = 8
+NUM_PAGES = 3
+LAYERS = ["model.layers.0.attn", "model.layers.1.attn"]
+
+
+class FakeSpyrePagedKVCache(NamedTuple):
+    """Tuple-compatible stand-in for spyre_attn.SpyrePagedKVCache."""
+
+    k_pages: list[torch.Tensor]
+    v_pages: list[torch.Tensor]
+
+
+def make_pages(fill: float = 0.0) -> list[torch.Tensor]:
+    return [
+        torch.full((NUM_KV_HEADS, BLOCK_SIZE, HEAD_DIM), fill, dtype=torch.float16)
+        for _ in range(NUM_PAGES)
+    ]
+
+
+def make_kv_caches() -> dict[str, FakeSpyrePagedKVCache]:
+    return {
+        name: FakeSpyrePagedKVCache(k_pages=make_pages(), v_pages=make_pages()) for name in LAYERS
+    }
+
+
+def test_is_paged_layer_cache_detects_page_lists():
+    assert is_paged_layer_cache((make_pages(), make_pages()))
+    assert is_paged_layer_cache(FakeSpyrePagedKVCache(make_pages(), make_pages()))
+
+
+def test_is_paged_layer_cache_rejects_other_layouts():
+    staging = torch.zeros(2, NUM_PAGES, BLOCK_SIZE, NUM_KV_HEADS, HEAD_DIM)
+    pages_with_bad_later_page = make_pages()
+    pages_with_bad_later_page[-1] = torch.zeros(NUM_KV_HEADS, BLOCK_SIZE)
+    assert not is_paged_layer_cache(staging)
+    assert not is_paged_layer_cache(None)
+    assert not is_paged_layer_cache(([], []))
+    assert not is_paged_layer_cache((make_pages(), make_pages()[:-1]))
+    assert not is_paged_layer_cache((make_pages()[0], make_pages()[0]))
+    assert not is_paged_layer_cache((pages_with_bad_later_page, make_pages()))
+
+
+def test_try_from_kv_caches_infers_geometry():
+    accessor = SpyrePagedKVCacheAccessor.try_from_kv_caches(make_kv_caches())
+    assert accessor is not None
+    assert accessor.num_layers == len(LAYERS)
+    assert accessor.layer_names == sorted(LAYERS)
+    assert accessor.num_pages == NUM_PAGES
+    assert accessor.num_kv_heads == NUM_KV_HEADS
+    assert accessor.block_size == BLOCK_SIZE
+    assert accessor.head_dim == HEAD_DIM
+    assert accessor.dtype == torch.float16
+    assert accessor.page_shape == (NUM_KV_HEADS, BLOCK_SIZE, HEAD_DIM)
+    assert accessor.block_shape == (BLOCK_SIZE, NUM_KV_HEADS, HEAD_DIM)
+    assert accessor.page_nbytes == NUM_KV_HEADS * BLOCK_SIZE * HEAD_DIM * 2
+
+
+def test_try_from_kv_caches_returns_none_for_staging_tensors():
+    staging = {"layer": torch.zeros(2, NUM_PAGES, BLOCK_SIZE, NUM_KV_HEADS, HEAD_DIM)}
+    assert SpyrePagedKVCacheAccessor.try_from_kv_caches(staging) is None
+    assert SpyrePagedKVCacheAccessor.try_from_kv_caches({}) is None
+
+
+def test_inconsistent_geometry_rejected():
+    caches = make_kv_caches()
+    caches[LAYERS[1]].k_pages[0] = torch.zeros(
+        NUM_KV_HEADS, BLOCK_SIZE * 2, HEAD_DIM, dtype=torch.float16
+    )
+    with pytest.raises(ValueError, match="Inconsistent page geometry"):
+        SpyrePagedKVCacheAccessor(caches)
+
+
+def test_inconsistent_later_page_geometry_rejected():
+    caches = make_kv_caches()
+    caches[LAYERS[0]].v_pages[-1] = torch.zeros(
+        NUM_KV_HEADS, BLOCK_SIZE, HEAD_DIM, dtype=torch.float32
+    )
+    with pytest.raises(ValueError, match="Inconsistent page geometry"):
+        SpyrePagedKVCacheAccessor(caches)
+
+
+def test_write_then_read_block_roundtrip():
+    caches = make_kv_caches()
+    accessor = SpyrePagedKVCacheAccessor(caches)
+    block = torch.arange(BLOCK_SIZE * NUM_KV_HEADS * HEAD_DIM, dtype=torch.float16).reshape(
+        BLOCK_SIZE, NUM_KV_HEADS, HEAD_DIM
+    )
+
+    accessor.write_block(layer_name=LAYERS[0], kv_kind="k", page_id=1, values=block)
+
+    assert torch.equal(accessor.read_block(layer_name=LAYERS[0], kv_kind="k", page_id=1), block)
+    # The write landed in the registered page tensor, permuted to page layout.
+    assert torch.equal(caches[LAYERS[0]].k_pages[1], block.permute(1, 0, 2))
+    # Other pages, kinds, and layers stay untouched.
+    assert caches[LAYERS[0]].k_pages[0].abs().sum() == 0
+    assert caches[LAYERS[0]].v_pages[1].abs().sum() == 0
+    assert caches[LAYERS[1]].k_pages[1].abs().sum() == 0
+
+
+def test_write_block_validates_shape_dtype_kind_and_range():
+    accessor = SpyrePagedKVCacheAccessor(make_kv_caches())
+    good = torch.zeros(BLOCK_SIZE, NUM_KV_HEADS, HEAD_DIM, dtype=torch.float16)
+
+    with pytest.raises(ValueError, match="block tensor shape"):
+        accessor.write_block(
+            layer_name=LAYERS[0], kv_kind="k", page_id=0, values=good.permute(1, 0, 2)
+        )
+    with pytest.raises(ValueError, match="block dtype"):
+        accessor.write_block(layer_name=LAYERS[0], kv_kind="k", page_id=0, values=good.float())
+    with pytest.raises(ValueError, match="kv_kind"):
+        accessor.write_block(layer_name=LAYERS[0], kv_kind="q", page_id=0, values=good)
+    with pytest.raises(IndexError):
+        accessor.write_block(layer_name=LAYERS[0], kv_kind="k", page_id=NUM_PAGES, values=good)
+    with pytest.raises(KeyError):
+        accessor.write_block(layer_name="nope", kv_kind="k", page_id=0, values=good)
+
+
+def test_transfer_units_accounting():
+    accessor = SpyrePagedKVCacheAccessor(make_kv_caches())
+    units = accessor.transfer_units([0, 1, NUM_PAGES + 5])
+    assert units["unit"] == "page"
+    assert units["unit_shape"] == (NUM_KV_HEADS, BLOCK_SIZE, HEAD_DIM)
+    assert units["units_total"] == len(LAYERS) * 2 * 2
+    assert units["total_nbytes"] == units["units_total"] * units["unit_nbytes"]
+    assert units["invalid_block_ids"] == [NUM_PAGES + 5]
+
+
+def test_describe_reports_layout():
+    desc = SpyrePagedKVCacheAccessor(make_kv_caches()).describe()
+    assert desc["layout"] == "list_of_pages"
+    assert desc["num_layers"] == len(LAYERS)
+    assert desc["num_pages"] == NUM_PAGES
+
+
+def test_accessor_module_has_no_runtime_imports():
+    """The accessor must stay importable without vLLM, NIXL, or torch_spyre."""
+    src = (CONNECTOR_DIR / "spyre_paged_kv_accessor.py").read_text()
+    for forbidden in (
+        "import vllm",
+        "from vllm",
+        "import nixl",
+        "from nixl",
+        "import torch_spyre",
+        "from torch_spyre",
+    ):
+        assert forbidden not in src


### PR DESCRIPTION

<!-- markdownlint-disable -->

## Description

Adds the first small foundation slice for the Spyre paged KV connector work.

This PR includes only standalone, dependency-light building blocks:

- `SpyrePagedKVCacheAccessor`, a torch-only accessor for the Spyre list-of-pages KV cache layout.
- Pure config resolver helpers for connector role, NIXL enablement, remote IP, and NIXL port.
- Minimal package scaffolding under `spyre_inference/distributed/kv_transfer/kv_connector/v1/`.
- Focused unit tests for the accessor and config resolvers.

This PR intentionally does not include the connector class, registration hooks, store backends, heap KV path, NIXL transfer path, smoke examples, or user-facing connector docs. Those are intended to follow in later, smaller PRs.

## Related Issues

Relates to the Spyre paged KV connector / PD disaggregation work.

## Test Plan

```bash
python3 -m compileall -q \
  spyre_inference/distributed/kv_transfer \
  tests/test_paged_kv_accessor.py \
  tests/test_connector_config.py

uvx --with torch pytest \
  tests/test_paged_kv_accessor.py \
  tests/test_connector_config.py \
  -q

PATH="$HOME/.local/bin:$PATH" ./format.sh
```

Results:

- `compileall`: passed
- targeted pytest: `21 passed`
- `./format.sh`: passed

## Checklist

- [x] I have read the [[contributing guidelines](https://torch-spyre.github.io/spyre-inference/contributing/)](https://torch-spyre.github.io/spyre-inference/contributing/)
- [x] My code follows the project's code style (run `bash format.sh`)
- [x] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
