### PR TITLE
:sparkles: Enable facebook/opt-125m upstream test

### DIFF
--- a/spyre_inference/__init__.py
+++ b/spyre_inference/__init__.py
@@ -37,10 +37,12 @@ def register():
 
 
 def register_ops():
-    """Register OOT custom ops for Spyre."""
-    from spyre_inference.custom_ops import register_all
+    """Register OOT custom ops and model patches for Spyre."""
+    from spyre_inference.custom_ops import register_all as register_custom_ops
+    from spyre_inference.models import register_all as register_model_patches
 
-    register_all()
+    register_custom_ops()
+    register_model_patches()
 
 
 def _init_logging():

--- a/spyre_inference/custom_ops/attention_dispatch.py
+++ b/spyre_inference/custom_ops/attention_dispatch.py
@@ -1,0 +1,85 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CPU-side dispatcher for vllm::unified_attention_with_output.
+
+SpyreQKVParallelLinear D2Hs q/k/v (downstream .split()/scatter need CPU),
+so the opaque attention op dispatches to CPU — but the real kernel is only
+registered for PrivateUse1. Move inputs back to Spyre, re-dispatch, and
+mirror the mutated outputs to the caller's CPU buffers.
+"""
+
+import torch
+
+# Force vllm::unified_attention_with_output to be defined before we add an impl.
+import vllm.model_executor.layers.attention.attention  # noqa: F401
+from vllm.logger import init_logger
+from vllm.utils.torch_utils import vllm_lib
+
+from .utils import convert
+
+logger = init_logger(__name__)
+
+_SPYRE = "spyre"
+
+
+def _cpu_unified_attention_with_output(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    output: torch.Tensor,
+    layer_name,
+    output_scale: torch.Tensor | None = None,
+    output_block_scale: torch.Tensor | None = None,
+    kv_cache_dummy_dep: torch.Tensor | None = None,
+) -> None:
+    q = convert(query, device=_SPYRE)
+    k = convert(key, device=_SPYRE)
+    v = convert(value, device=_SPYRE)
+    # `output` arrives uninitialized; allocate fresh on Spyre.
+    out = torch.empty_like(output, device=_SPYRE)
+    os_ = convert(output_scale, device=_SPYRE)
+    obs_ = convert(output_block_scale, device=_SPYRE)
+
+    torch.ops.vllm.unified_attention_with_output(
+        q,
+        k,
+        v,
+        out,
+        layer_name,
+        output_scale=os_,
+        output_block_scale=obs_,
+        kv_cache_dummy_dep=kv_cache_dummy_dep,
+    )
+
+    # mutates_args=["output", "output_block_scale"] in vllm's schema.
+    output.copy_(out)
+    if output_block_scale is not None:
+        output_block_scale.copy_(obs_)
+
+
+_REGISTERED = False
+
+
+def register() -> None:
+    global _REGISTERED
+    if _REGISTERED:
+        return
+    vllm_lib.impl(
+        "unified_attention_with_output",
+        _cpu_unified_attention_with_output,
+        dispatch_key="CPU",
+    )
+    _REGISTERED = True
+    logger.info("Registered CPU dispatch impl for vllm::unified_attention_with_output")

--- a/spyre_inference/custom_ops/attention_dispatch.py
+++ b/spyre_inference/custom_ops/attention_dispatch.py
@@ -52,11 +52,11 @@ def _cpu_unified_attention_with_output(
         convert(query, device="spyre"),
         convert(key, device="spyre"),
         convert(value, device="spyre"),
-        out,
+        out,  # ty: ignore[invalid-argument-type]
         layer_name,
         output_scale=convert(output_scale, device="spyre"),
         output_block_scale=obs_spyre,
-        kv_cache_dummy_dep=kv_cache_dummy_dep,
+        kv_cache_dummy_dep=kv_cache_dummy_dep,  # ty: ignore[invalid-argument-type]
     )
 
     # mutates_args=["output", "output_block_scale"] in vllm's schema.

--- a/spyre_inference/custom_ops/attention_dispatch.py
+++ b/spyre_inference/custom_ops/attention_dispatch.py
@@ -20,6 +20,8 @@ registered for PrivateUse1. Move inputs back to Spyre, re-dispatch, and
 mirror the mutated outputs to the caller's CPU buffers.
 """
 
+from functools import lru_cache
+
 import torch
 
 # Force vllm::unified_attention_with_output to be defined before we add an impl.
@@ -30,8 +32,6 @@ from vllm.utils.torch_utils import vllm_lib
 from .utils import convert
 
 logger = init_logger(__name__)
-
-_SPYRE = "spyre"
 
 
 def _cpu_unified_attention_with_output(
@@ -44,42 +44,32 @@ def _cpu_unified_attention_with_output(
     output_block_scale: torch.Tensor | None = None,
     kv_cache_dummy_dep: torch.Tensor | None = None,
 ) -> None:
-    q = convert(query, device=_SPYRE)
-    k = convert(key, device=_SPYRE)
-    v = convert(value, device=_SPYRE)
     # `output` arrives uninitialized; allocate fresh on Spyre.
-    out = torch.empty_like(output, device=_SPYRE)
-    os_ = convert(output_scale, device=_SPYRE)
-    obs_ = convert(output_block_scale, device=_SPYRE)
+    out = torch.empty_like(output, device="spyre")
+    obs_spyre = convert(output_block_scale, device="spyre")
 
     torch.ops.vllm.unified_attention_with_output(
-        q,
-        k,
-        v,
+        convert(query, device="spyre"),
+        convert(key, device="spyre"),
+        convert(value, device="spyre"),
         out,
         layer_name,
-        output_scale=os_,
-        output_block_scale=obs_,
+        output_scale=convert(output_scale, device="spyre"),
+        output_block_scale=obs_spyre,
         kv_cache_dummy_dep=kv_cache_dummy_dep,
     )
 
     # mutates_args=["output", "output_block_scale"] in vllm's schema.
     output.copy_(out)
     if output_block_scale is not None:
-        output_block_scale.copy_(obs_)
+        output_block_scale.copy_(obs_spyre)
 
 
-_REGISTERED = False
-
-
+@lru_cache(maxsize=1)
 def register() -> None:
-    global _REGISTERED
-    if _REGISTERED:
-        return
     vllm_lib.impl(
         "unified_attention_with_output",
         _cpu_unified_attention_with_output,
         dispatch_key="CPU",
     )
-    _REGISTERED = True
     logger.info("Registered CPU dispatch impl for vllm::unified_attention_with_output")

--- a/spyre_inference/custom_ops/vocab_parallel_embedding.py
+++ b/spyre_inference/custom_ops/vocab_parallel_embedding.py
@@ -44,7 +44,9 @@ class SpyreUnquantizedEmbeddingMethod(UnquantizedEmbeddingMethod):
         bias: torch.Tensor | None = None,
     ) -> torch.Tensor:
         out = torch.nn.functional.linear(
-            convert(x, device=layer.weight.device), layer.weight, bias
+            convert(x, device=layer.weight.device),
+            layer.weight,  # ty: ignore[invalid-argument-type]
+            bias,
         )
         return convert(out, device=x.device)
 

--- a/spyre_inference/custom_ops/vocab_parallel_embedding.py
+++ b/spyre_inference/custom_ops/vocab_parallel_embedding.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Spyre OOT replacement for VocabParallelEmbedding.
+"""Spyre OOT VocabParallelEmbedding.
 
-Inherits vocab sharding and weight loading from upstream. Overrides
-`forward` only to compute the TP shard mask on CPU: the upstream helper
-does int64 comparisons against Python int constants, which the Spyre
-inductor backend rejects with `unexpected argument Constant(value=N,
-dtype=torch.int64) to greaterequal`.
+Two overrides:
+- forward(): runs the TP shard-mask helper on CPU; upstream uses int64
+  comparisons that the Spyre inductor backend rejects.
+- quant_method.apply(): handles the tied-weight lm_head linear, where x
+  arrives on CPU (from `_SpyreModelWrapper`) while weight is on Spyre.
 """
 
 import torch
@@ -31,7 +31,22 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
     get_masked_input_and_mask,
 )
 
+from .utils import convert
+
 logger = init_logger(__name__)
+
+
+class SpyreUnquantizedEmbeddingMethod(UnquantizedEmbeddingMethod):
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        out = torch.nn.functional.linear(
+            convert(x, device=layer.weight.device), layer.weight, bias
+        )
+        return convert(out, device=x.device)
 
 
 @VocabParallelEmbedding.register_oot(name="VocabParallelEmbedding")
@@ -50,6 +65,7 @@ class SpyreVocabParallelEmbedding(VocabParallelEmbedding):
                 f"SpyreVocabParallelEmbedding does not support quantized "
                 f"embeddings (got {type(self.quant_method).__name__})."
             )
+        self.quant_method = SpyreUnquantizedEmbeddingMethod()
 
     def forward(self, input_: torch.Tensor) -> torch.Tensor:
         if self.tp_size > 1:

--- a/spyre_inference/models/__init__.py
+++ b/spyre_inference/models/__init__.py
@@ -12,27 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""This module contains all custom ops for spyre"""
+"""Spyre patches for vLLM model code that hits Spyre op gaps."""
 
 from functools import lru_cache
 
-from . import attention_dispatch
-from . import parallel_lm_head
-from . import rms_norm
-from . import rotary_embedding
-from . import linear
-from . import silu_and_mul
-from . import utils
-from . import vocab_parallel_embedding  # noqa: F401
 from vllm.logger import init_logger
+
+from . import opt
 
 logger = init_logger(__name__)
 
 
 @lru_cache(maxsize=1)
-def register_all():
-    logger.info("Registering custom ops for spyre_inference")
-    rotary_embedding.register()
-    rms_norm.register()
-    utils.register()
-    attention_dispatch.register()
+def register_all() -> None:
+    opt.register()

--- a/spyre_inference/models/__init__.py
+++ b/spyre_inference/models/__init__.py
@@ -16,11 +16,7 @@
 
 from functools import lru_cache
 
-from vllm.logger import init_logger
-
 from . import opt
-
-logger = init_logger(__name__)
 
 
 @lru_cache(maxsize=1)

--- a/spyre_inference/models/opt.py
+++ b/spyre_inference/models/opt.py
@@ -1,0 +1,38 @@
+# Copyright 2026 The Spyre-Inference Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Spyre patch for OPT's positional embedding.
+
+`OPTLearnedPositionalEmbedding.forward` does `positions + self.offset` on
+int64 tensors; torch-spyre has no integer aten.add kernel. Do the add on
+CPU. Remove once torch-spyre supports integer aten.add.
+"""
+
+import torch
+from torch import nn
+
+from vllm.logger import init_logger
+from vllm.model_executor.models import opt
+
+logger = init_logger(__name__)
+
+
+def _spyre_forward(self, positions: torch.Tensor) -> torch.Tensor:
+    shifted = (positions.cpu() + self.offset).to(positions.device)
+    return nn.Embedding.forward(self, shifted)
+
+
+def register() -> None:
+    opt.OPTLearnedPositionalEmbedding.forward = _spyre_forward
+    logger.info("Patched OPTLearnedPositionalEmbedding.forward for Spyre")

--- a/spyre_inference/models/opt.py
+++ b/spyre_inference/models/opt.py
@@ -34,5 +34,5 @@ def _spyre_forward(self, positions: torch.Tensor) -> torch.Tensor:
 
 
 def register() -> None:
-    opt.OPTLearnedPositionalEmbedding.forward = _spyre_forward
+    opt.OPTLearnedPositionalEmbedding.forward = _spyre_forward  # ty: ignore[invalid-assignment]
     logger.info("Patched OPTLearnedPositionalEmbedding.forward for Spyre")

--- a/tests/plugin/spyre_testing_plugin/upstream_tests.yaml
+++ b/tests/plugin/spyre_testing_plugin/upstream_tests.yaml
@@ -70,7 +70,7 @@ tests:
             allow:
               model:
                 # - openai-community/gpt2 # needs opaque-attention CPU dispatch + tied-weight lm_head fix
-                # - facebook/opt-125m # requires a torch-spyre fix for int adds
+                - facebook/opt-125m
                 - meta-llama/Llama-3.2-1B-Instruct
                 # - Qwen/Qwen2.5-0.5B-Instruct # needs tied-weight lm_head fix (compute_logits hits cpu/spyre mixed-device decomposition)
                 # - TitanML/tiny-mixtral # needs swa support


### PR DESCRIPTION
## Description

Enables the `facebook/opt-125m` upstream model test by addressing three independent failures:

- **`OPTLearnedPositionalEmbedding.forward` patch** (`spyre_inference/models/opt.py`): OPT does `positions + self.offset` on int64; torch-spyre has no integer `aten.add` kernel, which aborts the SDSC scheduler. Do the add on CPU; the resulting indices feed the on-device embedding lookup. The genuinely OPT-specific piece.
- **CPU dispatcher for `vllm::unified_attention_with_output`** (`spyre_inference/custom_ops/attention_dispatch.py`): `SpyreQKVParallelLinear` D2Hs q/k/v (downstream `.split()` / scatter need CPU), so the opaque attention op dispatches to CPU — but the kernel is only registered for `PrivateUse1` and boot fails. New CPU impl moves inputs back to Spyre, re-dispatches, and mirrors the mutated outputs back to the caller's CPU buffers. Not OPT-specific — fixes the same boot failure for any model whose QKV linear D2Hs.
- **`SpyreUnquantizedEmbeddingMethod`** (`spyre_inference/custom_ops/vocab_parallel_embedding.py`): For `tie_word_embeddings=True` (OPT, GPT-2), `lm_head = embed_tokens` and `lm_head.quant_method.apply(...)` lands x (CPU, from `_SpyreModelWrapper`) and weight (Spyre) with mixed devices. New `apply` does the device conversion before/after the linear.

The latter two were originally drafted in #294. Cherry-picked here to keep this PR scoped to "enable opt-125m"; #294 will be closed and the remaining pieces landed separately.

## Related Issues

Relates to #294.

## Test Plan

```
uv run pytest -m "upstream and not distributed" 'tests/models/language/generation/test_common.py::test_models[False-False-5-2-facebook/opt-125m]'
```

- [x] `opt-125m` upstream test passes
- [x] `llama-3.2-1B` upstream test still passes (no regression)
- [x] `bash format.sh` clean (ruff, ty, typos, markdownlint, actionlint)

## Checklist

- [x] I have read the [contributing guidelines](https://torch-spyre.github.io/spyre-inference/contributing/)
- [x] My code follows the project's code style (run `bash format.sh`)
- [x] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [x] My commits include a `Signed-off-by:` line (DCO compliance)
