### PR TITLE
cicd: add spyre-inference integration dispatch

### DIFF
--- a/.github/actions/build-spyre-deps/action.yml
+++ b/.github/actions/build-spyre-deps/action.yml
@@ -1,0 +1,93 @@
+name: Build torch-spyre and download RPMS from dispatch
+description: >
+  Install torch-spyre from source checking out the given reference 
+  Download and install spyre RPMs
+  This action is meant for integration dispatch events.
+
+inputs:
+  rpm_names:
+    description: A space separated list of RPM names to download and install
+    required: true
+  rpm_location:
+    description: |
+      Full Artifactory URL to download RPMs from (e.g.
+      https://artifactory.example.com/path/to/rpms). When set, overrides the
+      ARTIFACTORY_BASE_URL + ARTIFACTORY_RPM_PATH secrets.
+    required: false
+    default: ''
+  torch_spyre_ref:
+    description: Branch, tag, or SHA of torch-spyre to check out and test
+    required: false
+    default: ''
+  artifactory_user:
+    description: Artifactory username
+    required: false
+    default: ''
+  artifactory_api_key:
+    description: Artifactory API key
+    required: false
+    default: ''
+  artifactory_base_url:
+    description: Artifactory base URL
+    required: false
+    default: ''
+  artifactory_rpm_path:
+    description: Artifactory RPM path
+    required: false
+    default: ''
+
+
+runs:
+  using: composite
+  steps:
+    - name: Download RPMs
+      if: ${{ inputs.rpm_names != '' }}
+      shell: bash
+      env:
+        ARTIFACTORY_USER: ${{ inputs.artifactory_user }}
+        ARTIFACTORY_API_KEY: ${{ inputs.artifactory_api_key }}
+        ARTIFACTORY_BASE_URL: ${{ inputs.artifactory_base_url }}
+        ARTIFACTORY_RPM_PATH: ${{ inputs.artifactory_rpm_path }}
+        ARTIFACTORY_LOCATION: ${{ inputs.rpm_location }}
+        DOWNLOAD_SCRIPT: .github/scripts/download_rpms.sh
+        RPM_NAMES: ${{ inputs.rpm_names }}
+        RPMS_DOWNLOAD_DIR: ${{ inputs.output_dir }}
+      run: |
+        source "$HOME/.bashrc"
+        source /etc/profile.d/ibm-aiu-setup.sh
+        cd /home/senuser/torch-spyre
+        ls -la "$DOWNLOAD_SCRIPT"
+        "$DOWNLOAD_SCRIPT"
+
+    - name: Install RPMs
+      if: ${{ inputs.rpm_names != '' }}
+      shell: bash
+      run: |
+        cd /home/senuser/torch-spyre
+        ls -la rpms/
+        sudo dnf install -y rpms/*.rpm
+
+    - name: Checkout torch-spyre
+      shell: bash
+      working-directory: /home/senuser
+      env:
+        INPUT_REF: "${{ inputs.torch_spyre_ref }}"
+      run: |
+        source "$HOME/.bashrc"
+        source /etc/profile.d/ibm-aiu-setup.sh
+        git config --global --add safe.directory '*'
+        if [[ -n "$INPUT_REF" ]]; then
+          cd /home/senuser/torch-spyre
+          TARGET_SHA="$INPUT_REF"
+          TARGET_REF="$INPUT_REF"
+          echo "TARGET_REF=${TARGET_REF}"
+          echo "TARGET_SHA=${TARGET_SHA}"
+          git fetch --tags --force origin "+${TARGET_SHA}" || \
+            git fetch --tags --force origin
+          git checkout --force "${TARGET_SHA}"
+          git submodule sync --recursive
+          git submodule update --init --recursive --force
+          git log -1 --oneline
+        fi
+        uv pip show torch
+        uv pip freeze

--- a/.github/actions/build-spyre-deps/action.yml
+++ b/.github/actions/build-spyre-deps/action.yml
@@ -71,15 +71,15 @@ runs:
       shell: bash
       working-directory: /home/senuser
       env:
-        INPUT_REF: "${{ inputs.torch_spyre_ref }}"
+        TORCH_SPYRE_REF: "${{ inputs.torch_spyre_ref }}"
       run: |
         source "$HOME/.bashrc"
         source /etc/profile.d/ibm-aiu-setup.sh
         git config --global --add safe.directory '*'
-        if [[ -n "$INPUT_REF" ]]; then
+        if [[ -n "$TORCH_SPYRE_REF" ]]; then
           cd /home/senuser/torch-spyre
-          TARGET_SHA="$INPUT_REF"
-          TARGET_REF="$INPUT_REF"
+          TARGET_SHA="$TORCH_SPYRE_REF"
+          TARGET_REF="$TORCH_SPYRE_REF"
           echo "TARGET_REF=${TARGET_REF}"
           echo "TARGET_SHA=${TARGET_SHA}"
           git fetch --tags --force origin "+${TARGET_SHA}" || \

--- a/.github/workflows/test_each_commit.yaml
+++ b/.github/workflows/test_each_commit.yaml
@@ -128,11 +128,11 @@ jobs:
 
       - name: Build spyre-inference
         env:
-          INPUT_REF: "${{ inputs.torch_spyre_ref }}"
+          TORCH_SPYRE_REF: "${{ inputs.torch_spyre_ref }}"
         run: |
           source "$HOME/.bashrc"
           source /etc/profile.d/ibm-aiu-setup.sh
-          if [[ -n "$INPUT_REF" ]]; then
+          if [[ -n "$TORCH_SPYRE_REF" ]]; then
             uv add torch-spyre /home/senuser/torch-spyre
             uv sync --verbose --group dev
           else

--- a/.github/workflows/test_each_commit.yaml
+++ b/.github/workflows/test_each_commit.yaml
@@ -8,6 +8,23 @@ on:
     branches: [main]
   merge_group:
     types: [checks_requested]
+  workflow_dispatch:
+    inputs:
+      torch_spyre_ref:
+        description: Branch, tag, or SHA of torch-spyre to check out and test
+        required: false
+        type: string
+        default: ""
+      rpm_location:
+        description: The Artifactory location where to download the RPM from
+        required: false
+        type: string
+        default: ""
+      rpm_names:
+        description: A space separated list of RPM names to download and install
+        required: false
+        type: string
+        default: ""
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -77,6 +94,17 @@ jobs:
       - name: Configure image-versioned UV cache
         uses: ./.github/actions/spyre-uv-cache
 
+      - uses: ./.github/actions/build-spyre-deps
+        if: ${{ inputs.torch_spyre_ref != '' }}
+        with:
+          rpm_names: ${{ inputs.rpm_names }}
+          rpm_location: ${{ inputs.rpm_location }}
+          torch_spyre_ref: ${{ inputs.torch_spyre_ref }}
+          artifactory_user: ${{ secrets.ARTIFACTORY_USER }}
+          artifactory_api_key: ${{ secrets.ARTIFACTORY_API_KEY }}
+          artifactory_base_url: ${{ secrets.ARTIFACTORY_BASE_URL }}
+          artifactory_rpm_path: ${{ secrets.ARTIFACTORY_RPM_PATH }}
+
       - name: Gather runner info
         run: |
           source "$HOME/.bashrc"
@@ -99,13 +127,17 @@ jobs:
           echo "---"
 
       - name: Build spyre-inference
+        env:
+          INPUT_REF: "${{ inputs.torch_spyre_ref }}"
         run: |
           source "$HOME/.bashrc"
           source /etc/profile.d/ibm-aiu-setup.sh
-          uv sync \
-            --frozen \
-            --verbose \
-            --group dev
+          if [[ -n "$INPUT_REF" ]]; then
+            uv add torch-spyre /home/senuser/torch-spyre
+            uv sync --verbose --group dev
+          else
+            uv sync --frozen --verbose --group dev
+          fi
           # Print the resolved torch install for log visibility.
           uv pip show torch
           uv pip freeze

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ extra-build-variables = { vllm = { VLLM_TARGET_DEVICE = "cpu", CMAKE_ARGS = "--f
 # NB: torch-spyre can only be compiled where `sendnn` is available
 [tool.uv.sources]
 vllm = { git = "https://github.com/vllm-project/vllm", rev = "v0.20.1" }
-torch-spyre = { git = "https://github.com/torch-spyre/torch-spyre", rev = "f76e550cbcf98385de62647c81cfd871dc204cb5" }
+torch-spyre = { git = "https://github.com/torch-spyre/torch-spyre", rev = "c69c6f78daa9a24d907cb5dc7f40514ed28a5a96" }
 torch = [
   { index = "pytorch-cpu" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ extra-build-variables = { vllm = { VLLM_TARGET_DEVICE = "cpu", CMAKE_ARGS = "--f
 # NB: torch-spyre can only be compiled where `sendnn` is available
 [tool.uv.sources]
 vllm = { git = "https://github.com/vllm-project/vllm", rev = "v0.20.1" }
-torch-spyre = { git = "https://github.com/torch-spyre/torch-spyre", rev = "c69c6f78daa9a24d907cb5dc7f40514ed28a5a96" }
+torch-spyre = { git = "https://github.com/torch-spyre/torch-spyre", rev = "a6baa9c73b2de0f1b199c2c567d8609720bcf5a8" }
 torch = [
   { index = "pytorch-cpu" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -7374,7 +7374,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "torch", index = "https://download.pytorch.org/whl/cpu" },
-    { name = "torch-spyre", git = "https://github.com/torch-spyre/torch-spyre?rev=c69c6f78daa9a24d907cb5dc7f40514ed28a5a96" },
+    { name = "torch-spyre", git = "https://github.com/torch-spyre/torch-spyre?rev=a6baa9c73b2de0f1b199c2c567d8609720bcf5a8" },
     { name = "vllm", git = "https://github.com/vllm-project/vllm?rev=v0.20.1" },
 ]
 
@@ -8132,7 +8132,7 @@ wheels = [
 [[package]]
 name = "torch-spyre"
 version = "0.0.1"
-source = { git = "https://github.com/torch-spyre/torch-spyre?rev=c69c6f78daa9a24d907cb5dc7f40514ed28a5a96#c69c6f78daa9a24d907cb5dc7f40514ed28a5a96" }
+source = { git = "https://github.com/torch-spyre/torch-spyre?rev=a6baa9c73b2de0f1b199c2c567d8609720bcf5a8#a6baa9c73b2de0f1b199c2c567d8609720bcf5a8" }
 dependencies = [
     { name = "numpy" },
     { name = "psutil" },

--- a/uv.lock
+++ b/uv.lock
@@ -7374,7 +7374,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "torch", index = "https://download.pytorch.org/whl/cpu" },
-    { name = "torch-spyre", git = "https://github.com/torch-spyre/torch-spyre?rev=f76e550cbcf98385de62647c81cfd871dc204cb5" },
+    { name = "torch-spyre", git = "https://github.com/torch-spyre/torch-spyre?rev=c69c6f78daa9a24d907cb5dc7f40514ed28a5a96" },
     { name = "vllm", git = "https://github.com/vllm-project/vllm?rev=v0.20.1" },
 ]
 
@@ -8132,7 +8132,7 @@ wheels = [
 [[package]]
 name = "torch-spyre"
 version = "0.0.1"
-source = { git = "https://github.com/torch-spyre/torch-spyre?rev=f76e550cbcf98385de62647c81cfd871dc204cb5#f76e550cbcf98385de62647c81cfd871dc204cb5" }
+source = { git = "https://github.com/torch-spyre/torch-spyre?rev=c69c6f78daa9a24d907cb5dc7f40514ed28a5a96#c69c6f78daa9a24d907cb5dc7f40514ed28a5a96" }
 dependencies = [
     { name = "numpy" },
     { name = "psutil" },


### PR DESCRIPTION
This PR adds ability to dispatch test workflows on desired torch-spyre and underneath dependency RPMs. This dispatch will be used as part of integration testing with upstream libraries. 