### PR TITLE
:sparkles: Enable (longer context) granite support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,7 @@ When editing `./torch-spyre/` (or any sibling checkout) and reinstalling via `uv
 ## Spyre-Specific Constraints
 
 - **Device alignment**: Head size must be multiple of 64 (128-byte stick size / 2 bytes for float16)
-- **No tensor parallelism**: Custom linear layers assume TP=1
+- **Tensor parallelism**: TP≥1 supported (custom linear layers handle weight sharding + `all_reduce` via `SpyreCommunicator` — see `docs/architecture/index.md` "Distributed (TP)"). **DP>1 is rejected** in `TorchSpyrePlatform.check_and_update_config`; the spyre-comms global rank space hasn't been validated for DP×TP.
 - **dtype**: float16 only (model_config.dtype check in platform.py)
 - **Compilation**: Platform-level compile is set to `CompilationMode.NONE` due to CPU fallback ops creating intermediates. **Caveat**: under the pytest `default_vllm_config` fixture, `cfg.mode` is Python `None` (not the `NONE=0` enum), so per-module gates like `_maybe_compile` in `spyre_attn.py` may still wrap kernels with `torch.compile(..., dynamic=False)`. Don't assume "eager in tests" when comparing pytest behavior to a plain script.
 - **Single accelerator**: Spyre is contested by one process at a time. Never run two Spyre-backed commands concurrently — no `pytest -n`/`xdist`, no parallel `uv run pytest` invocations, no backgrounding one Spyre test while starting another. Parallel invocations hang, produce undefined device state, or corrupt the compile cache.

--- a/spyre_inference/platform.py
+++ b/spyre_inference/platform.py
@@ -79,6 +79,15 @@ class TorchSpyrePlatform(CpuPlatform):
         return "torch-spyre"
 
     @classmethod
+    def device_count(cls) -> int:
+        # CpuPlatform returns 1 (CPU = single device); for TP>1 we need the
+        # actual Spyre card count so upstream gates like
+        # `@multi_gpu_test(num_gpus=2)` don't skip on multi-card hosts.
+        import torch
+
+        return torch.spyre.device_count()
+
+    @classmethod
     def log_server_boot(cls, vllm_config: VllmConfig) -> None:
         # Only log in main process (not in TP workers)
         if multiprocessing.current_process().name != "MainProcess":

--- a/spyre_inference/platform.py
+++ b/spyre_inference/platform.py
@@ -83,8 +83,6 @@ class TorchSpyrePlatform(CpuPlatform):
         # CpuPlatform returns 1 (CPU = single device); for TP>1 we need the
         # actual Spyre card count so upstream gates like
         # `@multi_gpu_test(num_gpus=2)` don't skip on multi-card hosts.
-        import torch
-
         return torch.spyre.device_count()
 
     @classmethod

--- a/spyre_inference/v1/attention/backends/spyre_attn.py
+++ b/spyre_inference/v1/attention/backends/spyre_attn.py
@@ -777,9 +777,7 @@ class SpyreAttentionImpl(AttentionImpl[SpyreAttentionMetadata]):
         # result on CPU and bulk-copy at the end of the per-sequence loop.
         # Revisit when torch-spyre lands symbolic-offset overwrite
         # (torch-spyre#220 / #1371-3).
-        output_cpu = torch.zeros(
-            num_actual_tokens, num_heads, head_size, dtype=output.dtype, device="cpu"
-        )
+        output_cpu = torch.zeros_like(output, device="cpu")
 
         for seq_idx in range(num_seqs):
             # Most-naive implementation: no parallelization

--- a/spyre_inference/v1/attention/backends/spyre_attn.py
+++ b/spyre_inference/v1/attention/backends/spyre_attn.py
@@ -767,25 +767,16 @@ class SpyreAttentionImpl(AttentionImpl[SpyreAttentionMetadata]):
             "attention_mask_tiles must be precomputed by the metadata builder"
         )
 
-        # Per-token scatter into a spyre-resident `output` is unworkable today:
-        #   - `output[i:j] = ...` / `narrow(...).copy_(...)` silently smear the
-        #     source across the whole buffer on dim=0 (writes hit row 0).
-        #   - `torch.ops.spyre.overwrite(..., dims=[0], offsets=[q_start+i])`
-        #     does write to the right row, but its compile_once wrapper traces
-        #     once per unique (shape, offset) under `specialize_int=True`. Each
-        #     trace consumes a slot in dynamo's accumulated_cache_size_limit
-        #     (default 256, untouched by torch_spyre._autoload's per-fn 1024
-        #     bump). vLLM's model compile already fills most of that budget;
-        #     these calls tip it over, dynamo bails out to the eager kernel —
-        #     which is the same compile_once wrapper — and we recurse until
-        #     Python's recursion limit (granite repro). Bumping the limit
-        #     unblocks short tests but doesn't scale: with chunked prefill
-        #     disabled, query_len reaches the full prompt length, so a 128K
-        #     context would compile 128K SDSC binaries (hours of compile +
-        #     several GB of cache). Build the full result on CPU and write
-        #     `output` in one bulk copy instead. Revisit when torch-spyre
-        #     lands symbolic-offset overwrite (issues #220 / #1371-3) — one
-        #     compiled binary for any offset would let us scatter on-device.
+        # Scattering into `output` on Spyre dim=0 has no working primitive:
+        # `output[i:j] = ...` and `narrow().copy_(...)` silently write to row 0;
+        # `torch.ops.spyre.overwrite` is deprecated and its compile_once wrapper
+        # compiles one SDSC binary per unique offset, which recurses past the
+        # dynamo cache limit once vLLM's model compile has filled it. Raising
+        # the limit unblocks short tests but compiles N binaries for a
+        # query_len=N prefill, which doesn't scale to long contexts. Stage the
+        # result on CPU and bulk-copy at the end of the per-sequence loop.
+        # Revisit when torch-spyre lands symbolic-offset overwrite
+        # (torch-spyre#220 / #1371-3).
         output_cpu = torch.zeros(
             num_actual_tokens, num_heads, head_size, dtype=output.dtype, device="cpu"
         )

--- a/spyre_inference/v1/attention/backends/spyre_attn.py
+++ b/spyre_inference/v1/attention/backends/spyre_attn.py
@@ -757,7 +757,6 @@ class SpyreAttentionImpl(AttentionImpl[SpyreAttentionMetadata]):
         block_size = attn_metadata.block_size
 
         num_seqs = attn_metadata.num_seqs
-        num_actual_tokens = attn_metadata.num_actual_tokens
         query_start_loc = attn_metadata.query_start_loc
         seq_lens = attn_metadata.seq_lens
         block_table = attn_metadata.block_table

--- a/spyre_inference/v1/attention/backends/spyre_attn.py
+++ b/spyre_inference/v1/attention/backends/spyre_attn.py
@@ -757,6 +757,7 @@ class SpyreAttentionImpl(AttentionImpl[SpyreAttentionMetadata]):
         block_size = attn_metadata.block_size
 
         num_seqs = attn_metadata.num_seqs
+        num_actual_tokens = attn_metadata.num_actual_tokens
         query_start_loc = attn_metadata.query_start_loc
         seq_lens = attn_metadata.seq_lens
         block_table = attn_metadata.block_table
@@ -764,6 +765,29 @@ class SpyreAttentionImpl(AttentionImpl[SpyreAttentionMetadata]):
         aligned_max_query_len = attn_metadata.aligned_max_query_len
         assert mask_tiles_all is not None, (
             "attention_mask_tiles must be precomputed by the metadata builder"
+        )
+
+        # Per-token scatter into a spyre-resident `output` is unworkable today:
+        #   - `output[i:j] = ...` / `narrow(...).copy_(...)` silently smear the
+        #     source across the whole buffer on dim=0 (writes hit row 0).
+        #   - `torch.ops.spyre.overwrite(..., dims=[0], offsets=[q_start+i])`
+        #     does write to the right row, but its compile_once wrapper traces
+        #     once per unique (shape, offset) under `specialize_int=True`. Each
+        #     trace consumes a slot in dynamo's accumulated_cache_size_limit
+        #     (default 256, untouched by torch_spyre._autoload's per-fn 1024
+        #     bump). vLLM's model compile already fills most of that budget;
+        #     these calls tip it over, dynamo bails out to the eager kernel —
+        #     which is the same compile_once wrapper — and we recurse until
+        #     Python's recursion limit (granite repro). Bumping the limit
+        #     unblocks short tests but doesn't scale: with chunked prefill
+        #     disabled, query_len reaches the full prompt length, so a 128K
+        #     context would compile 128K SDSC binaries (hours of compile +
+        #     several GB of cache). Build the full result on CPU and write
+        #     `output` in one bulk copy instead. Revisit when torch-spyre
+        #     lands symbolic-offset overwrite (issues #220 / #1371-3) — one
+        #     compiled binary for any offset would let us scatter on-device.
+        output_cpu = torch.zeros(
+            num_actual_tokens, num_heads, head_size, dtype=output.dtype, device="cpu"
         )
 
         for seq_idx in range(num_seqs):
@@ -809,17 +833,13 @@ class SpyreAttentionImpl(AttentionImpl[SpyreAttentionMetadata]):
 
             # Reshape back: [num_kv_heads, num_queries_per_kv, padded_query_len, head_size]
             #   → [query_len, num_heads, head_size]
-            # Pull result to CPU before slicing (Spyre slicing is broken),
-            # then transfer each per-token contiguous slice back for scatter.
+            # Pull result to CPU (Spyre transpose+contiguous on the head axes
+            # is broken) and write into the CPU staging buffer; one bulk H2D
+            # at the end of the loop replaces the per-token writes.
             result_cpu = convert(result, "cpu", output.dtype)
             result_cpu = result_cpu.reshape(1, num_heads, aligned_max_query_len, head_size)
             result_cpu = result_cpu.transpose(1, 2).contiguous()
-            for i in range(query_len):
-                tok = convert(
-                    result_cpu[0, i : i + 1, :, :].contiguous(),
-                    _target_device,
-                    output.dtype,
-                )
-                _overwrite(tok, output, [0], [q_start + i])
+            output_cpu[q_start:q_end] = result_cpu[0, :query_len, :, :]
 
+        output.copy_(convert(output_cpu, device=_target_device))
         return output

--- a/tests/plugin/spyre_testing_plugin/pytest_plugin.py
+++ b/tests/plugin/spyre_testing_plugin/pytest_plugin.py
@@ -643,14 +643,25 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
         return
 
     for po in allow_entry.param_overrides:
-        if po.param_name not in metafunc.fixturenames:
+        # Support both single-name keys and comma-joined tuple-parametrize keys
+        # (e.g. `@pytest.mark.parametrize("a, b, c", [(1, 2, 3), ...])`).
+        sub_names = [n.strip() for n in po.param_name.split(",")]
+        if any(n not in metafunc.fixturenames for n in sub_names):
             continue
         for i, marker in enumerate(metafunc.definition.own_markers):
-            if marker.name == "parametrize" and marker.args[0] == po.param_name:
-                metafunc.definition.own_markers[i] = pytest.mark.parametrize(
-                    po.param_name, [_convert_yaml_value(v) for v in po.values]
-                ).mark
-                break
+            if marker.name != "parametrize":
+                continue
+            marker_names = [n.strip() for n in marker.args[0].split(",")]
+            if marker_names != sub_names:
+                continue
+            if len(sub_names) > 1:
+                new_values = [tuple(_convert_yaml_value(v) for v in row) for row in po.values]
+            else:
+                new_values = [_convert_yaml_value(v) for v in po.values]
+            metafunc.definition.own_markers[i] = pytest.mark.parametrize(
+                po.param_name, new_values
+            ).mark
+            break
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plugin/spyre_testing_plugin/upstream_tests.yaml
+++ b/tests/plugin/spyre_testing_plugin/upstream_tests.yaml
@@ -108,10 +108,8 @@ tests:
           tags: [granite, upstream, uses_subprocess]
           params:
             override:
-              model: []
-              # - ibm-ai-platform/micro-g3.3-8b-instruct-1b
-              # fails with RecursionError, needs softmax fix
-
+              model:
+                - ibm-ai-platform/micro-g3.3-8b-instruct-1b
               dtype: [torch.float16]
               max_tokens: [2] # one prefill and one decode
 
@@ -143,23 +141,26 @@ tests:
     - rel_path: tests/basic_correctness/test_basic_correctness.py
       allow_list:
         - test: "test_models"
-          mode: skip # (all models still fail)
+          # hardcoded prompt is ~5042 tokens; doesn't fit MAX_MODEL_LEN_CAP=128.
+          # Re-enable once the on-device KV cache cap is raised.
+          mode: skip
           tags: [model, basic_correctness, upstream, uses_subprocess]
           params:
             override:
               model:
-                - Qwen/Qwen3-0.6B # needs rmsnorm dispatch fix
-                - ibm-ai-platform/micro-g3.3-8b-instruct-1b # needs softmax fix
+                # - Qwen/Qwen3-0.6B # needs rmsnorm dispatch fix
+                - ibm-ai-platform/micro-g3.3-8b-instruct-1b
               backend: ["CUSTOM"]
               enforce_eager: [true]
         - test: "test_models_distributed"
-          mode: skip
+          mode: mandatory_pass
           tags:
             [model, basic_correctness, upstream, uses_subprocess, distributed]
           params:
             override:
-              model:
-                - Qwen/Qwen3-0.6B # needs rmsnorm dispatch fix
-                - ibm-granite/granite-3.3-2b-instruct # needs softmax fix
-              distributed_executor_backend: ["external_launcher"]
-              attention_backend: ["CUSTOM"]
+              # Upstream uses a single tuple parametrize keyed
+              # `(model, distributed_executor_backend, attention_backend, test_suite, extra_env)`;
+              # supply the full tuple per row.
+              "model, distributed_executor_backend, attention_backend, test_suite, extra_env":
+                - ["ibm-ai-platform/micro-g3.3-8b-instruct-1b", "mp", "CUSTOM", "L4", {}]
+              enable_prompt_embeds: [false]

--- a/tests/plugin/spyre_testing_plugin/upstream_tests.yaml
+++ b/tests/plugin/spyre_testing_plugin/upstream_tests.yaml
@@ -163,4 +163,6 @@ tests:
               # supply the full tuple per row.
               "model, distributed_executor_backend, attention_backend, test_suite, extra_env":
                 - ["ibm-ai-platform/micro-g3.3-8b-instruct-1b", "mp", "CUSTOM", "L4", {}]
-              enable_prompt_embeds: [false]
+            skip:
+              # input embeddings not yet supported on spyre
+              enable_prompt_embeds: [true]


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Description

Enables the upstream granite tests against `ibm-ai-platform/micro-g3.3-8b-instruct-1b` (single-card `test_granite.py::test_models` and TP=2 `test_basic_correctness.py::test_models_distributed`) by fixing a `RecursionError` in the attention backend that fired on longer prefills / larger batches. Also brings forward the platform `device_count` override and a small testing-plugin enhancement that were needed to make those tests actually run.

## Related Issues

`torch-spyre#220` / `torch-spyre#1371-3` — symbolic-offset support for `spyre.overwrite`; would let us revert to an on-device scatter and remove the CPU staging buffer added here.

## Changes

**Rewrite attention scatter-write** (`spyre_inference/v1/attention/backends/spyre_attn.py`)
- Per-token scatter into `output` had no working primitive on Spyre dim=0: `output[i:j] = ...` / `narrow().copy_(...)` silently write everything to row 0, and `torch.ops.spyre.overwrite` is deprecated. Its `compile_once` wrapper compiles one SDSC binary per unique `(shape, offset)` under `specialize_int=True`; once vLLM's model compile has filled the dynamo cache the kernel falls back to the same `compile_once` wrapper and recurses to Python's stack limit. Granite hit this in routine prefill; llama happened to compile-cache around it.
- `_online_softmax_attention` now builds the full per-attention-layer result in a CPU `output_cpu` tensor and copies it back to the Spyre output buffer in a single `output.copy_(...)` at the end of the per-sequence loop.
- Considered (and rejected) bumping `accumulated_cache_size_limit` to keep the on-device scatter: it works for short tests but compiles `N` binaries for a `query_len=N` prefill, which is unworkable as the on-device KV cache cap is raised (128K context = 128K binaries). When `torch-spyre` lands symbolic-offset overwrite, revisit and move the final write back on-device.

**Platform `device_count()` override** (`spyre_inference/platform.py`)
- `CpuPlatform.device_count()` returns 1 (CPU = single device); upstream gates like `@multi_gpu_test(num_gpus=2)` skipped on multi-card hosts as a result. Override to return `torch.spyre.device_count()` so TP-aware upstream tests actually run.

**Plugin support for tuple-parametrize override** (`tests/plugin/spyre_testing_plugin/pytest_plugin.py`)
- Some upstream tests use a single composite parametrize key like `@pytest.mark.parametrize("model, distributed_executor_backend, attention_backend, test_suite, extra_env", [...])`. The plugin's `override` hook only matched single-name keys, so the YAML couldn't redirect those tests at our model. Extends the matcher to recognise comma-joined keys (normalised on both sides) and to emit tuple values when the key is composite.

**Enable granite upstream tests** (`tests/plugin/spyre_testing_plugin/upstream_tests.yaml`)
- `test_granite.py::test_models`: `mandatory_pass` on `micro-g3.3-8b-instruct-1b` at fp16, `max_tokens=2`. Was a `model: []` placeholder waiting on the recursion fix.
- `test_basic_correctness.py::test_models_distributed`: `mandatory_pass` on `micro-g3.3-8b-instruct-1b` × `mp` executor × `CUSTOM` attention backend × test_suite `L4`, with `enable_prompt_embeds=[true]` skipped (prompt embeddings not yet supported on Spyre).
- `test_basic_correctness.py::test_models` remains skipped — its hardcoded ~5042-token prompt does not fit `MAX_MODEL_LEN_CAP=128`; orthogonal to this PR.
- No GHA workflow change needed: the existing `Upstream distributed vLLM tests` matrix entry (`-m "upstream and distributed"` on `spyre_pf_x2__pvc_1tb_x1`) already covers the newly-enabled TP=2 test, and `Upstream model vLLM tests` covers the granite single-card test.

**Doc correction** (`CLAUDE.md`)
- The "Spyre-Specific Constraints" list claimed "No tensor parallelism: Custom linear layers assume TP=1", which contradicts the in-tree `SpyreCommunicator` / `all_reduce` implementation documented at `docs/architecture/index.md` "Distributed (TP)". Corrected to "TP≥1 supported; DP>1 rejected in `TorchSpyrePlatform.check_and_update_config`".

## Test Plan

Local verification on a 2-Spyre host:

- [x] `uv run pytest -m "upstream and granite"` → 1 passed, 2172 deselected in 113s
- [x] `uv run pytest -m "upstream and distributed and model"` → 1 passed, 1 skipped (prompt-embeds), 2171 deselected in 129s
- [x] `uv run pytest -m "not upstream" tests/test_spyre_attn.py` → 73 passed, 24 skipped in 503s (no regression on the attention matrix from the CPU-buffer rewrite)
- [x] `bash format.sh` → ruff, ruff format, typos, markdownlint, GHA workflow lint, ty check all pass

## Checklist

- [X] I have read the [contributing guidelines](https://torch-spyre.github.io/spyre-inference/contributing/)
- [X] My code follows the project's code style (run `bash format.sh`)
- [X] I have added tests for my changes (if applicable) — covered by the newly-enabled upstream tests
- [X] I have updated the documentation (if applicable) — CLAUDE.md TP claim corrected
- [X] My commits include a `Signed-off-by:` line (DCO compliance)
