### PR TITLE
👷  Use prebuilt vllm wheels on linux

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,10 +101,8 @@ extra-build-variables = { vllm = { VLLM_TARGET_DEVICE = "cpu", CMAKE_ARGS = "--f
 vllm = [
   # Pre-built CPU wheel — avoids ~30 min C++ kernel compilation on x86_64 Linux CI runners.
   # manylinux_2_35 requires glibc >= 2.35; RHEL 10.2 ships 2.39 so this is compatible.
-  { url = "https://github.com/vllm-project/vllm/releases/download/v0.20.1/vllm-0.20.1%2Bcpu-cp38-abi3-manylinux_2_35_x86_64.whl",
-    marker = "sys_platform == 'linux' and platform_machine == 'x86_64'" },
-  { git = "https://github.com/vllm-project/vllm", rev = "v0.20.1",
-    marker = "sys_platform != 'linux' or platform_machine != 'x86_64'" },
+  { url = "https://github.com/vllm-project/vllm/releases/download/v0.20.1/vllm-0.20.1%2Bcpu-cp38-abi3-manylinux_2_35_x86_64.whl", marker = "sys_platform == 'linux' and platform_machine == 'x86_64'" },
+  { git = "https://github.com/vllm-project/vllm", rev = "v0.20.1", marker = "sys_platform != 'linux' or platform_machine != 'x86_64'" },
 ]
 torch-spyre = { git = "https://github.com/torch-spyre/torch-spyre", rev = "a6baa9c73b2de0f1b199c2c567d8609720bcf5a8" }
 torch = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,10 +99,10 @@ extra-build-variables = { vllm = { VLLM_TARGET_DEVICE = "cpu", CMAKE_ARGS = "--f
 # NB: torch-spyre can only be compiled where `sendnn` is available
 [tool.uv.sources]
 vllm = [
-  # Pre-built CPU wheel — avoids ~30 min C++ kernel compilation on x86_64 Linux CI runners.
+  # Pre-built CPU wheels (x86_64 + aarch64) — avoids ~30 min C++ kernel compilation on Linux CI.
   # manylinux_2_35 requires glibc >= 2.35; RHEL 10.2 ships 2.39 so this is compatible.
-  { url = "https://github.com/vllm-project/vllm/releases/download/v0.20.1/vllm-0.20.1%2Bcpu-cp38-abi3-manylinux_2_35_x86_64.whl", marker = "sys_platform == 'linux' and platform_machine == 'x86_64'" },
-  { git = "https://github.com/vllm-project/vllm", rev = "v0.20.1", marker = "sys_platform != 'linux' or platform_machine != 'x86_64'" },
+  { index = "vllm-cpu", marker = "sys_platform == 'linux'" },
+  { git = "https://github.com/vllm-project/vllm", rev = "v0.20.1", marker = "sys_platform != 'linux'" },
 ]
 torch-spyre = { git = "https://github.com/torch-spyre/torch-spyre", rev = "a6baa9c73b2de0f1b199c2c567d8609720bcf5a8" }
 torch = [
@@ -129,9 +129,17 @@ members = ["tests/plugin"]
 #     "ninja",
 # ]
 
+# Pre-built vllm CPU wheels (x86_64 + aarch64 Linux). The path component is the git commit SHA
+# for the pinned rev (v0.20.1 = 132765e3560659ff63ebd236203672e991b70e08). Update both this hash
+# and the rev in tool.uv.sources together when bumping vllm.
+[[tool.uv.index]]
+name = "vllm-cpu"
+url = "https://wheels.vllm.ai/132765e3560659ff63ebd236203672e991b70e08/cpu"
+explicit = true
+
 # The pytorch-cpu index here ensures we always pull the cpu version of torch everywhere
 # The `explicit=true` setting means this index will only be used for packages that we explicitly set
-# it for in `tool.uv.sources`. This is important to avoid requiring the use of 
+# it for in `tool.uv.sources`. This is important to avoid requiring the use of
 # `--index-strategy unsafe-best-match`
 [[tool.uv.index]]
 name = "pytorch-cpu"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,7 +98,14 @@ extra-build-variables = { vllm = { VLLM_TARGET_DEVICE = "cpu", CMAKE_ARGS = "--f
 # vLLM and torch-spyre must be pulled from github to be built from source
 # NB: torch-spyre can only be compiled where `sendnn` is available
 [tool.uv.sources]
-vllm = { git = "https://github.com/vllm-project/vllm", rev = "v0.20.1" }
+vllm = [
+  # Pre-built CPU wheel — avoids ~30 min C++ kernel compilation on x86_64 Linux CI runners.
+  # manylinux_2_35 requires glibc >= 2.35; RHEL 10.2 ships 2.39 so this is compatible.
+  { url = "https://github.com/vllm-project/vllm/releases/download/v0.20.1/vllm-0.20.1%2Bcpu-cp38-abi3-manylinux_2_35_x86_64.whl",
+    marker = "sys_platform == 'linux' and platform_machine == 'x86_64'" },
+  { git = "https://github.com/vllm-project/vllm", rev = "v0.20.1",
+    marker = "sys_platform != 'linux' or platform_machine != 'x86_64'" },
+]
 torch-spyre = { git = "https://github.com/torch-spyre/torch-spyre", rev = "a6baa9c73b2de0f1b199c2c567d8609720bcf5a8" }
 torch = [
   { index = "pytorch-cpu" },

--- a/tests/plugin/spyre_testing_plugin/pytest_plugin.py
+++ b/tests/plugin/spyre_testing_plugin/pytest_plugin.py
@@ -55,6 +55,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import tomllib
 import torch.distributed as dist
 import torch.testing
 
@@ -204,21 +205,28 @@ def _extract_vllm_commit_from_pyproject() -> str:
     Raises FileNotFoundError if pyproject.toml is missing, or KeyError
     if the expected source entry is not found.
     """
-    # Look for pyproject.toml at repo root
     repo_root_dir = Path(__file__).parent.parent.parent.parent
     pyproject_path = repo_root_dir / "pyproject.toml"
     if not pyproject_path.exists():
         raise FileNotFoundError(f"pyproject.toml not found in {repo_root_dir}")
 
-    content = pyproject_path.read_text()
-    # Look for vllm source with git and rev
-    # Pattern: vllm = { git = "...", rev = "commit_sha_or_semver_tag" }
-    match = re.search(
-        r'vllm\s*=\s*\{\s*git\s*=\s*"[^"]+"\s*,\s*rev\s*=\s*"([0-9a-f]{7,40}|v\d+\.\d+\.\d+(?:-[a-zA-Z0-9.]+)?)"\s*\}',
-        content,
-    )
-    if match:
-        return match.group(1)
+    with open(pyproject_path, "rb") as f:
+        data = tomllib.load(f)
+
+    try:
+        vllm_source = data["tool"]["uv"]["sources"]["vllm"]
+    except KeyError as e:
+        raise KeyError(
+            f"Ensure vllm is specified with 'rev' in pyproject.toml [tool.uv.sources]: missing key {e}"
+        ) from e
+
+    # Handle both a single source dict and a list of sources (e.g. index + git fallback)
+    if isinstance(vllm_source, list):
+        for source in vllm_source:
+            if isinstance(source, dict) and "git" in source and "rev" in source:
+                return source["rev"]
+    elif isinstance(vllm_source, dict) and "git" in vllm_source and "rev" in vllm_source:
+        return vllm_source["rev"]
 
     raise KeyError("Ensure vllm is specified with 'rev' in pyproject.toml [tool.uv.sources]")
 

--- a/tests/plugin/spyre_testing_plugin/pytest_plugin.py
+++ b/tests/plugin/spyre_testing_plugin/pytest_plugin.py
@@ -217,7 +217,8 @@ def _extract_vllm_commit_from_pyproject() -> str:
         vllm_source = data["tool"]["uv"]["sources"]["vllm"]
     except KeyError as e:
         raise KeyError(
-            f"Ensure vllm is specified with 'rev' in pyproject.toml [tool.uv.sources]: missing key {e}"
+            "Ensure vllm is specified with 'rev' in pyproject.toml"
+            f" [tool.uv.sources]: missing key {e}"
         ) from e
 
     # Handle both a single source dict and a list of sources (e.g. index + git fallback)

--- a/uv.lock
+++ b/uv.lock
@@ -4,15 +4,21 @@ requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux'",
+    "python_full_version >= '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux'",
+    "python_full_version >= '3.14' and platform_machine != 'aarch64' and platform_machine in 's390x, ppc64le' and sys_platform == 'linux'",
     "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine == 'x86_64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine != 'aarch64' and platform_machine in 's390x, ppc64le' and sys_platform == 'linux'",
     "python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
     "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
     "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_machine in 's390x, ppc64le' and sys_platform == 'linux'",
     "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
     "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
     "python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
@@ -31,7 +37,9 @@ resolution-markers = [
     "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
     "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'win32'",
     "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'emscripten'",
-    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and platform_machine == 'x86_64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine in 's390x, ppc64le' and sys_platform == 'linux'",
     "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
     "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
     "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32'",
@@ -58,7 +66,8 @@ overrides = [
     { name = "torch", marker = "platform_machine not in 's390x, ppc64le'", specifier = "==2.11.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "torchvision", marker = "sys_platform == 'never'", index = "https://download.pytorch.org/whl/cpu" },
     { name = "triton", marker = "sys_platform == 'never'" },
-    { name = "vllm", marker = "platform_machine not in 's390x, ppc64le'", git = "https://github.com/vllm-project/vllm?rev=v0.20.1" },
+    { name = "vllm", marker = "platform_machine not in 's390x, ppc64le' and sys_platform == 'linux'", index = "https://wheels.vllm.ai/132765e3560659ff63ebd236203672e991b70e08/cpu" },
+    { name = "vllm", marker = "platform_machine not in 's390x, ppc64le' and sys_platform != 'linux'", git = "https://github.com/vllm-project/vllm?rev=v0.20.1" },
 ]
 build-constraints = [{ name = "torch", specifier = "==2.11.0", index = "https://download.pytorch.org/whl/cpu" }]
 
@@ -283,14 +292,14 @@ name = "anthropic"
 version = "0.102.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "docstring-parser" },
-    { name = "httpx" },
-    { name = "jiter" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "typing-extensions" },
+    { name = "anyio", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "distro", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "docstring-parser", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "httpx", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "jiter", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "pydantic", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "sniffio", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "typing-extensions", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/47/cb2a71f70431fb09af4db83e3ea89eb2dd8e0e348d27af53ed32e6c599dd/anthropic-0.102.0.tar.gz", hash = "sha256:96f747cad11886c4ae12d4080131b94eebd68b202bd2190fe27959031bb1fa9c", size = 763697, upload-time = "2026-05-13T18:12:41.624Z" }
 wheels = [
@@ -315,7 +324,7 @@ name = "apache-tvm-ffi"
 version = "0.1.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6d/3d/4b9226cd45aa800a6904603dda9b323d728f3c3869952a673f3483b78b19/apache_tvm_ffi-0.1.11.tar.gz", hash = "sha256:153cd2c5a9717804cb0bcd9b2709f22a1e5f80ed05b5a490faf5949b136eedba", size = 2798354, upload-time = "2026-05-04T17:48:43.852Z" }
 wheels = [
@@ -599,7 +608,7 @@ name = "blake3"
 version = "1.0.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.12' and platform_machine == 'aarch64') or (python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or (python_full_version < '3.12' and sys_platform != 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/75/aa/abcd75e9600987a0bc6cfe9b6b2ff3f0e2cb08c170addc6e76035b5c4cb3/blake3-1.0.8.tar.gz", hash = "sha256:513cc7f0f5a7c035812604c2c852a0c1468311345573de647e310aca4ab165ba", size = 117308, upload-time = "2025-10-14T06:47:48.83Z" }
 wheels = [
@@ -1044,11 +1053,11 @@ name = "compressed-tensors"
 version = "0.15.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "loguru" },
-    { name = "pydantic" },
+    { name = "loguru", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "pydantic", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
     { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'darwin'" },
     { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and platform_machine not in 's390x, ppc64le') or (platform_machine not in 's390x, ppc64le' and sys_platform != 'darwin')" },
-    { name = "transformers" },
+    { name = "transformers", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/41/1b/c3c4a98ec5f2727656336f07a0c35862195c310d8eb0b2fa5b4be6848680/compressed_tensors-0.15.0.1.tar.gz", hash = "sha256:a8e93054e8a5ec49c980b09ed36c4c1249b4a8ee167920a8e461c4da26e78d99", size = 229412, upload-time = "2026-04-10T14:23:54.708Z" }
 wheels = [
@@ -1470,7 +1479,7 @@ name = "decord"
 version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "platform_machine != 'aarch64'" },
+    { name = "numpy", marker = "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and platform_machine in 's390x, ppc64le') or (platform_machine != 'aarch64' and sys_platform != 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/79/936af42edf90a7bd4e41a6cac89c913d4b47fa48a26b042d5129a9242ee3/decord-0.6.0-py3-none-manylinux2010_x86_64.whl", hash = "sha256:51997f20be8958e23b7c4061ba45d0efcd86bffd5fe81c695d0befee0d442976", size = 13602299, upload-time = "2021-06-14T21:30:55.486Z" },
@@ -1482,8 +1491,8 @@ name = "depyf"
 version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "astor" },
-    { name = "dill" },
+    { name = "astor", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "dill", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/88/35/83fb0178212279aa0af031031905804c6de5618435d229f41ed21bb9ad2c/depyf-0.20.0.tar.gz", hash = "sha256:fb7683bd72c44f67b56029df2c47721e9a02ffa4d7b19095f1c54c4ebf797a98", size = 6168761, upload-time = "2025-10-13T12:33:38.589Z" }
 wheels = [
@@ -1583,8 +1592,8 @@ name = "email-validator"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dnspython" },
-    { name = "idna" },
+    { name = "dnspython", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "idna", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
 wheels = [
@@ -1640,11 +1649,11 @@ name = "fastapi"
 version = "0.135.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "annotated-doc" },
-    { name = "pydantic" },
-    { name = "starlette" },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
+    { name = "annotated-doc", marker = "(python_full_version >= '3.12' and platform_machine != 'aarch64') or (python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or platform_machine == 'aarch64' or sys_platform != 'linux'" },
+    { name = "pydantic", marker = "(python_full_version >= '3.12' and platform_machine != 'aarch64') or (python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or platform_machine == 'aarch64' or sys_platform != 'linux'" },
+    { name = "starlette", marker = "(python_full_version >= '3.12' and platform_machine != 'aarch64') or (python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or platform_machine == 'aarch64' or sys_platform != 'linux'" },
+    { name = "typing-extensions", marker = "(python_full_version >= '3.12' and platform_machine != 'aarch64') or (python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or platform_machine == 'aarch64' or sys_platform != 'linux'" },
+    { name = "typing-inspection", marker = "(python_full_version >= '3.12' and platform_machine != 'aarch64') or (python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or platform_machine == 'aarch64' or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e7/7b/f8e0211e9380f7195ba3f3d40c292594fd81ba8ec4629e3854c353aaca45/fastapi-0.135.1.tar.gz", hash = "sha256:d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd", size = 394962, upload-time = "2026-03-01T18:18:29.369Z" }
 wheels = [
@@ -1653,14 +1662,14 @@ wheels = [
 
 [package.optional-dependencies]
 standard = [
-    { name = "email-validator" },
-    { name = "fastapi-cli", extra = ["standard"] },
-    { name = "httpx" },
-    { name = "jinja2" },
-    { name = "pydantic-extra-types" },
-    { name = "pydantic-settings" },
-    { name = "python-multipart" },
-    { name = "uvicorn", extra = ["standard"] },
+    { name = "email-validator", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "fastapi-cli", extra = ["standard"], marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "httpx", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "jinja2", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "pydantic-extra-types", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "pydantic-settings", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "python-multipart", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "uvicorn", extra = ["standard"], marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 
 [[package]]
@@ -1668,9 +1677,9 @@ name = "fastapi-cli"
 version = "0.0.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "rich-toolkit" },
-    { name = "typer" },
-    { name = "uvicorn", extra = ["standard"] },
+    { name = "rich-toolkit", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "typer", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "uvicorn", extra = ["standard"], marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6e/58/74797ae9e4610cfa0c6b34c8309096d3b20bb29be3b8b5fbf1004d10fa5f/fastapi_cli-0.0.24.tar.gz", hash = "sha256:1afc9c9e21d7ebc8a3ca5e31790cd8d837742be7e4f8b9236e99cb3451f0de00", size = 19043, upload-time = "2026-02-24T10:45:10.476Z" }
 wheels = [
@@ -1679,8 +1688,8 @@ wheels = [
 
 [package.optional-dependencies]
 standard = [
-    { name = "fastapi-cloud-cli" },
-    { name = "uvicorn", extra = ["standard"] },
+    { name = "fastapi-cloud-cli", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "uvicorn", extra = ["standard"], marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 
 [[package]]
@@ -1688,14 +1697,14 @@ name = "fastapi-cloud-cli"
 version = "0.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "fastar" },
-    { name = "httpx" },
-    { name = "pydantic", extra = ["email"] },
-    { name = "rich-toolkit" },
-    { name = "rignore" },
-    { name = "sentry-sdk" },
-    { name = "typer" },
-    { name = "uvicorn", extra = ["standard"] },
+    { name = "fastar", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "httpx", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "pydantic", extra = ["email"], marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "rich-toolkit", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "rignore", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "sentry-sdk", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "typer", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "uvicorn", extra = ["standard"], marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/57/cee8e91b83f39e75ae5562a2237261442a8179dcb3b631c7398113157398/fastapi_cloud_cli-0.17.1.tar.gz", hash = "sha256:0baece208fa88063bec46dccb5fb512f3199162092165e57654b44e64adbc44d", size = 47409, upload-time = "2026-04-27T13:38:07.094Z" }
 wheels = [
@@ -2122,10 +2131,10 @@ name = "gguf"
 version = "0.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "tqdm" },
+    { name = "numpy", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "pyyaml", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "requests", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "tqdm", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/ae/17f1308ae45cd7b08ebb521747d5b23f4efc4d172038a4e228dd5106c3ff/gguf-0.19.0.tar.gz", hash = "sha256:dbadcd6cc7ccd44256f2229fe7c2dff5e8aa5cf0612ab987fd2b1a57e428923f", size = 111220, upload-time = "2026-05-06T13:04:03.667Z" }
 wheels = [
@@ -2809,7 +2818,7 @@ name = "importlib-metadata"
 version = "8.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
@@ -3443,10 +3452,10 @@ name = "lm-format-enforcer"
 version = "0.11.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "interegular" },
-    { name = "packaging" },
-    { name = "pydantic" },
-    { name = "pyyaml" },
+    { name = "interegular", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "packaging", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "pydantic", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "pyyaml", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/84/d5/41cd417ba7dfdbbcfe46cebf81fb3dfd7c591b89897560ad05bb410a465d/lm_format_enforcer-0.11.3.tar.gz", hash = "sha256:e68081c108719cce284a9bcc889709b26ffb085a1945b5eba3a12cfa96d528da", size = 40258, upload-time = "2025-08-24T19:37:47.527Z" }
 wheels = [
@@ -3756,20 +3765,20 @@ name = "mcp"
 version = "1.27.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
-    { name = "jsonschema" },
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
-    { name = "pyjwt", extra = ["crypto"] },
-    { name = "python-multipart" },
+    { name = "anyio", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "httpx", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "httpx-sse", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "jsonschema", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "pydantic", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "pydantic-settings", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "pyjwt", extra = ["crypto"], marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "python-multipart", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
-    { name = "sse-starlette" },
-    { name = "starlette" },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
-    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+    { name = "sse-starlette", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "starlette", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "typing-extensions", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "typing-inspection", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "uvicorn", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'emscripten' and sys_platform != 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458, upload-time = "2026-05-08T16:50:12.601Z" }
 wheels = [
@@ -3818,13 +3827,13 @@ name = "model-hosting-container-standards"
 version = "0.1.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "fastapi" },
-    { name = "httpx" },
-    { name = "jmespath" },
-    { name = "pydantic" },
-    { name = "setuptools" },
-    { name = "starlette" },
-    { name = "supervisor" },
+    { name = "fastapi", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "httpx", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "jmespath", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "pydantic", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "setuptools", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "starlette", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "supervisor", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/03/5a/d669bdeb5ba96db42c6ef010835a25119b05f8c35ee5f1c3f715626625fe/model_hosting_container_standards-0.1.15.tar.gz", hash = "sha256:ae8dd74d3250545c14f0a7068186c7b0f0ab6563d31e7137f556b6b660c8a6a9", size = 93994, upload-time = "2026-05-05T18:22:29.357Z" }
 wheels = [
@@ -4325,14 +4334,14 @@ name = "openai"
 version = "2.36.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "httpx" },
-    { name = "jiter" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "tqdm" },
-    { name = "typing-extensions" },
+    { name = "anyio", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "distro", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "httpx", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "jiter", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "pydantic", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "sniffio", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "tqdm", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "typing-extensions", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f4/a1/4d5e84cf51720fc1526cc49e10ac1961abcccb55b0efb3d970db1e9a2728/openai-2.36.0.tar.gz", hash = "sha256:139dea0edd2f1b30c33d46ae1a6929e03906254140318e4608e98fe8c566f2e7", size = 753003, upload-time = "2026-05-07T17:33:17.075Z" }
 wheels = [
@@ -4344,7 +4353,7 @@ name = "openai-harmony"
 version = "0.0.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic" },
+    { name = "pydantic", marker = "(python_full_version >= '3.12' and platform_machine != 'aarch64') or (python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or platform_machine == 'aarch64' or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3e/92/2d038d096f29179c7c9571b431f9e739f87a487121901725e23fe338dd9d/openai_harmony-0.0.8.tar.gz", hash = "sha256:6e43f98e6c242fa2de6f8ea12eab24af63fa2ed3e89c06341fb9d92632c5cbdf", size = 284777, upload-time = "2025-11-05T19:07:06.727Z" }
 wheels = [
@@ -4396,8 +4405,8 @@ name = "opentelemetry-api"
 version = "1.41.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "importlib-metadata" },
-    { name = "typing-extensions" },
+    { name = "importlib-metadata", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "typing-extensions", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fa/fc/b7564cbef36601aef0d6c9bc01f7badb64be8e862c2e1c3c5c3b43b53e4f/opentelemetry_api-1.41.1.tar.gz", hash = "sha256:0ad1814d73b875f84494387dae86ce0b12c68556331ce6ce8fe789197c949621", size = 71416, upload-time = "2026-04-24T13:15:38.262Z" }
 wheels = [
@@ -4409,8 +4418,8 @@ name = "opentelemetry-exporter-otlp"
 version = "1.41.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-exporter-otlp-proto-grpc" },
-    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "opentelemetry-exporter-otlp-proto-http", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/84/d55baf8e1a222f40282956083e67de9fa92d5fa451108df4839505fa2a24/opentelemetry_exporter_otlp-1.41.1.tar.gz", hash = "sha256:299a2f0541ca175df186f5ac58fd5db177ba1e9b72b0826049062f750d55b47f", size = 6152, upload-time = "2026-04-24T13:15:40.006Z" }
 wheels = [
@@ -4422,7 +4431,7 @@ name = "opentelemetry-exporter-otlp-proto-common"
 version = "1.41.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-proto", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/fa/f9e3bd3c4d692b3ce9a2880a167d1f79681a1bea11f00d5bf76adc03e6ea/opentelemetry_exporter_otlp_proto_common-1.41.1.tar.gz", hash = "sha256:0e253156ea9c36b0bd3d2440c5c9ba7dd1f3fb64ba7a08fc85fbac536b56e1fb", size = 20409, upload-time = "2026-04-24T13:15:40.924Z" }
 wheels = [
@@ -4434,13 +4443,13 @@ name = "opentelemetry-exporter-otlp-proto-grpc"
 version = "1.41.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "googleapis-common-protos" },
-    { name = "grpcio" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp-proto-common" },
-    { name = "opentelemetry-proto" },
-    { name = "opentelemetry-sdk" },
-    { name = "typing-extensions" },
+    { name = "googleapis-common-protos", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "grpcio", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "opentelemetry-api", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "opentelemetry-exporter-otlp-proto-common", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "opentelemetry-proto", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "opentelemetry-sdk", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "typing-extensions", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1e/9b/e4503060b8695579dbaad187dc8cef4554188de68748c88060599b77489e/opentelemetry_exporter_otlp_proto_grpc-1.41.1.tar.gz", hash = "sha256:b05df8fa1333dc9a3fda36b676b96b5095ab6016d3f0c3296d430d629ba1443b", size = 25755, upload-time = "2026-04-24T13:15:41.93Z" }
 wheels = [
@@ -4452,13 +4461,13 @@ name = "opentelemetry-exporter-otlp-proto-http"
 version = "1.41.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "googleapis-common-protos" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp-proto-common" },
-    { name = "opentelemetry-proto" },
-    { name = "opentelemetry-sdk" },
-    { name = "requests" },
-    { name = "typing-extensions" },
+    { name = "googleapis-common-protos", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "opentelemetry-api", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "opentelemetry-exporter-otlp-proto-common", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "opentelemetry-proto", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "opentelemetry-sdk", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "requests", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "typing-extensions", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/5b/9d3c7f70cca10136ba82a81e738dee626c8e7fc61c6887ea9a58bf34c606/opentelemetry_exporter_otlp_proto_http-1.41.1.tar.gz", hash = "sha256:4747a9604c8550ab38c6fd6180e2fcb80de3267060bef2c306bad3cb443302bc", size = 24139, upload-time = "2026-04-24T13:15:42.977Z" }
 wheels = [
@@ -4470,7 +4479,7 @@ name = "opentelemetry-proto"
 version = "1.41.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "protobuf" },
+    { name = "protobuf", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/99/e8/633c6d8a9c8840338b105907e55c32d3da1983abab5e52f899f72a82c3d1/opentelemetry_proto-1.41.1.tar.gz", hash = "sha256:4b9d2eb631237ea43b80e16c073af438554e32bc7e9e3f8ca4a9582f900020e5", size = 45670, upload-time = "2026-04-24T13:15:49.768Z" }
 wheels = [
@@ -4482,9 +4491,9 @@ name = "opentelemetry-sdk"
 version = "1.41.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "typing-extensions" },
+    { name = "opentelemetry-api", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "opentelemetry-semantic-conventions", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "typing-extensions", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/d0/54ee30dab82fb0acda23d144502771ff76ef8728459c83c3e89ef9fb1825/opentelemetry_sdk-1.41.1.tar.gz", hash = "sha256:724b615e1215b5aeacda0abb8a6a8922c9a1853068948bd0bd225a56d0c792e6", size = 230180, upload-time = "2026-04-24T13:15:50.991Z" }
 wheels = [
@@ -4496,8 +4505,8 @@ name = "opentelemetry-semantic-conventions"
 version = "0.62b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "typing-extensions" },
+    { name = "opentelemetry-api", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "typing-extensions", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9e/de/911ac9e309052aca1b20b2d5549d3db45d1011e1a610e552c6ccdd1b64f8/opentelemetry_semantic_conventions-0.62b1.tar.gz", hash = "sha256:c5cc6e04a7f8c7cdd30be2ed81499fa4e75bfbd52c9cb70d40af1f9cd3619802", size = 145750, upload-time = "2026-04-24T13:15:52.236Z" }
 wheels = [
@@ -4509,8 +4518,8 @@ name = "opentelemetry-semantic-conventions-ai"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-sdk" },
-    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-sdk", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "opentelemetry-semantic-conventions", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/24/02/10aeacc37a38a3a8fa16ff67bec1ae3bf882539f6f9efb0f70acf802ca2d/opentelemetry_semantic_conventions_ai-0.5.1.tar.gz", hash = "sha256:153906200d8c1d2f8e09bd78dbef526916023de85ac3dab35912bfafb69ff04c", size = 26533, upload-time = "2026-03-26T14:20:38.73Z" }
 wheels = [
@@ -4994,8 +5003,8 @@ name = "prometheus-fastapi-instrumentator"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "prometheus-client" },
-    { name = "starlette" },
+    { name = "prometheus-client", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "starlette", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/69/6d/24d53033cf93826aa7857699a4450c1c67e5b9c710e925b1ed2b320c04df/prometheus_fastapi_instrumentator-7.1.0.tar.gz", hash = "sha256:be7cd61eeea4e5912aeccb4261c6631b3f227d8924542d79eaf5af3f439cbe5e", size = 20220, upload-time = "2025-03-19T19:35:05.351Z" }
 wheels = [
@@ -5458,7 +5467,7 @@ wheels = [
 
 [package.optional-dependencies]
 email = [
-    { name = "email-validator" },
+    { name = "email-validator", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 
 [[package]]
@@ -5581,9 +5590,9 @@ name = "pydantic-settings"
 version = "2.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
+    { name = "pydantic", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "python-dotenv", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "typing-inspection", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
 wheels = [
@@ -6106,7 +6115,7 @@ name = "pyzmq"
 version = "27.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "implementation_name == 'pypy'" },
+    { name = "cffi", marker = "(python_full_version >= '3.12' and implementation_name == 'pypy' and platform_machine != 'aarch64') or (python_full_version < '3.12' and implementation_name == 'pypy' and platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or (implementation_name == 'pypy' and platform_machine == 'aarch64') or (implementation_name == 'pypy' and sys_platform != 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
 wheels = [
@@ -6243,14 +6252,14 @@ name = "ray"
 version = "2.54.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "filelock" },
-    { name = "jsonschema" },
-    { name = "msgpack" },
-    { name = "packaging" },
-    { name = "protobuf" },
-    { name = "pyyaml" },
-    { name = "requests" },
+    { name = "click", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "filelock", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "jsonschema", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "msgpack", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "packaging", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "protobuf", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "pyyaml", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "requests", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/08/58/6209b2231947f3c8df09ce1436f1c76c4a11fcafd57c8def852dcbb6d8ef/ray-2.54.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:8e39dd56b47a0a1820d5a5a54385bbe54d1d67e1093736d12d8ed4e99d0fa455", size = 70098998, upload-time = "2026-02-18T04:04:58.801Z" },
@@ -6477,9 +6486,9 @@ name = "rich-toolkit"
 version = "0.19.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "rich" },
-    { name = "typing-extensions" },
+    { name = "click", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "rich", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "typing-extensions", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8f/10/dc6e64e85244971671981dc26b09353a1564f5e61b977c80180dc42ad90b/rich_toolkit-0.19.9.tar.gz", hash = "sha256:fce5c6f41f79382ecf60a79851b2543f627568e3e07c78ab4b8542e1ca247d1c", size = 197653, upload-time = "2026-05-13T09:55:04.286Z" }
 wheels = [
@@ -7081,8 +7090,8 @@ name = "sentry-sdk"
 version = "2.60.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
-    { name = "urllib3" },
+    { name = "certifi", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "urllib3", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/54/a2/2e6c090db384cc515069f4f85542bd5baf6786852073020ea73d4a76d3ea/sentry_sdk-2.60.0.tar.gz", hash = "sha256:0bd25e54e78ca02d0be512529fa644bbbf9e8470d7b26371294012d4ca93c978", size = 452946, upload-time = "2026-05-13T13:34:52.516Z" }
 wheels = [
@@ -7361,7 +7370,8 @@ dependencies = [
     { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'darwin'" },
     { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and platform_machine not in 's390x, ppc64le') or (platform_machine not in 's390x, ppc64le' and sys_platform != 'darwin')" },
     { name = "torch-spyre" },
-    { name = "vllm", marker = "platform_machine not in 's390x, ppc64le'" },
+    { name = "vllm", version = "0.20.1+cpu", source = { registry = "https://wheels.vllm.ai/132765e3560659ff63ebd236203672e991b70e08/cpu" }, marker = "platform_machine not in 's390x, ppc64le' and sys_platform == 'linux'" },
+    { name = "vllm", version = "0.20.1+cpu", source = { git = "https://github.com/vllm-project/vllm?rev=v0.20.1#132765e3560659ff63ebd236203672e991b70e08" }, marker = "platform_machine not in 's390x, ppc64le' and sys_platform != 'linux'" },
 ]
 
 [package.dev-dependencies]
@@ -7375,7 +7385,8 @@ dev = [
 requires-dist = [
     { name = "torch", index = "https://download.pytorch.org/whl/cpu" },
     { name = "torch-spyre", git = "https://github.com/torch-spyre/torch-spyre?rev=a6baa9c73b2de0f1b199c2c567d8609720bcf5a8" },
-    { name = "vllm", git = "https://github.com/vllm-project/vllm?rev=v0.20.1" },
+    { name = "vllm", marker = "sys_platform != 'linux'", git = "https://github.com/vllm-project/vllm?rev=v0.20.1" },
+    { name = "vllm", marker = "sys_platform == 'linux'", index = "https://wheels.vllm.ai/132765e3560659ff63ebd236203672e991b70e08/cpu" },
 ]
 
 [package.metadata.requires-dev]
@@ -7596,8 +7607,8 @@ name = "sse-starlette"
 version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "starlette" },
+    { name = "anyio", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "starlette", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f7/2b/58abc2d1fd397e7dde08e947e05c884d8ef2f78d5e2588c17a12d42d6994/sse_starlette-3.4.4.tar.gz", hash = "sha256:07e0fa0460138baf25cdd5fb28683472c3995dc1642225191b3832d62526bcb0", size = 31819, upload-time = "2026-05-12T17:37:17.019Z" }
 wheels = [
@@ -8062,15 +8073,18 @@ source = { registry = "https://download.pytorch.org/whl/cpu" }
 resolution-markers = [
     "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux'",
+    "python_full_version >= '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux'",
     "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine == 'x86_64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux'",
     "python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
     "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
     "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux'",
     "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
     "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'emscripten'",
@@ -8086,7 +8100,8 @@ resolution-markers = [
     "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
     "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'win32'",
     "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'emscripten'",
-    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and platform_machine == 'x86_64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux'",
     "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
     "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32'",
     "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'emscripten'",
@@ -8094,13 +8109,13 @@ resolution-markers = [
     "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "filelock", marker = "platform_machine == 'aarch64' or sys_platform != 'darwin'" },
-    { name = "fsspec", marker = "platform_machine == 'aarch64' or sys_platform != 'darwin'" },
-    { name = "jinja2", marker = "platform_machine == 'aarch64' or sys_platform != 'darwin'" },
-    { name = "networkx", marker = "platform_machine == 'aarch64' or sys_platform != 'darwin'" },
-    { name = "setuptools", marker = "platform_machine == 'aarch64' or sys_platform != 'darwin'" },
-    { name = "sympy", marker = "platform_machine == 'aarch64' or sys_platform != 'darwin'" },
-    { name = "typing-extensions", marker = "platform_machine == 'aarch64' or sys_platform != 'darwin'" },
+    { name = "filelock", marker = "(platform_machine == 'aarch64' and sys_platform == 'darwin') or (platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "fsspec", marker = "(platform_machine == 'aarch64' and sys_platform == 'darwin') or (platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "jinja2", marker = "(platform_machine == 'aarch64' and sys_platform == 'darwin') or (platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "networkx", marker = "(platform_machine == 'aarch64' and sys_platform == 'darwin') or (platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "setuptools", marker = "(platform_machine == 'aarch64' and sys_platform == 'darwin') or (platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "sympy", marker = "(platform_machine == 'aarch64' and sys_platform == 'darwin') or (platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "typing-extensions", marker = "(platform_machine == 'aarch64' and sys_platform == 'darwin') or (platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp311-cp311-linux_s390x.whl", hash = "sha256:5214b203ee187f8746c66f1378b72611b7c1e15c5cb325037541899e705ea24e", upload-time = "2026-04-27T21:55:40Z" },
@@ -8370,8 +8385,8 @@ name = "uvicorn"
 version = "0.41.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "h11" },
+    { name = "click", marker = "(python_full_version >= '3.12' and platform_machine != 'aarch64') or (python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or platform_machine == 'aarch64' or sys_platform != 'linux'" },
+    { name = "h11", marker = "(python_full_version >= '3.12' and platform_machine != 'aarch64') or (python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or platform_machine == 'aarch64' or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
 wheels = [
@@ -8381,12 +8396,12 @@ wheels = [
 [package.optional-dependencies]
 standard = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "httptools" },
-    { name = "python-dotenv" },
-    { name = "pyyaml" },
-    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
-    { name = "watchfiles" },
-    { name = "websockets" },
+    { name = "httptools", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "python-dotenv", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "pyyaml", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "uvloop", marker = "(platform_machine not in 's390x, ppc64le' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (platform_machine == 'aarch64' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'linux' and sys_platform != 'win32')" },
+    { name = "watchfiles", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "websockets", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 
 [[package]]
@@ -8445,70 +8460,185 @@ wheels = [
 [[package]]
 name = "vllm"
 version = "0.20.1+cpu"
-source = { git = "https://github.com/vllm-project/vllm?rev=v0.20.1#132765e3560659ff63ebd236203672e991b70e08" }
+source = { registry = "https://wheels.vllm.ai/132765e3560659ff63ebd236203672e991b70e08/cpu" }
+resolution-markers = [
+    "python_full_version >= '3.14' and platform_machine == 'x86_64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux'",
+    "python_full_version >= '3.14' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine == 'x86_64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine == 'x86_64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and platform_machine == 'x86_64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and platform_machine != 'x86_64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+]
 dependencies = [
-    { name = "aiohttp" },
-    { name = "anthropic" },
-    { name = "blake3" },
-    { name = "cachetools" },
-    { name = "cbor2" },
-    { name = "cloudpickle" },
-    { name = "compressed-tensors" },
-    { name = "depyf" },
-    { name = "diskcache" },
-    { name = "einops" },
-    { name = "fastapi", extra = ["standard"] },
-    { name = "filelock" },
-    { name = "gguf" },
-    { name = "ijson" },
-    { name = "intel-openmp", marker = "platform_machine == 'x86_64'" },
-    { name = "lark" },
-    { name = "llguidance", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ppc64le' or platform_machine == 'x86_64'" },
-    { name = "lm-format-enforcer" },
-    { name = "mcp" },
-    { name = "mistral-common", extra = ["image"] },
-    { name = "model-hosting-container-standards" },
-    { name = "msgspec" },
-    { name = "ninja" },
-    { name = "numba", marker = "platform_machine != 's390x'" },
-    { name = "numpy" },
-    { name = "openai" },
-    { name = "openai-harmony" },
-    { name = "opencv-python-headless" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp" },
-    { name = "opentelemetry-sdk" },
-    { name = "opentelemetry-semantic-conventions-ai" },
-    { name = "outlines-core" },
-    { name = "partial-json-parser" },
-    { name = "pillow" },
-    { name = "prometheus-client" },
-    { name = "prometheus-fastapi-instrumentator" },
-    { name = "protobuf" },
-    { name = "psutil" },
-    { name = "py-cpuinfo" },
-    { name = "pybase64" },
-    { name = "pydantic" },
-    { name = "python-json-logger" },
-    { name = "pyyaml" },
-    { name = "pyzmq" },
-    { name = "regex" },
-    { name = "requests" },
-    { name = "sentencepiece" },
-    { name = "setproctitle" },
-    { name = "setuptools" },
-    { name = "six", marker = "python_full_version >= '3.12'" },
-    { name = "tiktoken" },
-    { name = "tokenizers" },
+    { name = "aiohttp", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "anthropic", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "blake3", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "cachetools", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "cbor2", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "cloudpickle", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "compressed-tensors", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "depyf", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "diskcache", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "einops", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "fastapi", extra = ["standard"], marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "filelock", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "gguf", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "ijson", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "intel-openmp", marker = "platform_machine == 'x86_64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux'" },
+    { name = "lark", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "llguidance", marker = "(platform_machine == 'arm64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'ppc64le' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "lm-format-enforcer", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "mcp", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "mistral-common", extra = ["image"], marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "model-hosting-container-standards", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "msgspec", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "ninja", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "numba", marker = "(platform_machine != 's390x' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "numpy", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "openai", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "openai-harmony", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "opencv-python-headless", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "opentelemetry-api", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "opentelemetry-exporter-otlp", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "opentelemetry-sdk", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "opentelemetry-semantic-conventions-ai", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "outlines-core", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "partial-json-parser", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "pillow", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "prometheus-client", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "prometheus-fastapi-instrumentator", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "protobuf", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "psutil", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "py-cpuinfo", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "pybase64", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "pydantic", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "python-json-logger", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "pyyaml", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "pyzmq", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "regex", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "requests", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "sentencepiece", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "setproctitle", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "setuptools", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "six", marker = "(python_full_version >= '3.12' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (python_full_version >= '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "tiktoken", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "tokenizers", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine not in 's390x, ppc64le' and sys_platform == 'linux'" },
+    { name = "torchaudio", marker = "(platform_machine != 'riscv64' and platform_machine != 's390x' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "tqdm", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "transformers", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "typing-extensions", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "watchfiles", marker = "(platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+    { name = "xgrammar", marker = "(platform_machine == 'arm64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'ppc64le' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 's390x' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'x86_64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
+]
+wheels = [
+    { url = "https://wheels.vllm.ai/132765e3560659ff63ebd236203672e991b70e08/vllm-0.20.1%2Bcpu-cp38-abi3-manylinux_2_35_aarch64.whl" },
+    { url = "https://wheels.vllm.ai/132765e3560659ff63ebd236203672e991b70e08/vllm-0.20.1%2Bcpu-cp38-abi3-manylinux_2_35_x86_64.whl" },
+]
+
+[[package]]
+name = "vllm"
+version = "0.20.1+cpu"
+source = { git = "https://github.com/vllm-project/vllm?rev=v0.20.1#132765e3560659ff63ebd236203672e991b70e08" }
+resolution-markers = [
+    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version >= '3.14' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and platform_machine == 'aarch64' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine == 'aarch64' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'darwin'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "aiohttp", marker = "sys_platform != 'linux'" },
+    { name = "anthropic", marker = "sys_platform != 'linux'" },
+    { name = "blake3", marker = "sys_platform != 'linux'" },
+    { name = "cachetools", marker = "sys_platform != 'linux'" },
+    { name = "cbor2", marker = "sys_platform != 'linux'" },
+    { name = "cloudpickle", marker = "sys_platform != 'linux'" },
+    { name = "compressed-tensors", marker = "sys_platform != 'linux'" },
+    { name = "depyf", marker = "sys_platform != 'linux'" },
+    { name = "diskcache", marker = "sys_platform != 'linux'" },
+    { name = "einops", marker = "sys_platform != 'linux'" },
+    { name = "fastapi", extra = ["standard"], marker = "sys_platform != 'linux'" },
+    { name = "filelock", marker = "sys_platform != 'linux'" },
+    { name = "gguf", marker = "sys_platform != 'linux'" },
+    { name = "ijson", marker = "sys_platform != 'linux'" },
+    { name = "intel-openmp", marker = "platform_machine == 'x86_64' and sys_platform != 'linux'" },
+    { name = "lark", marker = "sys_platform != 'linux'" },
+    { name = "llguidance", marker = "(platform_machine == 'aarch64' and sys_platform != 'linux') or (platform_machine == 'arm64' and sys_platform != 'linux') or (platform_machine == 'ppc64le' and sys_platform != 'linux') or (platform_machine == 'x86_64' and sys_platform != 'linux')" },
+    { name = "lm-format-enforcer", marker = "sys_platform != 'linux'" },
+    { name = "mcp", marker = "sys_platform != 'linux'" },
+    { name = "mistral-common", extra = ["image"], marker = "sys_platform != 'linux'" },
+    { name = "model-hosting-container-standards", marker = "sys_platform != 'linux'" },
+    { name = "msgspec", marker = "sys_platform != 'linux'" },
+    { name = "ninja", marker = "sys_platform != 'linux'" },
+    { name = "numba", marker = "platform_machine != 's390x' and sys_platform != 'linux'" },
+    { name = "numpy", marker = "sys_platform != 'linux'" },
+    { name = "openai", marker = "sys_platform != 'linux'" },
+    { name = "openai-harmony", marker = "sys_platform != 'linux'" },
+    { name = "opencv-python-headless", marker = "sys_platform != 'linux'" },
+    { name = "opentelemetry-api", marker = "sys_platform != 'linux'" },
+    { name = "opentelemetry-exporter-otlp", marker = "sys_platform != 'linux'" },
+    { name = "opentelemetry-sdk", marker = "sys_platform != 'linux'" },
+    { name = "opentelemetry-semantic-conventions-ai", marker = "sys_platform != 'linux'" },
+    { name = "outlines-core", marker = "sys_platform != 'linux'" },
+    { name = "partial-json-parser", marker = "sys_platform != 'linux'" },
+    { name = "pillow", marker = "sys_platform != 'linux'" },
+    { name = "prometheus-client", marker = "sys_platform != 'linux'" },
+    { name = "prometheus-fastapi-instrumentator", marker = "sys_platform != 'linux'" },
+    { name = "protobuf", marker = "sys_platform != 'linux'" },
+    { name = "psutil", marker = "sys_platform != 'linux'" },
+    { name = "py-cpuinfo", marker = "sys_platform != 'linux'" },
+    { name = "pybase64", marker = "sys_platform != 'linux'" },
+    { name = "pydantic", marker = "sys_platform != 'linux'" },
+    { name = "python-json-logger", marker = "sys_platform != 'linux'" },
+    { name = "pyyaml", marker = "sys_platform != 'linux'" },
+    { name = "pyzmq", marker = "sys_platform != 'linux'" },
+    { name = "regex", marker = "sys_platform != 'linux'" },
+    { name = "requests", marker = "sys_platform != 'linux'" },
+    { name = "sentencepiece", marker = "sys_platform != 'linux'" },
+    { name = "setproctitle", marker = "sys_platform != 'linux'" },
+    { name = "setuptools", marker = "sys_platform != 'linux'" },
+    { name = "six", marker = "python_full_version >= '3.12' and sys_platform != 'linux'" },
+    { name = "tiktoken", marker = "sys_platform != 'linux'" },
+    { name = "tokenizers", marker = "sys_platform != 'linux'" },
     { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'darwin'" },
-    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and platform_machine not in 's390x, ppc64le') or (platform_machine not in 's390x, ppc64le' and sys_platform != 'darwin')" },
-    { name = "torchaudio", marker = "platform_machine != 'riscv64' and platform_machine != 's390x'" },
+    { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'darwin') or (platform_machine not in 's390x, ppc64le' and sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "torchaudio", marker = "platform_machine != 'riscv64' and platform_machine != 's390x' and sys_platform != 'linux'" },
     { name = "torchvision", marker = "sys_platform == 'never'" },
-    { name = "tqdm" },
-    { name = "transformers" },
-    { name = "typing-extensions" },
-    { name = "watchfiles" },
-    { name = "xgrammar", marker = "platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'ppc64le' or platform_machine == 's390x' or platform_machine == 'x86_64'" },
+    { name = "tqdm", marker = "sys_platform != 'linux'" },
+    { name = "transformers", marker = "sys_platform != 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform != 'linux'" },
+    { name = "watchfiles", marker = "sys_platform != 'linux'" },
+    { name = "xgrammar", marker = "(platform_machine == 'aarch64' and sys_platform != 'linux') or (platform_machine == 'arm64' and sys_platform != 'linux') or (platform_machine == 'ppc64le' and sys_platform != 'linux') or (platform_machine == 's390x' and sys_platform != 'linux') or (platform_machine == 'x86_64' and sys_platform != 'linux')" },
 ]
 
 [[package]]
@@ -8536,7 +8666,7 @@ name = "watchfiles"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
+    { name = "anyio", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
 wheels = [
@@ -8727,14 +8857,14 @@ name = "xgrammar"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "apache-tvm-ffi" },
-    { name = "numpy" },
-    { name = "pydantic" },
+    { name = "apache-tvm-ffi", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "numpy", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
+    { name = "pydantic", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
     { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le' and sys_platform == 'darwin'" },
     { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine == 'aarch64' and platform_machine not in 's390x, ppc64le') or (platform_machine not in 's390x, ppc64le' and sys_platform != 'darwin')" },
-    { name = "transformers" },
+    { name = "transformers", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
     { name = "triton", marker = "sys_platform == 'never'" },
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "platform_machine == 'aarch64' or (platform_machine != 'aarch64' and platform_machine not in 's390x, ppc64le') or sys_platform != 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a0/54/7e593fc41ffcaf5ac7c0379e0aec0cf03e53a742d1a91f64c6c7e79a6ac1/xgrammar-0.2.0.tar.gz", hash = "sha256:c4f0238a89869343171d43d069b8c5da874f3c2c25f408f20cd5987219a6adef", size = 2421093, upload-time = "2026-05-01T18:33:54.474Z" }
 wheels = [


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

The main offender of rebuilds on cache miss is the vllm kernel recompilation. We can try installing from vllm's own cpu wheels index for linux platforms that are supported, to speed up the builds and save on cache space.

The downside here is that linux boxes that are incompatible with the prebuilt wheels would fail to install on a `uv sync` (eg if they had glibc < 2.35). But, we may eventually nix the vllm cpu kernel dependency completely which would make this problem moot.

## Related Issues

## Test Plan

- [ ] Check the rebuild time on cache miss and correctness of test results

## Checklist

- [ ] I have read the [contributing guidelines](https://torch-spyre.github.io/spyre-inference/contributing/)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
