### PR TITLE
ci-cd: avoid circular dependency by not using the spyre-inference image to build spyre-inference

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,4 +5,5 @@ self-hosted-runner:
     - spyre_pf_x1
     - spyre_pf_x0__pvc_1tb_x1
     - spyre_pf_x1__pvc_1tb_x1
+    - image_torch_spyre
     - image_spyre_inference

--- a/.github/workflows/add_or_remove_artifacts_from_cache.yaml
+++ b/.github/workflows/add_or_remove_artifacts_from_cache.yaml
@@ -35,7 +35,7 @@ jobs:
       - x86_64
       - spyre_pf_x0__pvc_1tb_x1
       - linux
-      - image_spyre_inference
+      - image_torch_spyre
     timeout-minutes: 720
     env:
       CACHE_CONFIG_FILE_PATH: ${{ inputs.cache_config_file }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -38,14 +38,14 @@ jobs:
   type-check:
     name: 'ty type check'
     # `ty` needs the real torch/vllm/torch-spyre deps to type check imports,
-    # which need the spyre runtime libs (carried by `image_spyre_inference`)
+    # which need the spyre runtime libs (carried by `image_torch_spyre`)
     # to install. The check itself does not exercise the Spyre device, so it
     # runs on `spyre_pf_x0` (no cards).
     runs-on:
       - x86_64
       - spyre_pf_x0
       - linux
-      - image_spyre_inference
+      - image_torch_spyre
     timeout-minutes: 30
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/test_each_commit.yaml
+++ b/.github/workflows/test_each_commit.yaml
@@ -53,11 +53,11 @@ on:
       runner_label:
         description: |
           Per-PR ephemeral runner-set IMAGE label to select for runs-on
-          (image_spyre_inference_pr_<component>_<sha12>, e.g.
-          image_spyre_inference_pr_flex_8ddcf3e155e9). The per-PR ephemeral flow
+          (image_torch_spyre_pr_<component>_<sha12>, e.g.
+          image_torch_spyre_pr_flex_8ddcf3e155e9). The per-PR ephemeral flow
           passes that PR's set label so jobs land on the per-PR image (the changed
           RPM is baked in -> no runtime sudo). Empty keeps push/PR/merge_group runs
-          on the standing image_spyre_inference set (today's behaviour).
+          on the standing image_torch_spyre set (today's behaviour).
         required: false
         type: string
         default: ""
@@ -85,7 +85,7 @@ jobs:
               - x86_64
               - spyre_pf_x1__pvc_1tb_x1
               - linux
-            image_label: image_spyre_inference
+            image_label: image_torch_spyre
             flags: >-
               -m "not (distributed or upstream or attention)"
           - cfg: Spyre attention tests
@@ -93,7 +93,7 @@ jobs:
               - x86_64
               - spyre_pf_x1__pvc_1tb_x1
               - linux
-            image_label: image_spyre_inference
+            image_label: image_torch_spyre
             flags: >-
               -m "attention and not (distributed or upstream)"
           - cfg: Distributed spyre tests
@@ -101,7 +101,7 @@ jobs:
               - x86_64
               - spyre_pf_x2__pvc_1tb_x1
               - linux
-            image_label: image_spyre_inference
+            image_label: image_torch_spyre
             flags: >-
               -m distributed
           - cfg: Upstream vLLM tests
@@ -109,7 +109,7 @@ jobs:
               - x86_64
               - spyre_pf_x1__pvc_1tb_x1
               - linux
-            image_label: image_spyre_inference
+            image_label: image_torch_spyre
             flags: >-
               -m "upstream and not distributed and not model"
           - cfg: Upstream distributed vLLM tests
@@ -117,7 +117,7 @@ jobs:
               - x86_64
               - spyre_pf_x2__pvc_1tb_x1
               - linux
-            image_label: image_spyre_inference
+            image_label: image_torch_spyre
             flags: >-
               -m "upstream and distributed"
           - cfg: Upstream model vLLM tests
@@ -125,7 +125,7 @@ jobs:
               - x86_64
               - spyre_pf_x1__pvc_1tb_x1
               - linux
-            image_label: image_spyre_inference
+            image_label: image_torch_spyre
             flags: >-
               -m "upstream and model and not distributed"
     # Compose runner labels from matrix.runs_on and the image label.

--- a/CI.md
+++ b/CI.md
@@ -36,7 +36,7 @@ The runner set is selected using a set of labels in the `runs-on` field in each 
       - x86_64 # Intel CPU Architecture
       - spyre_pf_x1 # 1 Spyre card in PF mode
       - linux # Linux OS - Usually RHEL 9/10
-      - image_spyre_inference # The spyre-inference container image
+      - image_torch_spyre # The torch-spyre container image
 ```
 
 The workflow will only get picked up by a runner set that matches ALL of the labels specified in the `runs-on` field.


### PR DESCRIPTION
## Description

We should not use `spyre-inference` image to build `spyre-inference` because breaking changes in deeptools, flex, torch-spyre that require an corresponding fix in spyre-inference can't be tested unless we merge the PR into spyre-inference. And for merging the PR we need passing tests, which requires a proper runner image, which require image builds to pass, which requires spyre-inference build to pass. This creates a chicken and egg problem

## Related Issues

Related change in torch-spyre repo https://github.com/torch-spyre/torch-spyre/pull/2794

## Test Plan

<!-- Describe how you tested your changes. Include commands or steps to reproduce. -->

## Checklist

- [ ] I have read the [contributing guidelines](https://torch-spyre.github.io/spyre-inference/contributing/)
- [ ] My code follows the project's code style (run `bash format.sh`)
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] My commits include a `Signed-off-by:` line (DCO compliance)
