### PR TITLE
:construction_worker: Update uv caching strategies

### DIFF
--- a/.github/actions/spyre-uv-cache/action.yml
+++ b/.github/actions/spyre-uv-cache/action.yml
@@ -22,17 +22,13 @@ inputs:
     description: 'Persistent root for uv caches (one subdir per image hash).'
     required: false
     default: '/storage-1/spyre-inference/.cache'
-  manifest-path:
-    description: 'Spyre image component manifest used as the cache key.'
-    required: false
-    default: '/opt/ibm/spyre/components.txt'
 
 outputs:
   uv-cache-dir:
     description: 'The image-versioned UV_CACHE_DIR that was exported.'
     value: ${{ steps.compute.outputs.uv-cache-dir }}
   image-hash:
-    description: 'Short hash of the Spyre image component manifest.'
+    description: 'Short hash of the installed ibm-* RPM manifest.'
     value: ${{ steps.compute.outputs.image-hash }}
 
 runs:
@@ -42,12 +38,17 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        manifest="${{ inputs.manifest-path }}"
-        if [[ ! -f "$manifest" ]]; then
-          echo "::error::Spyre component manifest not found at $manifest"
+        manifest_file="/tmp/ibm-components.txt"
+        rpm -qa --qf '%{NAME}-%{VERSION}-%{RELEASE}\n' \
+            | grep '^ibm-' \
+            | sort > "${manifest_file}" || true
+        if [[ ! -s "${manifest_file}" ]]; then
+          echo "::error::no ibm-* RPMs found in the image; refusing to build a uv cache key from an empty manifest"
           exit 1
         fi
-        image_hash=$(sha256sum "$manifest" | cut -c1-12)
+        echo "# Installed ibm-* RPMs:"
+        cat "${manifest_file}"
+        image_hash=$(sha256sum "${manifest_file}" | cut -c1-12)
         cache_dir="${{ inputs.cache-root }}/uv-${image_hash}"
         echo "UV_CACHE_DIR=${cache_dir}" >> "$GITHUB_ENV"
         # The PVC backing the cache does not support hardlinks across to the

--- a/.github/actions/spyre-uv-cache/action.yml
+++ b/.github/actions/spyre-uv-cache/action.yml
@@ -14,7 +14,7 @@ description: |
   library versions CI ran against and replicate the environment locally.
 
   Pair with `astral-sh/setup-uv@v5` set to `enable-cache: true` and
-  `cache-key: ${{ steps.<id>.outputs.image-hash }}`.
+  `cache-suffix` set to this action's `image-hash` output.
 
 outputs:
   image-hash:

--- a/.github/actions/spyre-uv-cache/action.yml
+++ b/.github/actions/spyre-uv-cache/action.yml
@@ -1,32 +1,22 @@
-name: 'Spyre image-versioned UV cache'
+name: 'Spyre image-versioned UV cache key'
 description: |
-  Exports UV_CACHE_DIR pointed at a path keyed by the Spyre image's
-  component manifest hash. torch-spyre links against runtime binaries
-  carried by the image. Those binaries are upgraded in place when the 
-  image is rolled, but uv keys its built-wheel cache only by source URL
-  + commit — so without this action a wheel built on image v_N can be 
-  reused against image v_{N+1} and crash at import.
+  Computes a short hash of the installed ibm-* RPMs and outputs it as
+  `image-hash`. Pass this to `astral-sh/setup-uv` as `cache-key` so the
+  GHA cache is invalidated whenever the Spyre image changes.
 
-  Each image version gets its own UV_CACHE_DIR subdirectory under the
-  PVC, which means:
-    * No cross-image contamination — image bumps see an empty cache
-      and rebuild once, then warm-cache for every subsequent run.
-    * No mid-run mutation, no race conditions: jobs on the same image
-      hit the same dir, jobs on different images never touch the same
-      files.
+  torch-spyre links against runtime binaries carried by the image. Those
+  binaries are upgraded in place when the image is rolled, but uv keys its
+  built-wheel cache only by source URL + commit — so without this, a wheel
+  built on image v_N would be reused against image v_{N+1} and crash at
+  import.
 
-  Pair with `astral-sh/setup-uv@v5` set to `enable-cache: false`
+  Also prints the full ibm-* RPM list so developers can see exactly which
+  library versions CI ran against and replicate the environment locally.
 
-inputs:
-  cache-root:
-    description: 'Persistent root for uv caches (one subdir per image hash).'
-    required: false
-    default: '/storage-1/spyre-inference/.cache'
+  Pair with `astral-sh/setup-uv@v5` set to `enable-cache: true` and
+  `cache-key: ${{ steps.<id>.outputs.image-hash }}`.
 
 outputs:
-  uv-cache-dir:
-    description: 'The image-versioned UV_CACHE_DIR that was exported.'
-    value: ${{ steps.compute.outputs.uv-cache-dir }}
   image-hash:
     description: 'Short hash of the installed ibm-* RPM manifest.'
     value: ${{ steps.compute.outputs.image-hash }}
@@ -49,12 +39,5 @@ runs:
         echo "# Installed ibm-* RPMs:"
         cat "${manifest_file}"
         image_hash=$(sha256sum "${manifest_file}" | cut -c1-12)
-        cache_dir="${{ inputs.cache-root }}/uv-${image_hash}"
-        echo "UV_CACHE_DIR=${cache_dir}" >> "$GITHUB_ENV"
-        # The PVC backing the cache does not support hardlinks across to the
-        # venv filesystem, so force uv to copy. Without this, uv emits a
-        # warning per package on every sync and falls back to copy anyway.
-        echo "UV_LINK_MODE=copy" >> "$GITHUB_ENV"
-        echo "uv-cache-dir=${cache_dir}" >> "$GITHUB_OUTPUT"
         echo "image-hash=${image_hash}" >> "$GITHUB_OUTPUT"
-        echo "::notice::Using UV cache ${cache_dir} (image hash ${image_hash})"
+        echo "::notice::Spyre image hash ${image_hash}"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -48,31 +48,19 @@ jobs:
       - linux
       - image_spyre_inference
     timeout-minutes: 30
-    env:
-      # uv serializes builds of the same package via a per-distribution lock.
-      # On a fresh image-versioned cache dir, several concurrent jobs all try
-      # to build torch-spyre (~50s) and the late arrivals time out at the
-      # default 300s. Bump generously — late jobs just wait, no work is lost.
-      UV_LOCK_TIMEOUT: '1800'
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-    - id: uv-cache
-      name: "Configure image-versioned UV cache"
+    - id: spyre-uv-cache
+      name: "Compute Spyre image hash"
       uses: ./.github/actions/spyre-uv-cache
 
     - name: "Set up Python 3.12"
       uses: astral-sh/setup-uv@v5
       with:
         python-version: "3.12"
-        # GHA caching disabled on self-hosted runners — we point uv at the
-        # PVC instead. Despite what the docs imply, setup-uv@v5 *will*
-        # overwrite a pre-set UV_CACHE_DIR with its own temp path during
-        # this step (observed: "Set UV_CACHE_DIR to /…/_temp/setup-uv-cache").
-        # `cache-local-path` is the only input it reliably honors, so we
-        # pass the same value our spyre-uv-cache action exported.
-        enable-cache: false
-        cache-local-path: ${{ steps.uv-cache.outputs.uv-cache-dir }}
+        enable-cache: true
+        cache-suffix: ${{ steps.spyre-uv-cache.outputs.image-hash }}
     - name: "Install dependencies"
       run: |
         source /etc/profile.d/ibm-aiu-setup.sh

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: "Set up Python 3.12"
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
         python-version: "3.12"
         enable-cache: true
@@ -56,11 +56,12 @@ jobs:
       uses: ./.github/actions/spyre-uv-cache
 
     - name: "Set up Python 3.12"
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
         python-version: "3.12"
         enable-cache: true
         cache-suffix: ${{ steps.spyre-uv-cache.outputs.image-hash }}
+        prune-cache: false
     - name: "Install dependencies"
       run: |
         source /etc/profile.d/ibm-aiu-setup.sh

--- a/.github/workflows/test_each_commit.yaml
+++ b/.github/workflows/test_each_commit.yaml
@@ -88,10 +88,14 @@ jobs:
         uses: ./.github/actions/spyre-uv-cache
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
         with:
           enable-cache: true
           cache-suffix: ${{ steps.spyre-uv-cache.outputs.image-hash }}
+          # `uv cache prune --ci` (setup-uv's default) removes pre-built wheels,
+          # causing torch/vllm/torch-spyre to be rebuilt on every run despite a
+          # cache hit. Keep all wheels; the cache key (uv.lock hash) handles eviction.
+          prune-cache: false
 
       - uses: ./.github/actions/build-spyre-deps
         if: ${{ inputs.torch_spyre_ref != '' }}

--- a/.github/workflows/test_each_commit.yaml
+++ b/.github/workflows/test_each_commit.yaml
@@ -79,20 +79,19 @@ jobs:
       CI: ''
       STORAGE_1_DIR: /storage-1/spyre-inference
       HF_HOME: /storage-1/spyre-inference/.cache/huggingface
-      # UV_CACHE_DIR is exported by the spyre-uv-cache action below, keyed by
-      # the Spyre image's component manifest hash so torch-spyre wheels built
-      # against one runtime cannot be reused after an image bump.
-      # uv serializes builds of the same package via a per-distribution lock.
-      # On a fresh image-versioned cache dir, several concurrent jobs all try
-      # to build torch-spyre (~50s) and the late arrivals time out at the
-      # default 300s. Bump generously — late jobs just wait, no work is lost.
-      UV_LOCK_TIMEOUT: '1800'
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Configure image-versioned UV cache
+      - name: Compute Spyre image hash
+        id: spyre-uv-cache
         uses: ./.github/actions/spyre-uv-cache
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-suffix: ${{ steps.spyre-uv-cache.outputs.image-hash }}
 
       - uses: ./.github/actions/build-spyre-deps
         if: ${{ inputs.torch_spyre_ref != '' }}

--- a/.github/workflows/test_each_commit.yaml
+++ b/.github/workflows/test_each_commit.yaml
@@ -125,6 +125,10 @@ jobs:
           ls -lart
           echo "---"
 
+      - name: Dump UV cache info
+        run: |
+          find "$(uv cache dir)" -name '*.whl' -printf '%f\n' | sort -u
+
       - name: Build spyre-inference
         env:
           TORCH_SPYRE_REF: "${{ inputs.torch_spyre_ref }}"


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

This PR:
- updates our uv caching strategy to use the stock GHA cache instead of a shared pvc mount. This prevents thrashing of lockfiles when many jobs are accessing the same shared uv cache over network attached storage. The cache size is <1GB and seems to transfer pretty quickly from github
- updates our uv cache hash key to use `rpm` as the source of truth for installed ibm libraries. This is far more robust than using a prebaked manifest file. 
- prints the versions of each ibm library so that we know exactly what the CI worker has installed, and can replicate failures in our dev environments.

## Related Issues

## Test Plan

## Checklist

- [ ] I have read the [contributing guidelines](https://torch-spyre.github.io/spyre-inference/contributing/)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
