### PR TITLE
docs(claude-comments): add code style and comment guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,3 +205,8 @@ When exploring a new feature area (e.g., FP8 quantization, new operators, hardwa
 - **Type hints**: Ignore `possibly-missing-attribute` (ty)
 - **Excluded from ty**: `spyre_inference/__init__.py`
 - **Codespell**: Ignore list includes `dout, te, indicies, subtile, ElementE`
+- **Minimize comments**: Code should be self-explanatory; add comments only for global context or non-obvious reasoning
+- **Avoid trivial helpers**: Don't create 1-2 LOC functions used only once
+- **Match existing style**: Follow established code patterns and architectural conventions
+- **ASCII only in comments**: No Unicode characters in newly added code comments
+- **Prefer simplicity**: When uncertain, choose the simpler, more concise implementation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,6 +208,5 @@ When exploring a new feature area (e.g., FP8 quantization, new operators, hardwa
 - **Minimize comments**: Code should be self-explanatory; add comments only for global context or non-obvious reasoning
 - **Avoid trivial helpers**: Don't create 1-2 LOC functions used only once
 - **Match existing style**: Follow established code patterns and architectural conventions
-- **ASCII only in comments**: No Unicode characters in newly added code comments
 - **Prefer simplicity**: When uncertain, choose the simpler, more concise implementation
 - **Assume vLLM familiarity**: The reader may not be an expert on the specific code being read, but should have general experience with vLLM

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,3 +210,4 @@ When exploring a new feature area (e.g., FP8 quantization, new operators, hardwa
 - **Match existing style**: Follow established code patterns and architectural conventions
 - **ASCII only in comments**: No Unicode characters in newly added code comments
 - **Prefer simplicity**: When uncertain, choose the simpler, more concise implementation
+- **Assume vLLM familiarity**: The reader may not be an expert on the specific code being read, but should have general experience with vLLM


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Add instructions to CLAUDE.md to steer agent-assisted contributions away from inserting excessively long comments and docstrings.

Adapted from PyTorch's CLAUDE.md: https://github.com/pytorch/pytorch/blob/main/CLAUDE.md#coding-style-guidelines

## Related Issues

N/A

## Test Plan

N/A

## Checklist

- [x] I have read the [contributing guidelines](https://torch-spyre.github.io/spyre-inference/contributing/)
- [x] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
