### PR TITLE
Always enforce block size to be multiple of 64

### DIFF
--- a/spyre_inference/platform.py
+++ b/spyre_inference/platform.py
@@ -155,20 +155,18 @@ class TorchSpyrePlatform(CpuPlatform):
 
         # Override block_size to a multiple of 64 if the user didn't explicitly set it.
         # The list-based attention backend requires 64-element stick alignment for
-        # torch.compile. Only override default (non-user-specified) values.
+        # torch.compile.
         cache_config = vllm_config.cache_config
-        if not cache_config.user_specified_block_size:
-            original_block_size = cache_config.block_size
-            if original_block_size % 64 != 0:
-                # Round up to nearest multiple of 64
-                new_block_size = ((original_block_size + 63) // 64) * 64
-                logger.warning(
-                    "Block size must be a multiple of 64 for the list-based attention "
-                    "backend. Overriding block_size from %d to %d.",
-                    original_block_size,
-                    new_block_size,
-                )
-                cache_config.block_size = new_block_size
+        original_block_size = cache_config.block_size
+        if original_block_size % 64 != 0:
+            new_block_size = ((original_block_size + 63) // 64) * 64
+            logger.warning(
+                "Block size must be a multiple of 64 for the list-based attention "
+                "backend. Overriding block_size from %d to %d.",
+                original_block_size,
+                new_block_size,
+            )
+            cache_config.block_size = new_block_size
 
         parallel_config = vllm_config.parallel_config
 

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -110,11 +110,12 @@ def test_block_size_override_non_default_value():
     assert vllm_config.cache_config.block_size == 128
 
 
-def test_block_size_no_override_user_specified():
-    """Test that user-specified block_size is NOT overridden.
+def test_block_size_override_user_specified():
+    """Test that even user-specified block_size is overridden when invalid.
 
-    When user_specified_block_size is True, the platform should leave
-    block_size as-is. Invalid values will be caught by the backend ValueError.
+    Spyre has a hard requirement for block_size to be a multiple of 64.
+    Even when the user (or test harness) explicitly passes an invalid value,
+    the platform must correct it to avoid a later ValueError.
     """
     from spyre_inference.platform import TorchSpyrePlatform
 
@@ -138,9 +139,9 @@ def test_block_size_no_override_user_specified():
 
     TorchSpyrePlatform.check_and_update_config(vllm_config)
 
-    assert vllm_config.cache_config.block_size == 16, (
-        f"User-specified block_size should not be overridden, "
-        f"expected 16, got {vllm_config.cache_config.block_size}"
+    assert vllm_config.cache_config.block_size == 64, (
+        f"User-specified block_size=16 should be overridden to 64, "
+        f"got {vllm_config.cache_config.block_size}"
     )
 
 


### PR DESCRIPTION
## Description
 When running upstream tests, the test file sets blocksize to be 16 [here](https://github.com/vllm-project/vllm/blob/2365b7a8e7c0f6c55eeb820fba43416f880d3a51/tests/conftest.py#L923) which in not enforced by `platform.py` in this case which causes test to fail

## Related Issues

Fixes #300

## Test Plan
https://github.com/torch-spyre/spyre-inference/actions/runs/28175821354/job/83451766434?pr=295

## Checklist

- [x] I have read the [contributing guidelines](https://torch-spyre.github.io/spyre-inference/contributing/)
- [x] My code follows the project's code style (run `bash format.sh`)
- [x] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
