### PR TITLE
feat: expand upstream test coverage with model e2e

### DIFF
--- a/.github/workflows/test_each_commit.yaml
+++ b/.github/workflows/test_each_commit.yaml
@@ -67,7 +67,15 @@ jobs:
               - linux
               - image_spyre_inference
             flags: >-
-              -m upstream
+              -m "upstream and not distributed"
+          - cfg: Upstream distributed vLLM tests
+            runs_on:
+              - x86_64
+              - spyre_pf_x2__pvc_1tb_x1
+              - linux
+              - image_spyre_inference
+            flags: >-
+              -m "upstream and distributed"
     runs-on: ${{ matrix.runs_on }}
     timeout-minutes: 720
     env:

--- a/tests/plugin/spyre_testing_plugin/models.py
+++ b/tests/plugin/spyre_testing_plugin/models.py
@@ -67,7 +67,7 @@ class AllowEntry:
 
     Attributes:
         test:            fnmatch glob matched against the test function name.
-        mode:            mandatory_pass | xfail | xfail_strict.
+        mode:            mandatory_pass | skip | xfail | xfail_strict.
         tags:            Free-form labels for traceability (no runtime effect).
         param_skips:     Parameter combinations to skip within this test.
         param_allows:    Parameter combinations to allow (whitelist). If specified,

--- a/tests/plugin/spyre_testing_plugin/pytest_plugin.py
+++ b/tests/plugin/spyre_testing_plugin/pytest_plugin.py
@@ -545,6 +545,10 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
             item.add_marker(pytest.mark.skip(reason="param skipped"))
             continue
 
+        if allow_entry.mode == "skip":
+            item.add_marker(pytest.mark.skip(reason=f"skipped by {_YAML_FILENAME}"))
+            continue
+
         if allow_entry.mode == "xfail":
             item.add_marker(pytest.mark.xfail(strict=False))
         elif allow_entry.mode == "xfail_strict":

--- a/tests/plugin/spyre_testing_plugin/upstream_tests.yaml
+++ b/tests/plugin/spyre_testing_plugin/upstream_tests.yaml
@@ -27,19 +27,19 @@ tests:
   files:
     # RMSNorm tests require either https://github.com/vllm-project/vllm/pull/36246 or vLLM IR
     # changes to merge in order to pass
-    # - rel_path: tests/kernels/core/test_layernorm.py
-    #   allow_list:
-    #     - test: "test_rms_norm"
-    #       mode: mandatory_pass
-    #       tags: [rmsnorm, upstream]
-    #       params:
-    #         skip:
-    #           strided_input: [true]
-    #         override:
-    #           num_tokens: [1, 16]
-    #           hidden_size: [64]
-    #   block_list:
-    #     - test: "test_fused_rms_norm_quant"
+    - rel_path: tests/kernels/core/test_layernorm.py
+      allow_list:
+        - test: "test_rms_norm"
+          mode: xfail
+          tags: [rmsnorm, upstream]
+          params:
+            skip:
+              strided_input: [true]
+            override:
+              num_tokens: [1, 16]
+              hidden_size: [64]
+      block_list:
+        - test: "test_fused_rms_norm_quant"
     - rel_path: tests/kernels/core/test_activation.py
       allow_list:
         - test: "test_act_and_mul"
@@ -59,17 +59,20 @@ tests:
             rtol: 1e-2
 
     # Model tests are now failing too :(
-    # - rel_path: tests/models/language/generation/test_common.py
-    #   allow_list:
-    #     - test: "test_models"
-    #       mode: mandatory_pass
-    #       # uses_subprocess marker is added to make these tests run first.
-    #       # This must be added for any sets of tests that use `vllm.LLM`
-    #       tags: [facebook, upstream, uses_subprocess]
-    #       params:
-    #         allow:  # skip every model except facebook/opt-125m
-    #           model:
-    #           - facebook/opt-125m
+    - rel_path: tests/models/language/generation/test_common.py
+      allow_list:
+        - test: "test_models"
+          mode: xfail
+          # uses_subprocess marker is added to make these tests run first.
+          # This must be added for any sets of tests that use `vllm.LLM`
+          tags: [upstream, uses_subprocess]
+          params:
+            override:
+              model:
+                - facebook/opt-125m
+                - ibm-granite/granite-3.3-8b-instruct
+                - ibm-granite/granite-3.3-2b-instruct
+                - Qwen/Qwen3-0.6B
 
     - rel_path: tests/v1/attention/test_attention_backends.py
       allow_list:
@@ -90,5 +93,70 @@ tests:
               - small_prefill
               - mixed_small
           fixture_names:
-          - "patch_backend_list"
+            - "patch_backend_list"
 
+    - rel_path: tests/models/language/generation/test_granite.py
+      allow_list:
+        - test: "test_models"
+          mode: xfail # RAS::VFIO::MapDMAFailed - VFIO kernel module unable to map DMA memory region (errno: No space left on device)
+          tags: [granite, upstream, uses_subprocess]
+          params:
+            override:
+              model:
+                - ibm-granite/granite-3.3-8b-instruct
+                - ibm-granite/granite-3.3-2b-instruct
+              dtype: [torch.float32]
+
+    - rel_path: tests/models/language/generation_ppl_test/test_qwen.py
+      allow_list:
+        - test: "test_ppl"
+          mode: xfail # model_info0 (Qwen3-0.6B): RAS::VFIO::MapDMAFailed; model_info1 (Qwen3-0.6B-FP8): KeyError PlatformEnum.OOT - FP8 quant not supported on Spyre; model_info2 (Qwen3.5-0.8B): Qwen3_5ForConditionalGeneration not in vLLM registry
+          tags: [qwen, generation, upstream, uses_subprocess]
+
+    - rel_path: tests/models/language/pooling/test_embedding.py
+      allow_list:
+        - test: "test_models"
+          mode: xfail # RuntimeError: Spyre backend does not support type conversion yet during copy
+          tags: [embedding, upstream, uses_subprocess]
+          params:
+            allow:
+              model:
+                - BAAI/bge-base-en-v1.5
+
+    - rel_path: tests/models/language/pooling/test_auto_prefix_cache_support.py
+      allow_list:
+        - test: "test_embed_models"
+          mode: xfail # RuntimeError: Spyre backend does not support type conversion yet during copy
+          tags: [embedding, upstream, uses_subprocess]
+          params:
+            override:
+              model: ["BAAI/bge-m3"]
+
+    - rel_path: tests/basic_correctness/test_basic_correctness.py
+      allow_list:
+        - test: "test_models"
+          mode: xfail # RAS::VFIO::MapDMAFailed - VFIO kernel module unable to map DMA memory region (errno: No space left on device) on all models
+          tags: [basic_correctness, upstream, uses_subprocess]
+          params:
+            override:
+              model:
+                [
+                  "Qwen/Qwen3-0.6B",
+                  "ibm-granite/granite-3.3-2b-instruct",
+                  "ibm-granite/granite-3.3-8b-instruct",
+                ]
+              backend: ["CUSTOM"]
+              enforce_eager: [true]
+        - test: "test_models_distributed"
+          mode: xfail
+          tags: [basic_correctness, upstream, uses_subprocess, distributed]
+          params:
+            override:
+              model:
+                [
+                  "Qwen/Qwen3-0.6B",
+                  "ibm-granite/granite-3.3-2b-instruct",
+                  "ibm-granite/granite-3.3-8b-instruct",
+                ]
+              distributed_executor_backend: ["external_launcher"]
+              attention_backend: ["CUSTOM"]

--- a/tests/plugin/spyre_testing_plugin/upstream_tests.yaml
+++ b/tests/plugin/spyre_testing_plugin/upstream_tests.yaml
@@ -8,7 +8,7 @@
 # Fields:
 #   rel_path          Path relative to upstream vLLM repo root
 #   allow_list[].test fnmatch glob matched against test function name
-#   allow_list[].mode mandatory_pass (default) | xfail | xfail_strict
+#   allow_list[].mode mandatory_pass (default) | skip | skip | skip_strict
 #   allow_list[].tags Labels applied as pytest markers (filterable via -m)
 #   allow_list[].params.skip
 #                     Parameter name -> list of values to skip
@@ -30,7 +30,7 @@ tests:
     - rel_path: tests/kernels/core/test_layernorm.py
       allow_list:
         - test: "test_rms_norm"
-          mode: xfail
+          mode: skip
           tags: [rmsnorm, upstream]
           params:
             skip:
@@ -40,6 +40,7 @@ tests:
               hidden_size: [64]
       block_list:
         - test: "test_fused_rms_norm_quant"
+
     - rel_path: tests/kernels/core/test_activation.py
       allow_list:
         - test: "test_act_and_mul"
@@ -62,15 +63,14 @@ tests:
     - rel_path: tests/models/language/generation/test_common.py
       allow_list:
         - test: "test_models"
-          mode: xfail
+          mode: skip
           # uses_subprocess marker is added to make these tests run first.
           # This must be added for any sets of tests that use `vllm.LLM`
-          tags: [upstream, uses_subprocess]
+          tags: [model, upstream, uses_subprocess]
           params:
             override:
               model:
                 - facebook/opt-125m
-                - ibm-granite/granite-3.3-8b-instruct
                 - ibm-granite/granite-3.3-2b-instruct
                 - Qwen/Qwen3-0.6B
 
@@ -83,41 +83,40 @@ tests:
           params:
             allow:
               tensor_parallel_size:
-              - 1
-              - 2
-              - 4
+                - 1
+                - 2
+                - 4
               batch_spec_name:
-              - single_decode
-              - single_prefill
-              - small_decode
-              - small_prefill
-              - mixed_small
+                - single_decode
+                - single_prefill
+                - small_decode
+                - small_prefill
+                - mixed_small
           fixture_names:
             - "patch_backend_list"
 
     - rel_path: tests/models/language/generation/test_granite.py
       allow_list:
         - test: "test_models"
-          mode: xfail # RAS::VFIO::MapDMAFailed - VFIO kernel module unable to map DMA memory region (errno: No space left on device)
+          mode: skip # RAS::VFIO::MapDMAFailed - VFIO kernel module unable to map DMA memory region (errno: No space left on device)
           tags: [granite, upstream, uses_subprocess]
           params:
             override:
               model:
-                - ibm-granite/granite-3.3-8b-instruct
                 - ibm-granite/granite-3.3-2b-instruct
               dtype: [torch.float32]
 
     - rel_path: tests/models/language/generation_ppl_test/test_qwen.py
       allow_list:
         - test: "test_ppl"
-          mode: xfail # model_info0 (Qwen3-0.6B): RAS::VFIO::MapDMAFailed; model_info1 (Qwen3-0.6B-FP8): KeyError PlatformEnum.OOT - FP8 quant not supported on Spyre; model_info2 (Qwen3.5-0.8B): Qwen3_5ForConditionalGeneration not in vLLM registry
-          tags: [qwen, generation, upstream, uses_subprocess]
+          mode: skip # model_info0 (Qwen3-0.6B): RAS::VFIO::MapDMAFailed; model_info1 (Qwen3-0.6B-FP8): KeyError PlatformEnum.OOT - FP8 quant not supported on Spyre; model_info2 (Qwen3.5-0.8B): Qwen3_5ForConditionalGeneration not in vLLM registry
+          tags: [model, generation, upstream, uses_subprocess]
 
     - rel_path: tests/models/language/pooling/test_embedding.py
       allow_list:
         - test: "test_models"
-          mode: xfail # RuntimeError: Spyre backend does not support type conversion yet during copy
-          tags: [embedding, upstream, uses_subprocess]
+          mode: skip # RuntimeError: Spyre backend does not support type conversion yet during copy
+          tags: [model, embedding, upstream, uses_subprocess]
           params:
             allow:
               model:
@@ -126,8 +125,8 @@ tests:
     - rel_path: tests/models/language/pooling/test_auto_prefix_cache_support.py
       allow_list:
         - test: "test_embed_models"
-          mode: xfail # RuntimeError: Spyre backend does not support type conversion yet during copy
-          tags: [embedding, upstream, uses_subprocess]
+          mode: skip # RuntimeError: Spyre backend does not support type conversion yet during copy
+          tags: [model, embedding, upstream, uses_subprocess]
           params:
             override:
               model: ["BAAI/bge-m3"]
@@ -135,28 +134,23 @@ tests:
     - rel_path: tests/basic_correctness/test_basic_correctness.py
       allow_list:
         - test: "test_models"
-          mode: xfail # RAS::VFIO::MapDMAFailed - VFIO kernel module unable to map DMA memory region (errno: No space left on device) on all models
-          tags: [basic_correctness, upstream, uses_subprocess]
+          mode: skip # RAS::VFIO::MapDMAFailed - VFIO kernel module unable to map DMA memory region (errno: No space left on device) on all models
+          tags: [model, basic_correctness, upstream, uses_subprocess]
           params:
             override:
               model:
-                [
-                  "Qwen/Qwen3-0.6B",
-                  "ibm-granite/granite-3.3-2b-instruct",
-                  "ibm-granite/granite-3.3-8b-instruct",
-                ]
+                - Qwen/Qwen3-0.6B
+                - ibm-granite/granite-3.3-2b-instruct
               backend: ["CUSTOM"]
               enforce_eager: [true]
         - test: "test_models_distributed"
-          mode: xfail
-          tags: [basic_correctness, upstream, uses_subprocess, distributed]
+          mode: skip
+          tags:
+            [model, basic_correctness, upstream, uses_subprocess, distributed]
           params:
             override:
               model:
-                [
-                  "Qwen/Qwen3-0.6B",
-                  "ibm-granite/granite-3.3-2b-instruct",
-                  "ibm-granite/granite-3.3-8b-instruct",
-                ]
+                - Qwen/Qwen3-0.6B
+                - ibm-granite/granite-3.3-2b-instruct
               distributed_executor_backend: ["external_launcher"]
               attention_backend: ["CUSTOM"]


### PR DESCRIPTION
This PR attempts to add some more tests from upstream vLLM targetting e2e support testing. For now unsupported tests are marked `skip`