### PR TITLE
:zap: split attention tests

### DIFF
--- a/.github/workflows/test_each_commit.yaml
+++ b/.github/workflows/test_each_commit.yaml
@@ -87,7 +87,15 @@ jobs:
               - linux
             image_label: image_spyre_inference
             flags: >-
-              -m "not (distributed or upstream)"
+              -m "not (distributed or upstream or attention)"
+          - cfg: Spyre attention tests
+            runs_on:
+              - x86_64
+              - spyre_pf_x1__pvc_1tb_x1
+              - linux
+            image_label: image_spyre_inference
+            flags: >-
+              -m "attention and not (distributed or upstream)"
           - cfg: Distributed spyre tests
             runs_on:
               - x86_64

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,6 +236,7 @@ filterwarnings = [
 markers = [
     "distributed: Tests requiring multiple spyre cards",
     "upstream: Tests coming from upstream vLLM",
+    "attention: SpyreAttentionImpl tests (tests/test_spyre_attn.py); slow, runs in its own CI job",
 ]
 # --8<-- [end:test-markers-definition]
 

--- a/tests/test_spyre_attn.py
+++ b/tests/test_spyre_attn.py
@@ -26,6 +26,8 @@ from spyre_inference.v1.attention.backends.spyre_attn import (
     SpyrePagedKVCache,
 )
 
+pytestmark = pytest.mark.attention
+
 
 def _spyre_available() -> bool:
     try:


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Splits out the `test_spyre_attn` tests into their own job- they're very slow to execute right now so this should help reduce CI wall clock time

## Related Issues

<!-- Link related issues, e.g., `Fixes #` or `Relates to #456` -->

## Test Plan

<!-- Describe how you tested your changes. Include commands or steps to reproduce. -->

## Checklist

- [ ] I have read the [contributing guidelines](https://torch-spyre.github.io/spyre-inference/contributing/)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
