### PR TITLE
:bug: Use `cmake --fresh` for vllm

### DIFF
--- a/.github/workflows/test_each_commit.yaml
+++ b/.github/workflows/test_each_commit.yaml
@@ -105,7 +105,6 @@ jobs:
           uv sync \
             --frozen \
             --verbose \
-            --refresh \
             --group dev
           # Print the resolved torch install for log visibility.
           uv pip show torch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,8 @@ override-dependencies = [
 # with the same version of torch. This CANNOT conflict with a package's existing build dependencies
 build-constraint-dependencies = ["torch==2.11.0"]
 # This ensures that we build the cpu backend for vLLM
-extra-build-variables = { vllm = { VLLM_TARGET_DEVICE = "cpu" } }
+# The `CMAKE_ARGS="--fresh"` ensures that cmake doesn't cache binary paths from ephemeral build environments
+extra-build-variables = { vllm = { VLLM_TARGET_DEVICE = "cpu", CMAKE_ARGS = "--fresh" } }
 
 
 # vLLM and torch-spyre must be pulled from github to be built from source
@@ -118,10 +119,10 @@ members = ["tests/plugin"]
 # vllm from source for the cpu backend.
 # NB: This section CANNOT be used to override dependencies to a conflicting version. For example,
 # you cannot add torch==2.10.0 if vllm's build dependencies already specify torch>=2.11.0
-[tool.uv.extra-build-dependencies]
-vllm = [
-    "ninja",
-]
+# [tool.uv.extra-build-dependencies]
+# vllm = [
+#     "ninja",
+# ]
 
 # The pytorch-cpu index here ensures we always pull the cpu version of torch everywhere
 # The `explicit=true` setting means this index will only be used for packages that we explicitly set

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ extra-build-variables = { vllm = { VLLM_TARGET_DEVICE = "cpu", CMAKE_ARGS = "--f
 # NB: torch-spyre can only be compiled where `sendnn` is available
 [tool.uv.sources]
 vllm = { git = "https://github.com/vllm-project/vllm", rev = "v0.20.1" }
-torch-spyre = { git = "https://github.com/torch-spyre/torch-spyre", rev = "4dcfee15c3a9344652f067149ec65c4bf2941890" }
+torch-spyre = { git = "https://github.com/torch-spyre/torch-spyre", rev = "f76e550cbcf98385de62647c81cfd871dc204cb5" }
 torch = [
   { index = "pytorch-cpu" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,10 +118,10 @@ members = ["tests/plugin"]
 # vllm from source for the cpu backend.
 # NB: This section CANNOT be used to override dependencies to a conflicting version. For example,
 # you cannot add torch==2.10.0 if vllm's build dependencies already specify torch>=2.11.0
-# [tool.uv.extra-build-dependencies]
-# vllm = [
-#     "ninja",
-# ]
+[tool.uv.extra-build-dependencies]
+vllm = [
+    "ninja",
+]
 
 # The pytorch-cpu index here ensures we always pull the cpu version of torch everywhere
 # The `explicit=true` setting means this index will only be used for packages that we explicitly set

--- a/uv.lock
+++ b/uv.lock
@@ -7374,7 +7374,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "torch", index = "https://download.pytorch.org/whl/cpu" },
-    { name = "torch-spyre", git = "https://github.com/torch-spyre/torch-spyre?rev=4dcfee15c3a9344652f067149ec65c4bf2941890" },
+    { name = "torch-spyre", git = "https://github.com/torch-spyre/torch-spyre?rev=f76e550cbcf98385de62647c81cfd871dc204cb5" },
     { name = "vllm", git = "https://github.com/vllm-project/vllm?rev=v0.20.1" },
 ]
 
@@ -8132,7 +8132,7 @@ wheels = [
 [[package]]
 name = "torch-spyre"
 version = "0.0.1"
-source = { git = "https://github.com/torch-spyre/torch-spyre?rev=4dcfee15c3a9344652f067149ec65c4bf2941890#4dcfee15c3a9344652f067149ec65c4bf2941890" }
+source = { git = "https://github.com/torch-spyre/torch-spyre?rev=f76e550cbcf98385de62647c81cfd871dc204cb5#f76e550cbcf98385de62647c81cfd871dc204cb5" }
 dependencies = [
     { name = "numpy" },
     { name = "psutil" },


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Builds are currently failing with an error about ninja not being found, which is caused by `cmake` caching the ninja binary location from a previous run's ephemeral build environment which no longer exists. Passing the `--fresh` arg via `CMAKE_ARGS` is supported by vllm to work around this exact problem.

Also, `--refresh` was added in https://github.com/torch-spyre/spyre-inference/pull/227, but this causes packages to always rebuild from source which circumvents some of the uv caching. Pulling it out should improve build speeds

## Related Issues

<!-- Link related issues, e.g., `Fixes #` or `Relates to #456` -->

## Test Plan

<!-- Describe how you tested your changes. Include commands or steps to reproduce. -->

## Checklist

- [ ] I have read the [contributing guidelines](https://torch-spyre.github.io/spyre-inference/contributing/)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
