### PR TITLE
:bug: fix TP2 failure with cpu bounce, reinstate probes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,7 @@ extra-build-variables = { vllm = { VLLM_TARGET_DEVICE = "cpu" } }
 # NB: torch-spyre can only be compiled where `sendnn` is available
 [tool.uv.sources]
 vllm = { git = "https://github.com/vllm-project/vllm", rev = "v0.20.1" }
-torch-spyre = { git = "https://github.com/torch-spyre/torch-spyre", rev = "4dcfee15c3a9344652f067149ec65c4bf2941890" }
+torch-spyre = { git = "https://github.com/torch-spyre/torch-spyre", rev = "3faf9f1b9c59a280324379cd82e7bdaeb4f3e395" }
 torch = [
   { index = "pytorch-cpu" },
 ]

--- a/spyre_inference/distributed/spyre_communicator.py
+++ b/spyre_inference/distributed/spyre_communicator.py
@@ -108,52 +108,23 @@ class SpyreCommunicator(DeviceCommunicatorBase):
         if self.world_size == 1:
             return input_
 
-        if self.world_size != 2:
-            # REPLACE-WITH-NATIVE: once libspyre_comms supports allreduce
-            # natively, delete this entire `all_reduce` override and let
-            # the base class call `dist.all_reduce(input_, group=self.device_group)`.
-            raise NotImplementedError(
-                _spyre_collective_unsupported_message(
-                    "allreduce",
-                    self.world_size,
-                    blocker="libspyre_comms native allreduce impl",
-                )
-            )
-
-        # We hand `input_` directly to dist.send/dist.recv, which require
-        # contiguous storage. The base class's dist.all_reduce path has
-        # its own internal handling, but ours doesn't.
-        assert input_.is_contiguous(), (
-            "SpyreCommunicator.all_reduce requires a contiguous input tensor; "
-            f"got tensor with shape={tuple(input_.shape)} stride={input_.stride()}"
-        )
-
-        # TP=2 manual all_reduce.
-        #
-        # We verified on this pod that:
-        #   - dist.send / dist.recv on the spyreccl group work for paired
-        #     ranks at world_size=2.
-        #   - dist.broadcast works on the spyreccl group at any world size.
-        #   - The Spyre comms message matcher requires every p2p message
-        #     to have an immediate matching counterpart across all ranks;
-        #     only world_size=2 trivially satisfies that constraint with a
-        #     single send/recv pair.
-        #
-        # Pattern:
-        #   Rank 1 -> Rank 0 (send/recv).
-        #   Rank 0 sums in place.
-        #   Rank 0 -> all (broadcast).
-        #
         # REPLACE-WITH-NATIVE: when libspyre_comms gains a native allreduce
-        # and a comms RPM containing it is available, drop this branch.
-        other = 1 - self.rank_in_group
-        if self.rank_in_group == 0:
-            scratch = torch.empty_like(input_)
-            dist.recv(scratch, src=self.ranks[other], group=self.device_group)
-            input_.add_(scratch)
-        else:
-            dist.send(input_, dst=self.ranks[other], group=self.device_group)
-        dist.broadcast(input_, src=self.ranks[0], group=self.device_group)
+        # and a comms RPM containing it is available, drop this entire
+        # override and let the base class call
+        # `dist.all_reduce(input_, group=self.device_group)`.
+        #
+        # Bounce-through-CPU fallback. The send+recv+broadcast pattern this
+        # used to use is unreliable on the spyreccl backend: those primitives
+        # appear to return before data lands in the destination tensor, so
+        # follow-up reads see stale values. The multi-backend device_group
+        # (cpu:gloo,spyre:spyreccl) dispatches CPU tensors to gloo, which is
+        # well-tested. Copy to CPU, all-reduce there, copy back.
+        if input_.device.type == "spyre":
+            cpu_input = input_.cpu()
+            dist.all_reduce(cpu_input, group=self.device_group)
+            input_.copy_(cpu_input)
+            return input_
+        dist.all_reduce(input_, group=self.device_group)
         return input_
 
     def all_gather(self, input_: torch.Tensor, dim: int = -1) -> torch.Tensor:

--- a/tests/probes/tp_probe.py
+++ b/tests/probes/tp_probe.py
@@ -40,6 +40,28 @@ import torch
 import torch.distributed as dist
 
 
+def probe_tp_all_reduce(device, device_group, world_size, rank):
+    """High-level vllm `tensor_model_parallel_all_reduce` (via SpyreCommunicator).
+
+    Verifies the SpyreCommunicator.all_reduce fallback on a 1-D probe and a
+    (seq, hidden) slab. `device_group` is unused — `tensor_model_parallel_all_reduce`
+    resolves the group from `_TP.device_communicator` itself.
+    """
+    import vllm.distributed.parallel_state as ps
+    from vllm.distributed.communication_op import tensor_model_parallel_all_reduce
+
+    comm_cls = type(ps._TP.device_communicator).__name__
+    assert comm_cls == "SpyreCommunicator", f"got {comm_cls}"
+
+    expected = float(sum(range(1, world_size + 1)))
+    for shape in [(128,), (16, 1024)]:
+        t = torch.full(shape, float(rank + 1), dtype=torch.float16, device=device)
+        out = tensor_model_parallel_all_reduce(t)
+        cpu = out.cpu()
+        torch.testing.assert_close(cpu, torch.full_like(cpu, expected))
+        dist.barrier(device_ids=[device.index])
+
+
 def probe_native_all_reduce(device, device_group, world_size, rank):
     """Raw `dist.all_reduce` on the spyreccl device_group."""
     t = torch.full((1024,), float(rank + 1), dtype=torch.float16, device=device)
@@ -70,6 +92,231 @@ def probe_native_all_gather_list(device, device_group, world_size, rank):
         torch.testing.assert_close(o.cpu(), torch.full((1024,), float(r + 1), dtype=torch.float16))
 
 
+def probe_vocab_parallel_embedding(device, device_group, world_size, rank):
+    """TP=N SpyreVocabParallelEmbedding forward vs single-rank F.embedding.
+
+    Constructs the OOT VocabParallelEmbedding (which OOT-swaps to
+    SpyreVocabParallelEmbedding), loads each rank's shard from a
+    deterministic full-vocab weight, runs forward, and asserts the
+    all-reduced result matches a single-rank F.embedding over the full
+    weight bit-for-bit (modulo float16 reduction noise).
+    """
+    import torch.nn.functional as F
+    from vllm.model_executor.layers.vocab_parallel_embedding import (
+        VocabParallelEmbedding,
+    )
+
+    from spyre_inference.custom_ops.vocab_parallel_embedding import (
+        SpyreVocabParallelEmbedding,
+    )
+
+    vocab_size = 1024
+    embedding_dim = 64
+
+    layer = VocabParallelEmbedding(
+        vocab_size,
+        embedding_dim,
+        params_dtype=torch.float16,
+    )
+    assert isinstance(layer, SpyreVocabParallelEmbedding), type(layer)
+    assert layer.tp_size == world_size, layer.tp_size
+
+    # Both ranks reconstruct the same full-vocab reference, then each
+    # populates its shard from the same source — keeps the assertion
+    # below independent of weight initialization.
+    torch.manual_seed(42)
+    full_weight = torch.randn(vocab_size, embedding_dim, dtype=torch.float16) * 0.02
+
+    start = layer.shard_indices.org_vocab_start_index
+    end = layer.shard_indices.org_vocab_end_index
+    layer.weight.data.zero_()
+    layer.weight.data[: end - start].copy_(full_weight[start:end])
+    layer.to(device)
+
+    torch.manual_seed(7)
+    input_ids = torch.randint(0, vocab_size, (16,), dtype=torch.int64)
+
+    out = layer(input_ids.to(device)).cpu()
+    expected = F.embedding(input_ids, full_weight)
+    torch.testing.assert_close(out.float(), expected.float(), atol=1e-3, rtol=1e-3)
+    dist.barrier(device_ids=[device.index])
+
+
+def probe_merged_column_parallel_linear(device, device_group, world_size, rank):
+    """TP=N SpyreMergedColumnParallelLinear forward vs single-rank F.linear.
+
+    Models the gate_up_proj usage: output_sizes=[gate, up], so the per-rank
+    weight is [gate_shard | up_shard] stacked rows-wise (each shard is the
+    rank's slice of the corresponding full matrix). The expected output is
+    the per-shard F.linear results concatenated along the output dim — a
+    naive contiguous row-slice would mask a layout bug, so we build the
+    weight shard-by-shard.
+    """
+    import torch.nn.functional as F
+    from vllm.model_executor.layers.linear import MergedColumnParallelLinear
+
+    from spyre_inference.custom_ops.linear import SpyreMergedColumnParallelLinear
+    from spyre_inference.custom_ops.utils import convert
+
+    input_size = 512
+    output_size = 1024  # per-shard size (gate, up)
+
+    layer = MergedColumnParallelLinear(
+        input_size,
+        [output_size, output_size],
+        bias=False,
+        params_dtype=torch.float16,
+    )
+    assert isinstance(layer, SpyreMergedColumnParallelLinear), type(layer)
+
+    torch.manual_seed(42)
+    gate_full = torch.randn(output_size, input_size, dtype=torch.float16) * 0.02
+    up_full = torch.randn(output_size, input_size, dtype=torch.float16) * 0.02
+
+    shard = output_size // world_size
+    start = rank * shard
+    end = (rank + 1) * shard
+    layer.weight.data.copy_(torch.cat([gate_full[start:end], up_full[start:end]], dim=0))
+    layer.to(device)
+
+    torch.manual_seed(7)
+    x = torch.randn(16, input_size, dtype=torch.float16)
+
+    out, _ = layer(convert(x, device=device))
+    out = convert(out, device="cpu")
+    expected = torch.cat(
+        [F.linear(x, gate_full)[:, start:end], F.linear(x, up_full)[:, start:end]],
+        dim=-1,
+    )
+    torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+    dist.barrier(device_ids=[device.index])
+
+
+def probe_qkv_parallel_linear(device, device_group, world_size, rank):
+    """TP=N SpyreQKVParallelLinear forward vs single-rank F.linear.
+
+    Uses GQA shape (total_num_heads != total_num_kv_heads) so a naive
+    "slice the full weight row-wise per rank" load — which would pass for
+    MHA — actually mismatches the real per-rank `[Q | K | V]` layout.
+    The probe loads each shard from its corresponding full Q/K/V matrix
+    using the same head/replica math QKVParallelLinear performs in
+    __init__, then asserts each rank's output matches the concatenation
+    of per-shard F.linear results.
+    """
+    import torch.nn.functional as F
+    from vllm.model_executor.layers.linear import QKVParallelLinear
+
+    from spyre_inference.custom_ops.linear import SpyreQKVParallelLinear
+    from spyre_inference.custom_ops.utils import convert
+
+    hidden_size = 512
+    head_size = 64
+    total_num_heads = 8
+    total_num_kv_heads = 2  # GQA: kv heads < query heads
+
+    layer = QKVParallelLinear(
+        hidden_size,
+        head_size,
+        total_num_heads,
+        total_num_kv_heads=total_num_kv_heads,
+        bias=False,
+        params_dtype=torch.float16,
+    )
+    assert isinstance(layer, SpyreQKVParallelLinear), type(layer)
+
+    # Mirror QKVParallelLinear.__init__ partitioning math.
+    num_heads = total_num_heads // world_size
+    if world_size >= total_num_kv_heads:
+        num_kv_heads = 1
+        num_kv_head_replicas = world_size // total_num_kv_heads
+    else:
+        num_kv_heads = total_num_kv_heads // world_size
+        num_kv_head_replicas = 1
+    assert layer.num_heads == num_heads
+    assert layer.num_kv_heads == num_kv_heads
+    assert layer.num_kv_head_replicas == num_kv_head_replicas
+
+    q_full_rows = total_num_heads * head_size
+    kv_full_rows = total_num_kv_heads * head_size
+
+    torch.manual_seed(43)
+    q_full = torch.randn(q_full_rows, hidden_size, dtype=torch.float16) * 0.02
+    k_full = torch.randn(kv_full_rows, hidden_size, dtype=torch.float16) * 0.02
+    v_full = torch.randn(kv_full_rows, hidden_size, dtype=torch.float16) * 0.02
+
+    q_start = rank * num_heads * head_size
+    q_end = q_start + num_heads * head_size
+    kv_shard_idx = rank // num_kv_head_replicas
+    kv_start = kv_shard_idx * num_kv_heads * head_size
+    kv_end = kv_start + num_kv_heads * head_size
+
+    q_shard = q_full[q_start:q_end]
+    k_shard = k_full[kv_start:kv_end]
+    v_shard = v_full[kv_start:kv_end]
+    layer.weight.data.copy_(torch.cat([q_shard, k_shard, v_shard], dim=0))
+    layer.to(device)
+
+    torch.manual_seed(8)
+    x = torch.randn(16, hidden_size, dtype=torch.float16)
+
+    out, _ = layer(convert(x, device=device))
+    expected = torch.cat(
+        [
+            F.linear(x, q_shard),
+            F.linear(x, k_shard),
+            F.linear(x, v_shard),
+        ],
+        dim=-1,
+    )
+    torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+    dist.barrier(device_ids=[device.index])
+
+
+def probe_row_parallel_linear(device, device_group, world_size, rank):
+    """TP=N SpyreRowParallelLinear forward vs single-rank F.linear.
+
+    Constructs RowParallelLinear (OOT-swapped to SpyreRowParallelLinear),
+    loads each rank's input-dim shard from deterministic full weight, runs
+    forward, and asserts the all-reduced result matches single-rank F.linear
+    (modulo float16 all_reduce noise).
+    """
+    import torch.nn.functional as F
+    from vllm.model_executor.layers.linear import RowParallelLinear
+
+    from spyre_inference.custom_ops.linear import SpyreRowParallelLinear
+    from spyre_inference.custom_ops.utils import convert
+
+    input_size = 1024
+    output_size = 512
+
+    layer = RowParallelLinear(
+        input_size,
+        output_size,
+        bias=False,
+        params_dtype=torch.float16,
+    )
+    assert isinstance(layer, SpyreRowParallelLinear), type(layer)
+
+    torch.manual_seed(44)
+    full_weight = torch.randn(output_size, input_size, dtype=torch.float16) * 0.02
+
+    input_size_per_partition = input_size // world_size
+    start = rank * input_size_per_partition
+    end = (rank + 1) * input_size_per_partition
+    layer.weight.data.copy_(full_weight[:, start:end])
+    layer.to(device)
+
+    torch.manual_seed(9)
+    x_full = torch.randn(16, input_size, dtype=torch.float16)
+    x = x_full[:, start:end]
+
+    out, _ = layer(convert(x, device=device))
+    out = convert(out, device="cpu")
+    expected = F.linear(x_full, full_weight)
+    torch.testing.assert_close(out, expected, atol=1e-2, rtol=1e-2)
+    dist.barrier(device_ids=[device.index])
+
+
 def probe_native_gather(device, device_group, world_size, rank):
     """Raw `dist.gather` to rank 0 on the spyreccl device_group."""
     t = torch.full((1024,), float(rank + 1), dtype=torch.float16, device=device)
@@ -88,10 +335,15 @@ def probe_native_gather(device, device_group, world_size, rank):
 
 
 PROBES = {
+    "tp_all_reduce": probe_tp_all_reduce,
     "native_all_reduce": probe_native_all_reduce,
     "native_all_gather_into_tensor": probe_native_all_gather_into_tensor,
     "native_all_gather_list": probe_native_all_gather_list,
     "native_gather": probe_native_gather,
+    "vocab_parallel_embedding": probe_vocab_parallel_embedding,
+    "merged_column_parallel_linear": probe_merged_column_parallel_linear,
+    "qkv_parallel_linear": probe_qkv_parallel_linear,
+    "row_parallel_linear": probe_row_parallel_linear,
 }
 
 

--- a/tests/test_distributed_tp2.py
+++ b/tests/test_distributed_tp2.py
@@ -36,6 +36,69 @@ def _spyre_device_count() -> int:
         return 0
 
 
+@pytest.mark.uses_subprocess
+@pytest.mark.distributed
+@pytest.mark.skipif(
+    _spyre_device_count() < 2,
+    reason="needs >=2 Spyre cards; skipping TP=2 distributed test",
+)
+def test_tp2_tensor_model_parallel_all_reduce(run_tp_probe) -> None:
+    """End-to-end TP=2 `tensor_model_parallel_all_reduce` on real Spyre cards.
+
+    Spawns one subprocess per rank, each running through vllm's real
+    `init_worker_distributed_environment` against a real `VllmConfig`,
+    then verifies SpyreCommunicator.all_reduce returns numerically correct
+    results on a 1-D probe and a (seq, hidden) slab. This is the cheapest
+    surface that exercises the full collective stack — keep it as a fast
+    canary so an all_reduce regression doesn't surface only as a degenerate
+    end-to-end greedy-decode in `test_tp2_llm_generate_matches_tp1`.
+    """
+    run_tp_probe("tp_all_reduce", world_size=2)
+
+
+@pytest.mark.uses_subprocess
+@pytest.mark.distributed
+@pytest.mark.skipif(
+    _spyre_device_count() < 2,
+    reason="needs >=2 Spyre cards; skipping TP=2 distributed test",
+)
+def test_tp2_vocab_parallel_embedding(run_tp_probe) -> None:
+    """End-to-end TP=2 SpyreVocabParallelEmbedding forward on real Spyre cards.
+
+    Spawns one subprocess per rank, brings up spyreccl through vllm's real
+    init path, constructs the OOT VocabParallelEmbedding, and asserts each
+    rank's all-reduced output matches the full-vocab F.embedding reference.
+    """
+    run_tp_probe("vocab_parallel_embedding", world_size=2)
+
+
+@pytest.mark.uses_subprocess
+@pytest.mark.distributed
+@pytest.mark.skipif(
+    _spyre_device_count() < 2,
+    reason="needs >=2 Spyre cards; skipping TP=2 distributed test",
+)
+@pytest.mark.parametrize(
+    "probe",
+    [
+        "merged_column_parallel_linear",
+        "qkv_parallel_linear",
+        "row_parallel_linear",
+    ],
+)
+def test_tp_linear_layers(run_tp_probe, probe: str) -> None:
+    """End-to-end TP=2 test of a Spyre linear layer on Spyre cards.
+
+    Spawns one subprocess per rank, running through vllm's real
+    `init_worker_distributed_environment` against a real `VllmConfig`,
+    then verifies the layer returns numerically correct results on TP=2
+    with Spyre communication. Parametrized over the three layer types:
+    SpyreMergedColumnParallelLinear (output sharding), SpyreQKVParallelLinear
+    (Q/K/V sharding), and SpyreRowParallelLinear (input sharding).
+    """
+    run_tp_probe(probe, world_size=2)
+
+
 @pytest.mark.spyre
 @pytest.mark.uses_subprocess
 @pytest.mark.skipif(

--- a/uv.lock
+++ b/uv.lock
@@ -7374,7 +7374,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "torch", index = "https://download.pytorch.org/whl/cpu" },
-    { name = "torch-spyre", git = "https://github.com/torch-spyre/torch-spyre?rev=4dcfee15c3a9344652f067149ec65c4bf2941890" },
+    { name = "torch-spyre", git = "https://github.com/torch-spyre/torch-spyre?rev=3faf9f1b9c59a280324379cd82e7bdaeb4f3e395" },
     { name = "vllm", git = "https://github.com/vllm-project/vllm?rev=v0.20.1" },
 ]
 
@@ -8132,7 +8132,7 @@ wheels = [
 [[package]]
 name = "torch-spyre"
 version = "0.0.1"
-source = { git = "https://github.com/torch-spyre/torch-spyre?rev=4dcfee15c3a9344652f067149ec65c4bf2941890#4dcfee15c3a9344652f067149ec65c4bf2941890" }
+source = { git = "https://github.com/torch-spyre/torch-spyre?rev=3faf9f1b9c59a280324379cd82e7bdaeb4f3e395#3faf9f1b9c59a280324379cd82e7bdaeb4f3e395" }
 dependencies = [
     { name = "numpy" },
     { name = "psutil" },


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

This PR fixes a regression in TP=2 operation.

We used send/recv to implement `all_reduce` ourselves because it's not yet supported. However a recent change has broken both send and recv, so this no longer works. The tests that we previously had would have shown the failing all_reduce, but we had removed them with #215 when we TP=2 was finally fully operational. The only failure now is the full TP=2 test with repeated tokens, but this isn't specific enough to help debug to find the root cause of the problem.

This changes our `all_reduce` op to simply round trip to cpu, which is of course incredibly slow but seems to be the only option for the moment. This also adds tests back for both the all_reduce op and the individual layers that we've overridden for TP=2, so that next time something breaks we might have more info to start with.

Also upgrades torch-spyre to latest main commit, which was unhelpful in resolving the issue with send/recv anyway

## Related Issues

Fixes #276 

## Test Plan

- [ ] unit tests

## Checklist

- [ ] I have read the [contributing guidelines](https://torch-spyre.github.io/spyre-inference/contributing/)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
