### PR TITLE
:bug: align cache between test and type check

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,7 @@
 self-hosted-runner:
   labels:
     - x86_64
+    - spyre_pf_x0
     - spyre_pf_x1
     - spyre_pf_x0__pvc_1tb_x1
     - spyre_pf_x1__pvc_1tb_x1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -40,11 +40,10 @@ jobs:
     # `ty` needs the real torch/vllm/torch-spyre deps to type check imports,
     # which need the spyre runtime libs (carried by `image_spyre_inference`)
     # to install. The check itself does not exercise the Spyre device, so it
-    # runs on `spyre_pf_x0` (no cards). The `__pvc_1tb_x1` suffix gives us a
-    # persistent volume so we can cache `uv` artifacts across runs.
+    # runs on `spyre_pf_x0` (no cards).
     runs-on:
       - x86_64
-      - spyre_pf_x0__pvc_1tb_x1
+      - spyre_pf_x0
       - linux
       - image_spyre_inference
     timeout-minutes: 30
@@ -60,6 +59,7 @@ jobs:
       with:
         enable-cache: true
         cache-suffix: ${{ steps.spyre-uv-cache.outputs.image-hash }}
+        cache-local-path: ${{ runner.temp }}/setup-uv-cache
         prune-cache: false
 
     - name: "Install dependencies"

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -55,17 +55,18 @@ jobs:
       name: "Compute Spyre image hash"
       uses: ./.github/actions/spyre-uv-cache
 
-    - name: "Set up Python 3.12"
+    - name: "Set up Python"
       uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       with:
-        python-version: "3.12"
         enable-cache: true
         cache-suffix: ${{ steps.spyre-uv-cache.outputs.image-hash }}
         prune-cache: false
+
     - name: "Install dependencies"
       run: |
         source /etc/profile.d/ibm-aiu-setup.sh
         uv sync --frozen --no-dev -v
+
     - name: "Run ty via prek"
       run: |
         source /etc/profile.d/ibm-aiu-setup.sh

--- a/.github/workflows/test_each_commit.yaml
+++ b/.github/workflows/test_each_commit.yaml
@@ -92,6 +92,8 @@ jobs:
         with:
           enable-cache: true
           cache-suffix: ${{ steps.spyre-uv-cache.outputs.image-hash }}
+          # Use local runner temp to avoid ownership/permission issues on $HOME.
+          cache-local-path: ${{ runner.temp }}/setup-uv-cache
           # `uv cache prune --ci` (setup-uv's default) removes pre-built wheels,
           # causing torch/vllm/torch-spyre to be rebuilt on every run despite a
           # cache hit. Keep all wheels; the cache key (uv.lock hash) handles eviction.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

The type checking job pins the python version to `3.12` which ends up generating a different cache key for the uv cache than the test job. This duplicates ~2GB of cache. This fixes that

## Related Issues

## Test Plan

- [ ] check GHA cache keys on re-run

## Checklist

- [ ] I have read the [contributing guidelines](https://torch-spyre.github.io/spyre-inference/contributing/)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
