### PR TITLE
[Bugfix] fixing assert_close_outliers msg

### DIFF
--- a/tests/test_spyre_attn.py
+++ b/tests/test_spyre_attn.py
@@ -146,7 +146,6 @@ def assert_close_outliers(
     *,
     outlier_atol: float | None = None,
     outlier_rtol: float | None = None,
-    msg: str = "",
 ) -> None:
     """Assert tensors are close, allowing up to *max_outliers* elements to exceed tolerance.
 
@@ -200,8 +199,8 @@ def assert_close_outliers(
         raise AssertionError(
             f"{prefix}"
             f"max_outliers={max_outliers} was specified "
-            f"but {n_outliers} element(s) exceed tolerance."
-            f"{msg}"
+            f"but {n_outliers} element(s) exceed tolerance.\n"
+            f"{e}"
         ) from e
 
 
@@ -486,7 +485,6 @@ def test_spyre_attn(
         rtol=rtol,
         outlier_atol=atol * 2,
         outlier_rtol=rtol * 2,
-        msg="test_spyre_attn",
     )
 
 

--- a/tests/test_spyre_attn.py
+++ b/tests/test_spyre_attn.py
@@ -178,7 +178,7 @@ def assert_close_outliers(
                 raise AssertionError(
                     f"{n_outliers} outlier(s) exceed base tolerances, "
                     f"and at least one outlier also exceeds the relaxed bound "
-                    f"(worst diff={worst:.4g}). {msg}"
+                    f"(worst diff={worst:.4g})."
                 )
         if n_outliers > 0:
             print(


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

#205 introduced a version of `torch.assert_close` that allows to have a limited number of outliers in the tensor. This is helpful to e.g. keep the general atol/rtol low but avoid failing unit tests due to expected inaccuracies in reductions. 

However, the error messages was malformed and with the fix in this PR it reads now niecly:
```
E           AssertionError: 3598 elements exceed atol=0.3, rtol=0.2. max_outliers=5 was specified but 3598 element(s) exceed tolerance.                                                                          
E           Tensor-likes are not close!                                                                 
E                                                                                                       
E           Mismatched elements: 3598 / 131072 (2.7%)
E           Greatest absolute difference: 1.80078125 at index (10, 25, 59) (up to 0.3 allowed)
E           Greatest relative difference: 19904.0 at index (17, 3, 90) (up to 0.2 allowed)

tests/test_spyre_attn.py:199: AssertionError
```

## Related Issues

N/A 

## Test Plan

Unit tests should still pass

## Checklist

- [x] I have read the [contributing guidelines](https://torch-spyre.github.io/spyre-inference/contributing/)
- [x] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
