### PR TITLE
:test_tube: expand upstream attn tests

### DIFF
--- a/tests/plugin/spyre_testing_plugin/upstream_tests.yaml
+++ b/tests/plugin/spyre_testing_plugin/upstream_tests.yaml
@@ -77,12 +77,17 @@ tests:
           mode: mandatory_pass
           tags: [attention, upstream]
           params:
-            allow:  # We only support TP=1, BS=1
+            allow:
               tensor_parallel_size:
               - 1
+              - 2
+              - 4
               batch_spec_name:
               - single_decode
               - single_prefill
+              - small_decode
+              - small_prefill
+              - mixed_small
           fixture_names:
           - "patch_backend_list"
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

This simply expands the test cases for the upstream attention tests. We hadn't yet enabled either the cases with batch size > 1 or TP > 1, all of which now work. (These don't actually run in tensor parallel, but do check the sharded attention math).

## Related Issues

N/A, just pushing up the coverage

## Test Plan

<!-- Describe how you tested your changes. Include commands or steps to reproduce. -->

## Checklist

- [ ] I have read the [contributing guidelines](https://torch-spyre.github.io/spyre-inference/contributing/)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
