### PR TITLE
ci: accept the full per-PR dispatch contract (runner_label/ref/repository)

### DIFF
--- a/.github/workflows/test_each_commit.yaml
+++ b/.github/workflows/test_each_commit.yaml
@@ -81,15 +81,27 @@ jobs:
       matrix:
         include:
           - cfg: Non-distributed spyre tests
-            spyre: spyre_pf_x1__pvc_1tb_x1
+            runs_on:
+              - x86_64
+              - spyre_pf_x1__pvc_1tb_x1
+              - linux
+            image_label: image_spyre_inference
             flags: >-
               -m "not (distributed or upstream)"
           - cfg: Distributed spyre tests
-            spyre: spyre_pf_x2__pvc_1tb_x1
+            runs_on:
+              - x86_64
+              - spyre_pf_x2__pvc_1tb_x1
+              - linux
+            image_label: image_spyre_inference
             flags: >-
               -m distributed
           - cfg: Upstream vLLM tests
-            spyre: spyre_pf_x1__pvc_1tb_x1
+            runs_on:
+              - x86_64
+              - spyre_pf_x1__pvc_1tb_x1
+              - linux
+            image_label: image_spyre_inference
             flags: >-
               -m "upstream and not distributed"
           - cfg: Upstream distributed vLLM tests
@@ -97,16 +109,13 @@ jobs:
               - x86_64
               - spyre_pf_x2__pvc_1tb_x1
               - linux
-              - image_spyre_inference
+            image_label: image_spyre_inference
             flags: >-
               -m "upstream and distributed"
-    # Compose the runner labels from the per-cfg card token (matrix.spyre) and the
-    # image label. runner_label defaults to image_spyre_inference (push/PR/merge_group
-    # land on the standing set); the per-PR ephemeral flow passes
-    # image_spyre_inference_pr_<KEY> via workflow_dispatch so jobs land on the per-PR
-    # runner (baked RPM, no runtime sudo). Composed via fromJSON because runs-on
-    # can't append a scalar to a matrix array inline.
-    runs-on: ${{ fromJSON(format('["x86_64","{0}","linux","{1}"]', matrix.spyre, inputs.runner_label || 'image_spyre_inference')) }}
+    # Compose runner labels from matrix.runs_on and the image label.
+    # When inputs.runner_label is set (per-PR dispatch flow), it replaces
+    # the standing image label with the per-PR image label.
+    runs-on: ${{ fromJSON(format('["{0}","{1}"]', join(matrix.runs_on, '","'), inputs.runner_label || matrix.image_label)) }}
     timeout-minutes: 720
     env:
       # The CI env var is very important.

--- a/.github/workflows/test_each_commit.yaml
+++ b/.github/workflows/test_each_commit.yaml
@@ -25,6 +25,16 @@ on:
         required: false
         type: string
         default: ""
+      image_label:
+        description: |
+          Image scaleSetLabel to select for runs-on (image_spyre_inference |
+          image_spyre_inference_pr_<KEY>). The per-PR ephemeral flow passes that
+          PR's set label (e.g. image_spyre_inference_pr_flex_8ddcf3e155e9) so jobs
+          land on the per-PR image (the RPM is baked in -> no runtime sudo).
+          Default keeps push/PR/merge_group runs on the standing set.
+        required: false
+        type: string
+        default: image_spyre_inference
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -45,27 +55,15 @@ jobs:
       matrix:
         include:
           - cfg: Non-distributed spyre tests
-            runs_on:
-              - x86_64
-              - spyre_pf_x1__pvc_1tb_x1
-              - linux
-              - image_spyre_inference
+            spyre: spyre_pf_x1__pvc_1tb_x1
             flags: >-
               -m "not (distributed or upstream)"
           - cfg: Distributed spyre tests
-            runs_on:
-              - x86_64
-              - spyre_pf_x2__pvc_1tb_x1
-              - linux
-              - image_spyre_inference
+            spyre: spyre_pf_x2__pvc_1tb_x1
             flags: >-
               -m distributed
           - cfg: Upstream vLLM tests
-            runs_on:
-              - x86_64
-              - spyre_pf_x1__pvc_1tb_x1
-              - linux
-              - image_spyre_inference
+            spyre: spyre_pf_x1__pvc_1tb_x1
             flags: >-
               -m "upstream and not distributed"
           - cfg: Upstream distributed vLLM tests
@@ -76,7 +74,13 @@ jobs:
               - image_spyre_inference
             flags: >-
               -m "upstream and distributed"
-    runs-on: ${{ matrix.runs_on }}
+    # Compose the runner labels from the per-cfg card token (matrix.spyre) and the
+    # image label. image_label defaults to image_spyre_inference (push/PR/merge_group
+    # land on the standing set); the per-PR ephemeral flow passes
+    # image_spyre_inference_pr_<KEY> via workflow_dispatch so jobs land on the per-PR
+    # runner (baked RPM, no runtime sudo). Composed via fromJSON because runs-on
+    # can't append a scalar to a matrix array inline.
+    runs-on: ${{ fromJSON(format('["x86_64","{0}","linux","{1}"]', matrix.spyre, inputs.image_label || 'image_spyre_inference')) }}
     timeout-minutes: 720
     env:
       # The CI env var is very important.

--- a/.github/workflows/test_each_commit.yaml
+++ b/.github/workflows/test_each_commit.yaml
@@ -25,16 +25,42 @@ on:
         required: false
         type: string
         default: ""
-      image_label:
-        description: |
-          Image scaleSetLabel to select for runs-on (image_spyre_inference |
-          image_spyre_inference_pr_<KEY>). The per-PR ephemeral flow passes that
-          PR's set label (e.g. image_spyre_inference_pr_flex_8ddcf3e155e9) so jobs
-          land on the per-PR image (the RPM is baked in -> no runtime sudo).
-          Default keeps push/PR/merge_group runs on the standing set.
+      ref:
+        description: Branch, tag, or SHA of spyre-inference to check out and test
         required: false
         type: string
-        default: image_spyre_inference
+        default: ""
+      repository:
+        description: |
+          Full clone URL/owner-name of the spyre-inference fork to check out
+          (e.g. "myuser/spyre-inference"); leave empty for the base repo. Used by
+          the cross-repo Test-With: flow to test a companion fork/branch.
+        required: false
+        type: string
+        default: ""
+      pr_url_hash:
+        description: |
+          Hash of the full URL of the PR that triggered this run.
+          Sent by the internal integration pipeline; unused on push/PR/merge_group.
+        required: false
+        type: string
+        default: ""
+      build_torch_spyre:
+        description: Accepted for dispatch-contract parity with torch-spyre; unused here.
+        required: false
+        type: boolean
+        default: true
+      runner_label:
+        description: |
+          Per-PR ephemeral runner-set IMAGE label to select for runs-on
+          (image_spyre_inference_pr_<component>_<sha12>, e.g.
+          image_spyre_inference_pr_flex_8ddcf3e155e9). The per-PR ephemeral flow
+          passes that PR's set label so jobs land on the per-PR image (the changed
+          RPM is baked in -> no runtime sudo). Empty keeps push/PR/merge_group runs
+          on the standing image_spyre_inference set (today's behaviour).
+        required: false
+        type: string
+        default: ""
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -75,12 +101,12 @@ jobs:
             flags: >-
               -m "upstream and distributed"
     # Compose the runner labels from the per-cfg card token (matrix.spyre) and the
-    # image label. image_label defaults to image_spyre_inference (push/PR/merge_group
+    # image label. runner_label defaults to image_spyre_inference (push/PR/merge_group
     # land on the standing set); the per-PR ephemeral flow passes
     # image_spyre_inference_pr_<KEY> via workflow_dispatch so jobs land on the per-PR
     # runner (baked RPM, no runtime sudo). Composed via fromJSON because runs-on
     # can't append a scalar to a matrix array inline.
-    runs-on: ${{ fromJSON(format('["x86_64","{0}","linux","{1}"]', matrix.spyre, inputs.image_label || 'image_spyre_inference')) }}
+    runs-on: ${{ fromJSON(format('["x86_64","{0}","linux","{1}"]', matrix.spyre, inputs.runner_label || 'image_spyre_inference')) }}
     timeout-minutes: 720
     env:
       # The CI env var is very important.
@@ -94,6 +120,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # Cross-repo Test-With: companion fork/branch (empty = base repo / dispatched ref).
+          repository: ${{ inputs.repository || github.repository }}
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Compute Spyre image hash
         id: spyre-uv-cache


### PR DESCRIPTION
## What
Make `test_each_commit.yaml` accept the **full per-PR ephemeral dispatch contract** that the internal integration pipeline sends, mirroring torch-spyre's `torch_spyre_tests.yaml`:

- declare `workflow_dispatch` inputs `ref`, `repository`, `pr_url_hash`, `build_torch_spyre`, `runner_label` (dropped the earlier `image_label` — `runner_label` is the dispatch's name for it)
- select the per-PR image in all 3 matrix configs via `runs-on: [... , ${{ inputs.runner_label || 'image_spyre_inference' }}]`
- thread `ref`/`repository` into the `build-spyre-inference` composite action so a cross-repo `Test-With:` companion fork/branch is checked out

## Why
The internal pipeline's `workflow_dispatch` always sends `ref`, `repository`, `pr_url_hash`, `build_torch_spyre` and (on the ephemeral path) `runner_label`. GitHub Actions **rejects a dispatch that carries inputs the workflow doesn't declare** ("Unexpected inputs provided" → HTTP 422), so the previous `image_label`-only version would 422 every dispatch from the per-PR ephemeral / downstream-fan-out / Test-With flow. This wires spyre-inference into that flow: a component PR (deeptools/flex) that affects spyre-inference, or an explicit `Test-With: spyre-inference#N`, now lands on a **per-PR runner set** (`image_hf_adapters_pr_<KEY>`) whose image has the PR's RPM **baked in** — no runtime `sudo dnf` (broken on the torch-cicd SCC).

`push` / `pull_request` / `merge_group` runs are **unchanged**: all new inputs default empty / to the standing `image_spyre_inference` set.

## Notes
- DO NOT MERGE casually — coordinated with the spyre-frameworks downstream-fan-out work (internal PR #53). Companion hf-adapters change: torch-spyre/hf-adapters#68.
- Until this merges to `main`, a fan-out dispatch (ref=main) to spyre-inference 422s; dispatching against this branch's ref works (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)